### PR TITLE
Format::AndNot

### DIFF
--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -141,6 +141,7 @@ fn check_covered(
             check_covered(module, path, format)?;
         }
         Format::Peek(_) => {} // FIXME
+        Format::AndNot(format, _negated) => check_covered(module, path, format)?,
         Format::Slice(_, format) => {
             check_covered(module, path, format)?;
         }
@@ -231,6 +232,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_flat(value, format),
+            Format::AndNot(format, _) => self.write_flat(value, format),
             Format::Slice(_, format) => self.write_flat(value, format),
             Format::Bits(format) => self.write_flat(value, format),
             Format::WithRelativeOffset(_, format) => self.write_flat(value, format),

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -115,6 +115,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_decoded_value(value, format),
+            Format::AndNot(format, _) => self.write_decoded_value(value, format),
             Format::Slice(_, format) => self.write_decoded_value(value, format),
             Format::Bits(format) => self.write_decoded_value(value, format),
             Format::WithRelativeOffset(_, format) => self.write_decoded_value(value, format),
@@ -716,6 +717,11 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Peek(format) => {
                 write!(&mut self.writer, "peek ")?;
                 self.write_atomic_format(format)
+            }
+            Format::AndNot(format, negated) => {
+                self.write_atomic_format(format)?;
+                write!(&mut self.writer, " and-not ")?;
+                self.write_atomic_format(negated)
             }
             Format::Slice(len, format) => {
                 write!(&mut self.writer, "slice ")?;

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -713,6 +713,10 @@ impl<'module, W: io::Write> Context<'module, W> {
                 write!(&mut self.writer, " ")?;
                 self.write_atomic_format(format)
             }
+            Format::Peek(format) => {
+                write!(&mut self.writer, "peek ")?;
+                self.write_atomic_format(format)
+            }
             Format::Slice(len, format) => {
                 write!(&mut self.writer, "slice ")?;
                 self.write_atomic_expr(len)?;


### PR DESCRIPTION
Negated formats are only accepted if they don't require unbounded backtracking.