### PR TITLE
Remove Expr::UnwrapVariant and simplify some expr types

### DIFF
--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -471,8 +471,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 Box::new(var("y")),
                             )))),
                             Box::new(add(
-                                Expr::AsU16(Box::new(add(var("hlit"), var("hdist")))),
-                                Expr::U16(258),
+                                Expr::AsU32(Box::new(add(var("hlit"), var("hdist")))),
+                                Expr::U32(258),
                             )),
                         )),
                     ),

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -90,7 +90,7 @@ fn distance_record0(start: usize, base: &BaseModule, extra_bits: usize) -> Forma
 
 fn distance_record(base: &BaseModule) -> Format {
     Format::Match(
-        var("distance-code"),
+        Expr::AsU8(Box::new(var("distance-code"))),
         vec![
             (Pattern::U8(0), distance_record0(1, base, 0)),
             (Pattern::U8(1), distance_record0(2, base, 0)),
@@ -341,10 +341,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Pattern::Wildcard,
                                     Expr::Seq(vec![Expr::Variant(
                                         "literal".to_string(),
-                                        Box::new(Expr::RecordProj(
+                                        Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
                                             Box::new(var("x")),
                                             "code".to_string(),
-                                        )),
+                                        )))),
                                     )]),
                                 ),
                             ],
@@ -376,10 +376,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 Box::new(Expr::Lambda(
                                     "x".to_string(),
                                     Box::new(Expr::Match(
-                                        Box::new(Expr::RecordProj(
+                                        Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
                                             Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
                                             "code".to_string(),
-                                        )),
+                                        )))),
                                         vec![
                                             (
                                                 Pattern::U8(16),
@@ -505,7 +505,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         (
                             "extra",
                             Format::Match(
-                                var("code"),
+                                Expr::AsU8(Box::new(var("code"))),
                                 vec![
                                     (Pattern::U8(16), bits2.clone()),
                                     (Pattern::U8(17), bits3.clone()),
@@ -523,10 +523,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Box::new(Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Match(
-                            Box::new(Expr::RecordProj(
+                            Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
                                 Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
                                 "code".to_string(),
-                            )),
+                            )))),
                             vec![
                                 (
                                     Pattern::U8(16),
@@ -728,10 +728,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Pattern::Wildcard,
                                     Expr::Seq(vec![Expr::Variant(
                                         "literal".to_string(),
-                                        Box::new(Expr::RecordProj(
+                                        Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
                                             Box::new(var("x")),
                                             "code".to_string(),
-                                        )),
+                                        )))),
                                     )]),
                                 ),
                             ],

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -90,7 +90,7 @@ fn distance_record0(start: usize, base: &BaseModule, extra_bits: usize) -> Forma
 
 fn distance_record(base: &BaseModule) -> Format {
     Format::Match(
-        var("distance-code-value"),
+        var("distance-code"),
         vec![
             (Pattern::U8(0), distance_record0(1, base, 0)),
             (Pattern::U8(1), distance_record0(2, base, 0)),
@@ -143,7 +143,6 @@ fn length_record(start: usize, base: &BaseModule, extra_bits: usize) -> Format {
                 None,
             )),
         ),
-        ("distance-code-value", Format::Compute(var("distance-code"))),
         ("distance-record", distance_record(base)),
     ])
 }
@@ -159,7 +158,6 @@ fn length_record_fixed(start: usize, base: &BaseModule, extra_bits: usize) -> Fo
             )),
         ),
         ("distance-code", bits(5, base)),
-        ("distance-code-value", Format::Compute(var("distance-code"))),
         ("distance-record", distance_record(base)),
     ])
 }

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -143,10 +143,7 @@ fn length_record(start: usize, base: &BaseModule, extra_bits: usize) -> Format {
                 None,
             )),
         ),
-        (
-            "distance-code-value",
-            Format::Compute(Expr::UnwrapVariant(Box::new(var("distance-code")))),
-        ),
+        ("distance-code-value", Format::Compute(var("distance-code"))),
         ("distance-record", distance_record(base)),
     ])
 }
@@ -251,9 +248,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::UnwrapVariant(Box::new(
-                                Expr::RecordProj(Box::new(var("x")), "code".to_string()),
-                            ))))),
+                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                Box::new(var("x")),
+                                "code".to_string(),
+                            )))),
                             Box::new(Expr::U16(256)),
                         )),
                     ),
