### PR TITLE
Use a non-allocating byte set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,379 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
+name = "cc"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "doodle"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "getrandom"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "libc"
+version = "0.2.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "libm"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+
+[[package]]
+name = "num-traits"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+dependencies = [
+ "autocfg",
+ "libm",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "rustix"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e78cc525325c06b4a7ff02db283472f3c042b7ff0c391f96c6d5ac6f4f91b75"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[dev-dependencies]
+proptest = "1.1.0"
+
 [dependencies]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -117,7 +117,20 @@ impl<const LEN: usize> From<[u8; LEN]> for ByteSet {
 
 impl fmt::Debug for ByteSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_set().entries(self.iter()).finish()
+        if self.len() < 128 {
+            f.debug_set().entries(self.iter()).finish()
+        } else {
+            f.write_str("!")?;
+            f.debug_set().entries((!self).iter()).finish()
+        }
+    }
+}
+
+impl ops::Not for &ByteSet {
+    type Output = ByteSet;
+
+    fn not(self) -> ByteSet {
+        self.complement()
     }
 }
 
@@ -125,7 +138,7 @@ impl ops::Not for ByteSet {
     type Output = ByteSet;
 
     fn not(self) -> ByteSet {
-        self.complement()
+        !&self
     }
 }
 
@@ -198,5 +211,15 @@ mod tests {
         assert!(ByteSet::is_disjoint(&not_00, &is_00));
         assert!(!ByteSet::is_disjoint(&not_00, &is_255));
         assert!(ByteSet::is_disjoint(&is_00, &is_255));
+    }
+
+    #[test]
+    fn test_debug_below_128() {
+        assert_eq!(format!("{:?}", ByteSet::from([32, 1])), "{1, 32}");
+    }
+
+    #[test]
+    fn test_debug_above_128() {
+        assert_eq!(format!("{:?}", !ByteSet::from([32, 1])), "!{1, 32}");
     }
 }

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -96,6 +96,10 @@ impl ByteSet {
         ByteSet::zip_bits_with(&self, other, |bits0, bits1| bits0 | bits1)
     }
 
+    pub fn difference(&self, other: &ByteSet) -> ByteSet {
+        ByteSet::zip_bits_with(&self, other, |b0, b1| b0 & !b1)
+    }
+
     pub fn intersection(&self, other: &ByteSet) -> ByteSet {
         ByteSet::zip_bits_with(&self, other, |bits0, bits1| bits0 & bits1)
     }
