### PR TITLE
Allow formats to be serialised to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ language, [Fathom](https://github.com/yeslogic/fathom).
 Decoding files using the CLI:
 
 ```sh
-cargo run test2.jpg
+cargo run file test2.jpg
 ```
 
 Viewing decoded data on the web frontend (requires Python):
 
 ```sh
-cargo run -- --output=json test2.jpg > frontend/test.json
+cargo run format --output=json > frontend/format.json
+cargo run file --output=json test2.jpg > frontend/test.json
 python3 -m http.server --directory frontend
 ```

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,1 +1,2 @@
 test.json
+format.json

--- a/frontend/display.js
+++ b/frontend/display.js
@@ -1,10 +1,12 @@
 function main() {
   const structureSection = document.getElementById('structure');
-  fetch('./test.json')
-    .then(r => r.json())
-    .then(json => {
-      structureSection.appendChild(valueToHTML(json));
-    });
+  Promise.all([
+    fetch('./test.json').then(r => r.json()),
+    fetch('./format.json').then(r => r.json()),
+  ]).then(([value, format]) => {
+    // TODO: format-directed printing
+    structureSection.appendChild(valueToHTML(value));
+  });
 }
 
 // Convert a value into HTML.

--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -19,14 +19,17 @@ pub fn main(module: &mut FormatModule) -> Format {
     let png = png::main(module, &base);
     let riff = riff::main(module, &base);
 
-    Format::Map(
-        Expr::RecordProj(Box::new(Expr::Var(0)), "data".to_string()),
-        Box::new(record([
-            (
-                "data",
-                alts([("gif", gif), ("jpeg", jpeg), ("png", png), ("riff", riff)]),
-            ),
-            ("end", Format::EndOfInput),
-        ])),
+    module.define_format(
+        "main",
+        Format::Map(
+            Expr::RecordProj(Box::new(Expr::Var(0)), "data".to_string()),
+            Box::new(record([
+                (
+                    "data",
+                    alts([("gif", gif), ("jpeg", jpeg), ("png", png), ("riff", riff)]),
+                ),
+                ("end", Format::EndOfInput),
+            ])),
+        ),
     )
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,8 @@ use crate::byte_set::ByteSet;
 pub mod byte_set;
 pub mod output;
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+#[serde(tag = "tag", content = "data")]
 pub enum Pattern {
     Binding,
     Wildcard,
@@ -108,7 +109,8 @@ impl Value {
     }
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+#[serde(tag = "tag", content = "data")]
 pub enum Expr {
     Var(usize),
     Bool(bool),
@@ -187,7 +189,8 @@ impl Expr {
 /// formats no longer describe regular languages.
 ///
 /// [regular expressions]: https://en.wikipedia.org/wiki/Regular_expression#Formal_definition
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+#[serde(tag = "tag", content = "data")]
 pub enum Format {
     /// Reference to a top-level item
     ItemVar(usize),
@@ -226,6 +229,7 @@ impl Format {
     pub const EMPTY: Format = Format::Tuple(Vec::new());
 }
 
+#[derive(Debug, Serialize)]
 pub struct FormatModule {
     names: Vec<String>,
     formats: Vec<Format>,

--- a/tests/decode.rs
+++ b/tests/decode.rs
@@ -31,7 +31,7 @@ mod gif {
 
     #[test]
     fn test_decode_test_gif() {
-        let output = doodle().args(["test.gif"]).output().unwrap();
+        let output = doodle().args(["file", "test.gif"]).output().unwrap();
         let expected = expect_test::expect_file!("expected/decode/test.gif.stdout");
         check_output(output, expected)
     }
@@ -42,14 +42,14 @@ mod jpeg {
 
     #[test]
     fn test_decode_test_jpg() {
-        let output = doodle().args(["test.jpg"]).output().unwrap();
+        let output = doodle().args(["file", "test.jpg"]).output().unwrap();
         let expected = expect_test::expect_file!("expected/decode/test.jpg.stdout");
         check_output(output, expected)
     }
 
     #[test]
     fn test_decode_test2_jpg() {
-        let output = doodle().args(["test2.jpg"]).output().unwrap();
+        let output = doodle().args(["file", "test2.jpg"]).output().unwrap();
         let expected = expect_test::expect_file!("expected/decode/test2.jpg.stdout");
         check_output(output, expected)
     }
@@ -60,7 +60,7 @@ mod png {
 
     #[test]
     fn test_decode_test_png() {
-        let output = doodle().args(["test.png"]).output().unwrap();
+        let output = doodle().args(["file", "test.png"]).output().unwrap();
         let expected = expect_test::expect_file!("expected/decode/test.png.stdout");
         check_output(output, expected)
     }
@@ -71,7 +71,7 @@ mod riff {
 
     #[test]
     fn test_decode_test_webp() {
-        let output = doodle().args(["test.webp"]).output().unwrap();
+        let output = doodle().args(["file", "test.webp"]).output().unwrap();
         let expected = expect_test::expect_file!("expected/decode/test.webp.stdout");
         check_output(output, expected)
     }


### PR DESCRIPTION
This implements `doodle format --output=json` for dumping the main format to stdout.