### PR TITLE
Add Expr::Div and Expr::Shr

### DIFF
--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -554,6 +554,16 @@ impl<'module, W: io::Write> Context<'module, W> {
                 write!(&mut self.writer, " << ")?;
                 self.write_proj_expr(expr1)
             }
+            Expr::Shr(expr0, expr1) => {
+                self.write_proj_expr(expr0)?;
+                write!(&mut self.writer, " >> ")?;
+                self.write_proj_expr(expr1)
+            }
+            Expr::Div(expr0, expr1) => {
+                self.write_proj_expr(expr0)?;
+                write!(&mut self.writer, " / ")?;
+                self.write_proj_expr(expr1)
+            }
             Expr::Rem(expr0, expr1) => {
                 self.write_proj_expr(expr0)?;
                 write!(&mut self.writer, " % ")?;


### PR DESCRIPTION
Adds `Expr` primitives for the Divide and Right-Shift operations, with support for pretty-printing said operations.

Clarifies documentation of `Format::Slice` to indicate its actual behavior under the current implementation (i.e. skip any leftover bytes within the slice after consuming as many bytes as the wrapped Format can allow it to).