### PR TITLE
Do a better job of recovering mapped formats

### DIFF
--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -21,6 +21,28 @@ fn is_atomic_value(value: &Value) -> bool {
     }
 }
 
+/// Attempt to recover a format that can be used to render a value that was
+/// decoded with a map format. We currently handle cases like:
+///
+/// - `map (fun x => x) format`
+/// - `map (fun x => x.foo) format`
+/// - `map (fun x => x.3) format`
+/// - `map (fun x => x.foo.bar.3) format`
+fn mapped_format<'format>(expr: &Expr, format: &'format Format) -> Option<&'format Format> {
+    match expr {
+        Expr::Var(0) => Some(format),
+        Expr::RecordProj(head, label) => match mapped_format(head, format)? {
+            Format::Record(fields) => fields.iter().find_map(|(l, f)| (l == label).then_some(f)),
+            _ => None,
+        },
+        Expr::TupleProj(head, index) => match mapped_format(head, format)? {
+            Format::Tuple(formats) => formats.get(*index),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 enum Column {
     Branch,
     Space,
@@ -80,21 +102,9 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Peek(format) => self.write_decoded_value(value, format),
             Format::Slice(_, format) => self.write_decoded_value(value, format),
             Format::WithRelativeOffset(_, format) => self.write_decoded_value(value, format),
-            Format::Map(expr, format) => match expr {
-                Expr::RecordProj(head, label) => match (head.as_ref(), format.as_ref()) {
-                    (Expr::Var(0), Format::Record(fields)) => {
-                        let (_, format) = fields.iter().find(|(l, _)| l == label).unwrap();
-                        self.write_decoded_value(value, format)
-                    }
-                    _ => self.write_value(value),
-                },
-                Expr::TupleProj(head, index) => match (head.as_ref(), format.as_ref()) {
-                    (Expr::Var(0), Format::Tuple(formats)) => {
-                        self.write_decoded_value(value, &formats[*index])
-                    }
-                    _ => self.write_value(value),
-                },
-                _ => self.write_value(value),
+            Format::Map(expr, format) => match mapped_format(expr, format) {
+                Some(format) => self.write_decoded_value(value, format),
+                None => self.write_value(value),
             },
             Format::Match(head, branches) => {
                 let head = head.eval(&mut self.values);


### PR DESCRIPTION
This handles the possibility of multiple projections in map formats