### PR TITLE
Combine the functionality of map formats

### DIFF
--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -1,4 +1,4 @@
-use doodle::{Format, FormatModule, Func};
+use doodle::{Expr, Format, FormatModule};
 
 use crate::format::base::*;
 
@@ -20,7 +20,7 @@ pub fn main(module: &mut FormatModule) -> Format {
     let riff = riff::main(module, &base);
 
     Format::Map(
-        Func::RecordProj("data".to_string()),
+        Expr::RecordProj(Box::new(Expr::Var(0)), "data".to_string()),
         Box::new(record([
             (
                 "data",

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,5 +1,5 @@
 use doodle::byte_set::ByteSet;
-use doodle::{Expr, Format, FormatModule, Func, Pattern};
+use doodle::{Expr, Format, FormatModule, Pattern};
 
 pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
     Format::Tuple(formats.into_iter().collect())
@@ -83,18 +83,24 @@ pub fn main(module: &mut FormatModule) -> BaseModule {
 
     let u16be = module.define_format(
         "base.u16be",
-        Format::Map(Func::U16Be, Box::new(tuple([u8.clone(), u8.clone()]))),
+        Format::Map(
+            Expr::U16Be(Box::new(Expr::Var(0))),
+            Box::new(tuple([u8.clone(), u8.clone()])),
+        ),
     );
 
     let u16le = module.define_format(
         "base.u16le",
-        Format::Map(Func::U16Le, Box::new(tuple([u8.clone(), u8.clone()]))),
+        Format::Map(
+            Expr::U16Le(Box::new(Expr::Var(0))),
+            Box::new(tuple([u8.clone(), u8.clone()])),
+        ),
     );
 
     let u32be = module.define_format(
         "base.u32be",
         Format::Map(
-            Func::U32Be,
+            Expr::U32Be(Box::new(Expr::Var(0))),
             Box::new(tuple([u8.clone(), u8.clone(), u8.clone(), u8.clone()])),
         ),
     );
@@ -102,7 +108,7 @@ pub fn main(module: &mut FormatModule) -> BaseModule {
     let u32le = module.define_format(
         "base.u32le",
         Format::Map(
-            Func::U32Le,
+            Expr::U32Le(Box::new(Expr::Var(0))),
             Box::new(tuple([u8.clone(), u8.clone(), u8.clone(), u8.clone()])),
         ),
     );
@@ -110,7 +116,7 @@ pub fn main(module: &mut FormatModule) -> BaseModule {
     let asciiz_string = module.define_format(
         "base.asciiz-string",
         Format::Map(
-            Func::RecordProj("string".to_string()),
+            Expr::RecordProj(Box::new(Expr::Var(0)), "string".to_string()),
             Box::new(record([
                 ("string", repeat(not_byte(0x00))),
                 ("null", is_byte(0x00)),

--- a/src/bin/doodle/format/jpeg.rs
+++ b/src/bin/doodle/format/jpeg.rs
@@ -1,4 +1,4 @@
-use doodle::{Expr, Format, FormatModule, Func, Pattern};
+use doodle::{Expr, Format, FormatModule, Pattern};
 
 use crate::format::base::*;
 
@@ -10,7 +10,7 @@ use crate::format::base::*;
 pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &Format) -> Format {
     fn marker(id: u8) -> Format {
         Format::Map(
-            Func::TupleProj(1),
+            Expr::TupleProj(Box::new(Expr::Var(0)), 1),
             Box::new(tuple([is_byte(0xFF), is_byte(id)])),
         )
     }
@@ -364,10 +364,13 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &Format) -> Form
     let mcu = module.define_format(
         "jpeg.mcu",
         Format::Map(
-            Func::Match(vec![
-                (Pattern::variant("byte", Pattern::Binding), Expr::Var(0)),
-                (Pattern::variant("zero", Pattern::Wildcard), Expr::U8(0xFF)),
-            ]),
+            Expr::Match(
+                Box::new(Expr::Var(0)),
+                vec![
+                    (Pattern::variant("byte", Pattern::Binding), Expr::Var(0)),
+                    (Pattern::variant("zero", Pattern::Wildcard), Expr::U8(0xFF)),
+                ],
+            ),
             Box::new(alts([
                 ("byte", not_byte(0xFF)),
                 ("zero", tuple([is_byte(0xFF), is_byte(0x00)])),
@@ -379,19 +382,22 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &Format) -> Form
     let scan_data = module.define_format(
         "jpeg.scan-data",
         Format::Map(
-            Func::Stream,
+            Expr::Stream(Box::new(Expr::Var(0))),
             Box::new(repeat(Format::Map(
-                Func::Match(vec![
-                    (Pattern::variant("mcu", Pattern::Binding), Expr::Var(0)),
-                    (Pattern::variant("rst0", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst1", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst2", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst3", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst4", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst5", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst6", Pattern::Wildcard), Expr::UNIT),
-                    (Pattern::variant("rst7", Pattern::Wildcard), Expr::UNIT),
-                ]),
+                Expr::Match(
+                    Box::new(Expr::Var(0)),
+                    vec![
+                        (Pattern::variant("mcu", Pattern::Binding), Expr::Var(0)),
+                        (Pattern::variant("rst0", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst1", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst2", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst3", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst4", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst5", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst6", Pattern::Wildcard), Expr::UNIT),
+                        (Pattern::variant("rst7", Pattern::Wildcard), Expr::UNIT),
+                    ],
+                ),
                 Box::new(alts([
                     // FIXME: Extract into separate ECS repetition
                     ("mcu", mcu), // TODO: repeat(mcu),

--- a/src/bin/doodle/format/tiff.rs
+++ b/src/bin/doodle/format/tiff.rs
@@ -1,4 +1,4 @@
-use doodle::{Expr, Format, FormatModule, Func, Pattern};
+use doodle::{Expr, Format, FormatModule, Pattern};
 
 use crate::format::base::*;
 
@@ -45,14 +45,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> Format {
             (
                 "byte-order",
                 alts([
-                    (
-                        "le",
-                        Format::Map(Func::Expr(Expr::UNIT), Box::new(is_bytes(b"II"))),
-                    ),
-                    (
-                        "be",
-                        Format::Map(Func::Expr(Expr::UNIT), Box::new(is_bytes(b"MM"))),
-                    ),
+                    ("le", Format::Map(Expr::UNIT, Box::new(is_bytes(b"II")))),
+                    ("be", Format::Map(Expr::UNIT, Box::new(is_bytes(b"MM")))),
                 ]),
             ),
             (

--- a/tests/expected/decode/test.jpg.stdout
+++ b/tests/expected/decode/test.jpg.stdout
@@ -3,7 +3,7 @@
     ├── frame <- jpeg.frame :=
     │   ├── initial-segment <- _ |...| _ :=
     │   │   └── app0 <- jpeg.app0 :=
-    │   │       ├── marker <- map _.1 (...) := 224
+    │   │       ├── marker <- map (fun x => x.1) (...) := 224
     │   │       ├── length <- base.u16be := 16
     │   │       └── data <- slice (length - 2) jpeg.app0-data :=
     │   │           ├── identifier <- base.asciiz-string :=
@@ -23,7 +23,7 @@
     │   ├── segments <- repeat jpeg.table-or-misc :=
     │   │   ├── 0 <- jpeg.table-or-misc :=
     │   │   │   └── dqt <- jpeg.dqt :=
-    │   │   │       ├── marker <- map _.1 (...) := 219
+    │   │   │       ├── marker <- map (fun x => x.1) (...) := 219
     │   │   │       ├── length <- base.u16be := 67
     │   │   │       └── data <- slice (length - 2) jpeg.dqt-data :=
     │   │   │           ├── precision-table-id <- base.u8 := 0
@@ -42,7 +42,7 @@
     │   │   │               └── 63 <- base.u8 := 50
     │   │   └── 1 <- jpeg.table-or-misc :=
     │   │       └── dqt <- jpeg.dqt :=
-    │   │           ├── marker <- map _.1 (...) := 219
+    │   │           ├── marker <- map (fun x => x.1) (...) := 219
     │   │           ├── length <- base.u16be := 67
     │   │           └── data <- slice (length - 2) jpeg.dqt-data :=
     │   │               ├── precision-table-id <- base.u8 := 1
@@ -61,7 +61,7 @@
     │   │                   └── 63 <- base.u8 := 50
     │   ├── header <- jpeg.frame-header :=
     │   │   └── sof0 <- jpeg.sof0 :=
-    │   │       ├── marker <- map _.1 (...) := 192
+    │   │       ├── marker <- map (fun x => x.1) (...) := 192
     │   │       ├── length <- base.u16be := 17
     │   │       └── data <- slice (length - 2) jpeg.sof-data :=
     │   │           ├── sample-precision <- base.u8 := 8
@@ -85,7 +85,7 @@
     │   │   ├── segments <- repeat jpeg.table-or-misc :=
     │   │   │   ├── 0 <- jpeg.table-or-misc :=
     │   │   │   │   └── dht <- jpeg.dht :=
-    │   │   │   │       ├── marker <- map _.1 (...) := 196
+    │   │   │   │       ├── marker <- map (fun x => x.1) (...) := 196
     │   │   │   │       ├── length <- base.u16be := 27
     │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
     │   │   │   │           ├── class-table-id <- base.u8 := 0
@@ -113,7 +113,7 @@
     │   │   │   │               └── 7 <- base.u8 := 1
     │   │   │   ├── 1 <- jpeg.table-or-misc :=
     │   │   │   │   └── dht <- jpeg.dht :=
-    │   │   │   │       ├── marker <- map _.1 (...) := 196
+    │   │   │   │       ├── marker <- map (fun x => x.1) (...) := 196
     │   │   │   │       ├── length <- base.u16be := 58
     │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
     │   │   │   │           ├── class-table-id <- base.u8 := 16
@@ -145,7 +145,7 @@
     │   │   │   │               └── 38 <- base.u8 := 225
     │   │   │   ├── 2 <- jpeg.table-or-misc :=
     │   │   │   │   └── dht <- jpeg.dht :=
-    │   │   │   │       ├── marker <- map _.1 (...) := 196
+    │   │   │   │       ├── marker <- map (fun x => x.1) (...) := 196
     │   │   │   │       ├── length <- base.u16be := 26
     │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
     │   │   │   │           ├── class-table-id <- base.u8 := 1
@@ -172,7 +172,7 @@
     │   │   │   │               └── 6 <- base.u8 := 6
     │   │   │   └── 3 <- jpeg.table-or-misc :=
     │   │   │       └── dht <- jpeg.dht :=
-    │   │   │           ├── marker <- map _.1 (...) := 196
+    │   │   │           ├── marker <- map (fun x => x.1) (...) := 196
     │   │   │           ├── length <- base.u16be := 38
     │   │   │           └── data <- slice (length - 2) jpeg.dht-data :=
     │   │   │               ├── class-table-id <- base.u8 := 17
@@ -203,7 +203,7 @@
     │   │   │                   ~
     │   │   │                   └── 18 <- base.u8 := 145
     │   │   ├── sos <- jpeg.sos :=
-    │   │   │   ├── marker <- map _.1 (...) := 218
+    │   │   │   ├── marker <- map (fun x => x.1) (...) := 218
     │   │   │   ├── length <- base.u16be := 12
     │   │   │   └── data <- slice (length - 2) jpeg.sos-data :=
     │   │   │       ├── num-image-components <- base.u8 := 3

--- a/tests/expected/decode/test2.jpg.stdout
+++ b/tests/expected/decode/test2.jpg.stdout
@@ -3,7 +3,7 @@
     ├── frame <- jpeg.frame :=
     │   ├── initial-segment <- _ |...| _ :=
     │   │   └── app1 <- jpeg.app1 :=
-    │   │       ├── marker <- map _.1 (...) := 225
+    │   │       ├── marker <- map (fun x => x.1) (...) := 225
     │   │       ├── length <- base.u16be := 5426
     │   │       └── data <- slice (length - 2) jpeg.app1-data :=
     │   │           ├── identifier <- base.asciiz-string :=
@@ -72,7 +72,7 @@
     │   ├── segments <- repeat jpeg.table-or-misc :=
     │   │   ├── 0 <- jpeg.table-or-misc :=
     │   │   │   └── app13 <- jpeg.app13 :=
-    │   │   │       ├── marker <- map _.1 (...) := 237
+    │   │   │       ├── marker <- map (fun x => x.1) (...) := 237
     │   │   │       ├── length <- base.u16be := 10600
     │   │   │       └── data <- slice (length - 2) (repeat base.u8) :=
     │   │   │           ├── 0 <- base.u8 := 80
@@ -89,7 +89,7 @@
     │   │   │           └── 10597 <- base.u8 := 0
     │   │   ├── 1 <- jpeg.table-or-misc :=
     │   │   │   └── app1 <- jpeg.app1 :=
-    │   │   │       ├── marker <- map _.1 (...) := 225
+    │   │   │       ├── marker <- map (fun x => x.1) (...) := 225
     │   │   │       ├── length <- base.u16be := 4429
     │   │   │       └── data <- slice (length - 2) jpeg.app1-data :=
     │   │   │           ├── identifier <- base.asciiz-string :=
@@ -121,7 +121,7 @@
     │   │   │                   └── 4397 <- base.u8 := 62
     │   │   ├── 2 <- jpeg.table-or-misc :=
     │   │   │   └── app2 <- jpeg.app2 :=
-    │   │   │       ├── marker <- map _.1 (...) := 226
+    │   │   │       ├── marker <- map (fun x => x.1) (...) := 226
     │   │   │       ├── length <- base.u16be := 576
     │   │   │       └── data <- slice (length - 2) (repeat base.u8) :=
     │   │   │           ├── 0 <- base.u8 := 73
@@ -138,7 +138,7 @@
     │   │   │           └── 573 <- base.u8 := 156
     │   │   ├── 3 <- jpeg.table-or-misc :=
     │   │   │   └── app14 <- jpeg.app14 :=
-    │   │   │       ├── marker <- map _.1 (...) := 238
+    │   │   │       ├── marker <- map (fun x => x.1) (...) := 238
     │   │   │       ├── length <- base.u16be := 14
     │   │   │       └── data <- slice (length - 2) (repeat base.u8) :=
     │   │   │           ├── 0 <- base.u8 := 65
@@ -155,7 +155,7 @@
     │   │   │           └── 11 <- base.u8 := 1
     │   │   └── 4 <- jpeg.table-or-misc :=
     │   │       └── dqt <- jpeg.dqt :=
-    │   │           ├── marker <- map _.1 (...) := 219
+    │   │           ├── marker <- map (fun x => x.1) (...) := 219
     │   │           ├── length <- base.u16be := 132
     │   │           └── data <- slice (length - 2) jpeg.dqt-data :=
     │   │               ├── precision-table-id <- base.u8 := 0
@@ -174,7 +174,7 @@
     │   │                   └── 128 <- base.u8 := 12
     │   ├── header <- jpeg.frame-header :=
     │   │   └── sof0 <- jpeg.sof0 :=
-    │   │       ├── marker <- map _.1 (...) := 192
+    │   │       ├── marker <- map (fun x => x.1) (...) := 192
     │   │       ├── length <- base.u16be := 17
     │   │       └── data <- slice (length - 2) jpeg.sof-data :=
     │   │           ├── sample-precision <- base.u8 := 8
@@ -198,13 +198,13 @@
     │   │   ├── segments <- repeat jpeg.table-or-misc :=
     │   │   │   ├── 0 <- jpeg.table-or-misc :=
     │   │   │   │   └── dri <- jpeg.dri :=
-    │   │   │   │       ├── marker <- map _.1 (...) := 221
+    │   │   │   │       ├── marker <- map (fun x => x.1) (...) := 221
     │   │   │   │       ├── length <- base.u16be := 4
     │   │   │   │       └── data <- slice (length - 2) jpeg.dri-data :=
     │   │   │   │           └── restart-interval <- base.u16be := 89
     │   │   │   └── 1 <- jpeg.table-or-misc :=
     │   │   │       └── dht <- jpeg.dht :=
-    │   │   │           ├── marker <- map _.1 (...) := 196
+    │   │   │           ├── marker <- map (fun x => x.1) (...) := 196
     │   │   │           ├── length <- base.u16be := 418
     │   │   │           └── data <- slice (length - 2) jpeg.dht-data :=
     │   │   │               ├── class-table-id <- base.u8 := 0
@@ -235,7 +235,7 @@
     │   │   │                   ~
     │   │   │                   └── 398 <- base.u8 := 250
     │   │   ├── sos <- jpeg.sos :=
-    │   │   │   ├── marker <- map _.1 (...) := 218
+    │   │   │   ├── marker <- map (fun x => x.1) (...) := 218
     │   │   │   ├── length <- base.u16be := 12
     │   │   │   └── data <- slice (length - 2) jpeg.sos-data :=
     │   │   │       ├── num-image-components <- base.u8 := 3


### PR DESCRIPTION
Building off #54, this moves the `Func` operations into `Expr`, meaning we no longer need two map formats.