### PR TITLE
Format for alignment

### DIFF
--- a/src/bin/doodle/main.rs
+++ b/src/bin/doodle/main.rs
@@ -5,7 +5,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use clap::{Parser, ValueEnum};
-use doodle::{Decoder, FormatModule};
+use doodle::{Decoder, FormatModule, ReadCtxt};
 
 mod format;
 
@@ -65,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
             let input = fs::read(filename)?;
             let (value, _) = decoder
-                .parse(&mut Vec::new(), &input)
+                .parse(&mut Vec::new(), ReadCtxt::new(&input))
                 .ok_or("parse failure")?;
 
             match output {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -76,6 +76,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             }
             Format::Fail => panic!("uninhabited format"),
             Format::EndOfInput => self.write_value(value),
+            Format::Align(_) => self.write_value(value),
             Format::Byte(_) => self.write_value(value),
             Format::Union(branches) => match value {
                 Value::Variant(label, value) => {
@@ -538,6 +539,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             }
             Format::Fail => write!(&mut self.writer, "fail"),
             Format::EndOfInput => write!(&mut self.writer, "end-of-input"),
+            Format::Align(n) => write!(&mut self.writer, "align {n}"),
 
             Format::Byte(bs) => {
                 if bs.len() < 128 {


### PR DESCRIPTION
`Format::Align(n)` will skip over (read and discard) the minimum number of bytes needed to ensure that the current offset is an integer multiple of `n`.