@@ -265,7 +263,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         (
                             "extra",
                             Format::Match(
-                                Expr::UnwrapVariant(Box::new(var("code"))),
+                                var("code"),
                                 vec![
                                     (Pattern::U16(257), length_record_fixed(3, base, 0)),
                                     (Pattern::U16(258), length_record_fixed(4, base, 0)),
@@ -309,10 +307,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Box::new(Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Match(
-                            Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".to_string(),
-                            )))),
+                            Box::new(Expr::RecordProj(Box::new(var("x")), "code".to_string())),
                             vec![
                                 (Pattern::U16(256), Expr::Seq(vec![])),
                                 (Pattern::U16(257), reference_record()),
@@ -348,10 +343,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Pattern::Wildcard,
                                     Expr::Seq(vec![Expr::Variant(
                                         "literal".to_string(),
-                                        Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
+                                        Box::new(Expr::RecordProj(
                                             Box::new(var("x")),
                                             "code".to_string(),
-                                        )))),
+                                        )),
                                     )]),
                                 ),
                             ],
@@ -383,10 +378,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 Box::new(Expr::Lambda(
                                     "x".to_string(),
                                     Box::new(Expr::Match(
-                                        Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
+                                        Box::new(Expr::RecordProj(
                                             Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
                                             "code".to_string(),
-                                        )))),
+                                        )),
                                         vec![
                                             (
                                                 Pattern::U8(16),
@@ -403,9 +398,21 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                                             ),
                                                             Expr::U8(3),
                                                         )),
-                                                        Box::new(Expr::UnwrapVariant(Box::new(
-                                                            Expr::TupleProj(Box::new(var("x")), 0),
-                                                        ))),
+                                                        Box::new(Expr::Match(
+                                                            Box::new(Expr::TupleProj(
+                                                                Box::new(var("x")),
+                                                                0,
+                                                            )),
+                                                            vec![(
+                                                                Pattern::Variant(
+                                                                    "some".to_string(),
+                                                                    Box::new(Pattern::Binding(
+                                                                        "y".to_string(),
+                                                                    )),
+                                                                ),
+                                                                Expr::Var("y".to_string()),
+                                                            )],
+                                                        )),
                                                     ),
                                                 ]),
                                             ),
@@ -500,7 +507,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         (
                             "extra",
                             Format::Match(
-                                Expr::UnwrapVariant(Box::new(var("code"))),
+                                var("code"),
                                 vec![
                                     (Pattern::U8(16), bits2.clone()),
                                     (Pattern::U8(17), bits3.clone()),
@@ -518,10 +525,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Box::new(Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Match(
-                            Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
+                            Box::new(Expr::RecordProj(
                                 Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
                                 "code".to_string(),
-                            )))),
+                            )),
                             vec![
                                 (
                                     Pattern::U8(16),
@@ -538,9 +545,16 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                                 ),
                                                 Expr::U8(3),
                                             )),
-                                            Box::new(Expr::UnwrapVariant(Box::new(
-                                                Expr::TupleProj(Box::new(var("x")), 0),
-                                            ))),
+                                            Box::new(Expr::Match(
+                                                Box::new(Expr::TupleProj(Box::new(var("x")), 0)),
+                                                vec![(
+                                                    Pattern::Variant(
+                                                        "some".to_string(),
+                                                        Box::new(Pattern::Binding("y".to_string())),
+                                                    ),
+                                                    Expr::Var("y".to_string()),
+                                                )],
+                                            )),
                                         ),
                                     ]),
                                 ),
@@ -618,9 +632,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::UnwrapVariant(Box::new(
-                                Expr::RecordProj(Box::new(var("x")), "code".to_string()),
-                            ))))),
+                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                Box::new(var("x")),
+                                "code".to_string(),
+                            )))),
                             Box::new(Expr::U16(256)),
                         )),
                     ),