@@ -200,17 +204,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn is_disjoint() {
-        let not_00 = !ByteSet::from([0x00]);
-        let not_255 = !ByteSet::from([0xFF]);
-        let is_00 = ByteSet::from([0x00]);
-        let is_255 = ByteSet::from([0xFF]);
-        assert!(!ByteSet::is_disjoint(&not_00, &not_00));
-        assert!(!ByteSet::is_disjoint(&not_00, &not_255));
-        assert!(ByteSet::is_disjoint(&not_00, &is_00));
-        assert!(!ByteSet::is_disjoint(&not_00, &is_255));
-        assert!(ByteSet::is_disjoint(&is_00, &is_255));
+    mod is_disjoint {
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn test_complement(bs in any_byte_set()) {
+                assert!(ByteSet::is_disjoint(&bs, &bs.complement()));
+            }
+
+            #[test]
+            fn test_difference_left(bs0 in any_byte_set(), bs1 in any_byte_set()) {
+                assert!(ByteSet::is_disjoint(&ByteSet::difference(&bs0, &bs1), &bs1));
+            }
+
+            #[test]
+            fn test_difference_right(bs0 in any_byte_set(), bs1 in any_byte_set()) {
+                assert!(ByteSet::is_disjoint(&bs0, &ByteSet::difference(&bs1, &bs0)));
+            }
+        }
     }
 
     #[test]

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -1,0 +1,202 @@
+use std::{fmt, ops};
+
+/// Compact, allocation-free set of `u8`s.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct ByteSet {
+    /// Each bit of the array represents a number in the range `0..=255`
+    bits: [u64; 4],
+}
+
+impl ByteSet {
+    pub fn new() -> ByteSet {
+        ByteSet::empty()
+    }
+
+    pub fn from_bits(bits: [u64; 4]) -> ByteSet {
+        ByteSet { bits }
+    }
+
+    pub fn empty() -> ByteSet {
+        ByteSet::from_bits([0; 4])
+    }
+
+    pub fn full() -> ByteSet {
+        ByteSet::from_bits([u64::MAX; 4])
+    }
+
+    pub fn iter<'this>(&'this self) -> impl 'this + Iterator<Item = u8> {
+        (0..=255).filter(|b| self.contains(*b))
+    }
+
+    fn get_bit_with<T>(&self, b: u8, f: impl FnOnce(u64, u8) -> T) -> T {
+        match b {
+            0..=63 => f(self.bits[0], b),
+            64..=127 => f(self.bits[1], b - 64),
+            128..=191 => f(self.bits[2], b - 128),
+            192..=255 => f(self.bits[3], b - 192),
+        }
+    }
+
+    fn set_bit_with(&mut self, b: u8, f: impl FnOnce(&mut u64, u8)) {
+        match b {
+            0..=63 => f(&mut self.bits[0], b),
+            64..=127 => f(&mut self.bits[1], b - 64),
+            128..=191 => f(&mut self.bits[2], b - 128),
+            192..=255 => f(&mut self.bits[3], b - 192),
+        }
+    }
+
+    fn map_bits(&self, f: impl Fn(u64) -> u64) -> ByteSet {
+        ByteSet::from_bits([
+            f(self.bits[0]),
+            f(self.bits[1]),
+            f(self.bits[2]),
+            f(self.bits[3]),
+        ])
+    }
+
+    fn zip_bits_with(&self, other: &ByteSet, f: impl Fn(u64, u64) -> u64) -> ByteSet {
+        ByteSet::from_bits([
+            f(self.bits[0], other.bits[0]),
+            f(self.bits[1], other.bits[1]),
+            f(self.bits[2], other.bits[2]),
+            f(self.bits[3], other.bits[3]),
+        ])
+    }
+
+    pub fn len(&self) -> u32 {
+        self.bits[0].count_ones()
+            + self.bits[1].count_ones()
+            + self.bits[2].count_ones()
+            + self.bits[3].count_ones()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub fn insert(&mut self, b: u8) {
+        self.set_bit_with(b, |bits, i| *bits |= 1 << i);
+    }
+
+    #[allow(dead_code)]
+    pub fn remove(&mut self, b: u8) {
+        self.set_bit_with(b, |byte, i| *byte &= !(1 << i));
+    }
+
+    pub fn contains(&self, b: u8) -> bool {
+        self.get_bit_with(b, |bits, i| bits & (1 << i) != 0)
+    }
+
+    pub fn complement(&self) -> ByteSet {
+        self.map_bits(|bits| !bits)
+    }
+
+    pub fn union(&self, other: &ByteSet) -> ByteSet {
+        ByteSet::zip_bits_with(&self, other, |bits0, bits1| bits0 | bits1)
+    }
+
+    pub fn intersection(&self, other: &ByteSet) -> ByteSet {
+        ByteSet::zip_bits_with(&self, other, |bits0, bits1| bits0 & bits1)
+    }
+
+    pub fn is_disjoint(&self, other: &ByteSet) -> bool {
+        ByteSet::intersection(self, other).is_empty()
+    }
+}
+
+impl<const LEN: usize> From<[u8; LEN]> for ByteSet {
+    fn from(bytes: [u8; LEN]) -> ByteSet {
+        let mut bs = ByteSet::new();
+        for b in bytes {
+            bs.insert(b);
+        }
+        bs
+    }
+}
+
+impl fmt::Debug for ByteSet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_set().entries(self.iter()).finish()
+    }
+}
+
+impl ops::Not for ByteSet {
+    type Output = ByteSet;
+
+    fn not(self) -> ByteSet {
+        self.complement()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+    use proptest::sample;
+
+    use super::*;
+
+    fn any_byte_set() -> impl Strategy<Value = ByteSet> {
+        Strategy::prop_union(
+            sample::select(vec![ByteSet::empty(), ByteSet::full()]).boxed(),
+            any::<[u64; 4]>().prop_map(ByteSet::from_bits).boxed(),
+        )
+    }
+
+    mod is_empty {
+        use super::*;
+
+        #[test]
+        fn test_empty() {
+            assert!(ByteSet::empty().is_empty());
+        }
+
+        #[test]
+        fn test_full() {
+            assert!(!ByteSet::full().is_empty());
+        }
+
+        proptest! {
+            #[test]
+            fn test_any(b in any::<u8>()) {
+                assert!(!ByteSet::from([b]).is_empty())
+            }
+        }
+    }
+
+    mod contains {
+        use super::*;
+
+        proptest! {
+            #[test]
+            fn test_any(b in any::<u8>()) {
+                assert!(ByteSet::from([b]).contains(b));
+            }
+
+            #[test]
+            fn test_insert(b in any::<u8>(), mut bs in any_byte_set()) {
+                bs.insert(b);
+                assert!(bs.contains(b));
+            }
+
+            #[test]
+            fn test_remove(b in any::<u8>(), mut bs in any_byte_set()) {
+                bs.remove(b);
+                assert!(!bs.contains(b));
+            }
+        }
+    }
+
+    #[test]
+    fn is_disjoint() {
+        let not_00 = !ByteSet::from([0x00]);
+        let not_255 = !ByteSet::from([0xFF]);
+        let is_00 = ByteSet::from([0x00]);
+        let is_255 = ByteSet::from([0xFF]);
+        assert!(!ByteSet::is_disjoint(&not_00, &not_00));
+        assert!(!ByteSet::is_disjoint(&not_00, &not_255));
+        assert!(ByteSet::is_disjoint(&not_00, &is_00));
+        assert!(!ByteSet::is_disjoint(&not_00, &is_255));
+        assert!(ByteSet::is_disjoint(&is_00, &is_255));
+    }
+}


### PR DESCRIPTION
This uses a specialised byte set as opposed to a `HashSet`. I'm wasn’t confident on some of the set operations, so added some property-based tests – but I can remove them we want to avoid adding a dependency at the moment.