@@ -635,7 +650,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         (
                             "extra",
                             Format::Match(
-                                Expr::UnwrapVariant(Box::new(var("code"))),
+                                var("code"),
                                 vec![
                                     (Pattern::U16(257), length_record(3, base, 0)),
                                     (Pattern::U16(258), length_record(4, base, 0)),
@@ -679,10 +694,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     Box::new(Expr::Lambda(
                         "x".to_string(),
                         Box::new(Expr::Match(
-                            Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".to_string(),
-                            )))),
+                            Box::new(Expr::RecordProj(Box::new(var("x")), "code".to_string())),
                             vec![
                                 (Pattern::U16(256), Expr::Seq(vec![])),
                                 (Pattern::U16(257), reference_record()),
@@ -718,10 +730,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Pattern::Wildcard,
                                     Expr::Seq(vec![Expr::Variant(
                                         "literal".to_string(),
-                                        Box::new(Expr::UnwrapVariant(Box::new(Expr::RecordProj(
+                                        Box::new(Expr::RecordProj(
                                             Box::new(var("x")),
                                             "code".to_string(),
-                                        )))),
+                                        )),
                                     )]),
                                 ),
                             ],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1473,11 +1473,7 @@ fn make_huffman_codes(lengths: &[usize]) -> Format {
         if len != 0 {
             codes.push((n.to_string(), bit_range(len, next_code[len])));
             let pattern = Pattern::Variant(n.to_string(), Box::new(Pattern::Wildcard));
-            let val = if n > 255 {
-                Expr::U16(n.try_into().unwrap())
-            } else {
-                Expr::U8(n.try_into().unwrap())
-            };
+            let val = Expr::U16(n.try_into().unwrap());
             branches.push((pattern, val));
             //println!("{:?}", codes[codes.len()-1]);
             next_code[len] += 1;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ pub enum Expr {
     Add(Box<Expr>, Box<Expr>),
     Sub(Box<Expr>, Box<Expr>),
 
+    AsU8(Box<Expr>),
     AsU16(Box<Expr>),
     AsU32(Box<Expr>),
 
@@ -527,9 +528,16 @@ impl Expr {
                 (x, y) => panic!("mismatched operands {x:?}, {y:?}"),
             },
 
+            Expr::AsU8(x) => match x.eval_value(scope) {
+                Value::U8(x) => Value::U8(x),
+                Value::U16(x) if x < 256 => Value::U8(x as u8),
+                Value::U32(x) if x < 256 => Value::U8(x as u8),
+                x => panic!("cannot convert {x:?} to U8"),
+            },
             Expr::AsU16(x) => match x.eval_value(scope) {
                 Value::U8(x) => Value::U16(u16::from(x)),
                 Value::U16(x) => Value::U16(x),
+                Value::U32(x) if x < 65536 => Value::U16(x as u16),
                 x => panic!("cannot convert {x:?} to U16"),
             },
             Expr::AsU32(x) => match x.eval_value(scope) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,11 +570,7 @@ impl Expr {
             Expr::SeqLength(seq) => match seq.eval(scope) {
                 Value::Seq(values) => {
                     let len = values.len();
-                    if len < 65536 {
-                        Value::U16(len as u16)
-                    } else {
-                        Value::U32(len as u32)
-                    }
+                    Value::U32(len as u32)
                 }
                 _ => panic!("SeqLength: expected Seq"),
             },

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -560,6 +560,10 @@ impl<'module, W: io::Write> Context<'module, W> {
                 self.write_proj_expr(expr1)
             }
 
+            Expr::AsU8(expr) => {
+                write!(&mut self.writer, "as-u8 ")?;
+                self.write_proj_expr(expr)
+            }
             Expr::AsU16(expr) => {
                 write!(&mut self.writer, "as-u16 ")?;
                 self.write_proj_expr(expr)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -655,11 +655,6 @@ impl<'module, W: io::Write> Context<'module, W> {
                 self.write_expr(expr)?;
                 write!(&mut self.writer, " }}")
             }
-            Expr::UnwrapVariant(expr) => {
-                write!(&mut self.writer, "unwrap(")?;
-                self.write_expr(expr)?;
-                write!(&mut self.writer, ")")
-            }
             Expr::Seq(..) => write!(&mut self.writer, "[..]"),
             expr => {
                 write!(&mut self.writer, "(")?;


### PR DESCRIPTION
UnwrapVariant was a hack anyway and impossible to type correctly, it should have used pattern matching.