### PR TITLE
Improved switch building and support for PeekNot

### DIFF
--- a/src/bin/doodle/format/tar.rs
+++ b/src/bin/doodle/format/tar.rs
@@ -112,8 +112,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         "tar.header",
         tuple([
             Format::Peek(Box::new(is_byte(0x61))), // FIXME filename must start with 'a'
-            Format::FixedSlice(
-                BLOCK_SIZE as usize,
+            Format::Slice(
+                Expr::U32(BLOCK_SIZE),
                 Box::new(record([
                     ("name", cstr_arr_opt0(100)),                       // bytes 0 - 99
                     ("mode", cbytes(8)),                                // bytes 100 - 107
@@ -142,8 +142,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
 
     let full_block = repeat_count(Expr::U32(BLOCK_SIZE), Format::Byte(ByteSet::full()));
     let partial_block = |nbytes: Expr| {
-        Format::FixedSlice(
-            BLOCK_SIZE as usize,
+        Format::Slice(
+            Expr::U32(BLOCK_SIZE),
             Box::new(tuple([
                 repeat_count(nbytes, Format::Byte(ByteSet::full())),
                 repeat(is_byte(0x00)),

--- a/src/bin/doodle/format/tar.rs
+++ b/src/bin/doodle/format/tar.rs
@@ -111,7 +111,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     let header = module.define_format(
         "tar.header",
         tuple([
-            Format::Peek(Box::new(not_byte(0x00))),
+            Format::Peek(Box::new(is_byte(0x61))), // FIXME filename must start with 'a'
             Format::FixedSlice(
                 BLOCK_SIZE as usize,
                 Box::new(record([

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -18,6 +18,13 @@ impl Bounds {
         }
     }
 
+    pub fn is_exact(&self) -> Option<usize> {
+        match self.max {
+            Some(n) if n == self.min => Some(n),
+            _ => None,
+        }
+    }
+
     pub fn union(lhs: Bounds, rhs: Bounds) -> Bounds {
         Bounds {
             min: usize::min(lhs.min, rhs.min),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1329,7 +1329,7 @@ impl<'a> MatchTreeStep<'a> {
 
     fn union(mut self, other: MatchTreeStep<'a>) -> MatchTreeStep<'a> {
         self.accept = self.accept || other.accept;
-        for (bs, nexts) in other.branches.into_iter() {
+        for (bs, nexts) in other.branches {
             self.union_branch(bs, nexts);
         }
         self
@@ -1581,8 +1581,8 @@ impl<'a> MatchTreeLevel<'a> {
         if other.accept {
             self.merge_accept(index)?;
         }
-        for (bs, mut nexts) in other.branches.into_iter() {
-            for next in nexts.drain() {
+        for (bs, nexts) in other.branches {
+            for next in nexts {
                 self.merge_branch(index, bs, next)?;
             }
         }
@@ -1602,14 +1602,14 @@ impl<'a> MatchTreeLevel<'a> {
 
     fn grow(
         module: &'a FormatModule,
-        mut nexts: HashSet<(usize, Rc<Next<'a>>)>,
+        nexts: HashSet<(usize, Rc<Next<'a>>)>,
         depth: usize,
     ) -> Option<MatchTree> {
         if let Some(tree) = Self::accepts(&nexts) {
             Some(tree)
         } else if depth > 0 {
             let mut tree = Self::reject();
-            for (i, next) in nexts.drain() {
+            for (i, next) in nexts {
                 let subtree = MatchTreeStep::add_next(module, next);
                 tree = tree.merge(i, subtree).ok()?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1302,6 +1302,15 @@ impl<'a> MatchTreeStep<'a> {
         }
     }
 
+    fn branch(index: usize, bs: ByteSet, next: Rc<Next<'a>>) -> MatchTreeStep<'a> {
+        let mut nexts = Nexts::new();
+        nexts.add(index, next);
+        MatchTreeStep {
+            accept: None,
+            branches: vec![(bs, nexts)],
+        }
+    }
+
     fn merge_accept(&mut self, index: usize) -> Result<(), ()> {
         match self.accept {
             None => {
@@ -1447,11 +1456,7 @@ impl<'a> MatchTreeStep<'a> {
             Format::Align(_) => {
                 Ok(Self::accept(index)) // FIXME
             }
-            Format::Byte(bs) => {
-                let mut tree = Self::reject();
-                tree.merge_branch(index, *bs, next)?;
-                Ok(tree)
-            }
+            Format::Byte(bs) => Ok(Self::branch(index, *bs, next)),
             Format::Union(branches) => {
                 let mut tree = Self::reject();
                 for (_, f) in branches {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1282,9 +1282,8 @@ impl<'a> Nexts<'a> {
         }
     }
 
-    fn add(&mut self, index: usize, next: Rc<Next<'a>>) -> Result<(), ()> {
+    fn add(&mut self, index: usize, next: Rc<Next<'a>>) {
         self.set.insert((index, next));
-        Ok(())
     }
 }
 
@@ -1329,13 +1328,13 @@ impl<'a> MatchTreeStep<'a> {
                     new_branches.push((orig, nexts.clone()));
                 }
                 *bs0 = common;
-                nexts.add(index, next.clone())?;
+                nexts.add(index, next.clone());
                 bs = bs.difference(bs0);
             }
         }
         if !bs.is_empty() {
             let mut nexts = Nexts::new();
-            nexts.add(index, next.clone())?;
+            nexts.add(index, next.clone());
             self.branches.push((bs, nexts));
         }
         self.branches.append(&mut new_branches);
@@ -1383,13 +1382,13 @@ impl<'a> MatchTreeStep<'a> {
                 nexts.add(
                     index,
                     Rc::new(Next::Slice(n - 1, Rc::new(Next::Empty), next.clone())),
-                )?;
+                );
                 tree.branches.push((ByteSet::full(), nexts));
             } else {
                 for (_bs, ref mut nexts) in tree.branches.iter_mut() {
                     let mut new_nexts = Nexts::new();
                     for (index, inside) in nexts.set.drain() {
-                        new_nexts.add(index, Rc::new(Next::Slice(n - 1, inside, next.clone())))?;
+                        new_nexts.add(index, Rc::new(Next::Slice(n - 1, inside, next.clone())));
                     }
                     *nexts = new_nexts;
                 }
@@ -1593,7 +1592,7 @@ impl MatchTree {
     fn build(module: &FormatModule, branches: &[Format], next: Rc<Next<'_>>) -> Option<MatchTree> {
         let mut nexts = Nexts::new();
         for (i, f) in branches.iter().enumerate() {
-            nexts.add(i, Rc::new(Next::Cat(f, next.clone()))).ok()?;
+            nexts.add(i, Rc::new(Next::Cat(f, next.clone())));
         }
         const MAX_DEPTH: usize = 32;
         MatchTreeStep::grow(module, nexts, MAX_DEPTH)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,8 +438,6 @@ pub enum Format {
     Peek(Box<Format>),
     /// Restrict a format to a sub-stream of a given number of bytes (skips any leftover bytes in the sub-stream)
     Slice(Expr, Box<Format>),
-    /// Like [Format::Slice], except the number of bytes is invariant and known in advance
-    FixedSlice(usize, Box<Format>),
     /// Parse bitstream
     Bits(Box<Format>),
     /// Matches a format at a byte offset relative to the current stream position
@@ -613,7 +611,6 @@ impl FormatModule {
             }
             Format::Peek(a) => self.infer_format_type(scope, a),
             Format::Slice(_expr, a) => self.infer_format_type(scope, a),
-            Format::FixedSlice(_sz, a) => self.infer_format_type(scope, a),
             Format::Bits(a) => self.infer_format_type(scope, a),
             Format::WithRelativeOffset(_expr, a) => self.infer_format_type(scope, a),
             Format::Compute(expr) => expr.infer_type(scope),
@@ -701,7 +698,6 @@ enum Decoder {
     RepeatUntilSeq(Expr, Box<Decoder>),
     Peek(Box<Decoder>),
     Slice(Expr, Box<Decoder>),
-    FixedSlice(usize, Box<Decoder>),
     Bits(Box<Decoder>),
     WithRelativeOffset(Expr, Box<Decoder>),
     Compute(Expr),
@@ -1216,7 +1212,6 @@ impl Format {
             Format::RepeatUntilSeq(_, _f) => Bounds::new(0, None),
             Format::Peek(_) => Bounds::exact(0),
             Format::Slice(expr, _) => expr.bounds(),
-            Format::FixedSlice(sz, _) => Bounds::exact(*sz),
             Format::Bits(f) => f.match_bounds(module).bits_to_bytes(),
             Format::WithRelativeOffset(_, _) => Bounds::exact(0),
             Format::Compute(_) => Bounds::exact(0),
@@ -1256,7 +1251,7 @@ impl Format {
             Format::RepeatUntilLast(_, _f) => false,
             Format::RepeatUntilSeq(_, _f) => false,
             Format::Peek(_) => false,
-            Format::Slice(_, _) | Format::FixedSlice(_, _) => false,
+            Format::Slice(_, _) => false,
             Format::Bits(_) => false,
             Format::WithRelativeOffset(_, _) => false,
             Format::Compute(_) => false,
@@ -1516,13 +1511,6 @@ impl<'a> MatchTreeStep<'a> {
                     Self::add_slice(module, index, n, inside, next)
                 } else {
                     Self::add_slice(module, index, bounds.min, inside, Rc::new(Next::Empty))
-                }
-            }
-            Format::FixedSlice(sz, a) => {
-                if *sz == 0 {
-                    Ok(Self::accept(index))
-                } else {
-                    Self::add(module, index, a, next.clone()) // FIXME thi may not be right
                 }
             }
             Format::Bits(_a) => {
@@ -2081,10 +2069,6 @@ impl Decoder {
                 let da = Box::new(Decoder::compile_next(compiler, a, Rc::new(Next::Empty))?);
                 Ok(Decoder::Slice(expr.clone(), da))
             }
-            Format::FixedSlice(sz, a) => {
-                let da = Box::new(Decoder::compile_next(compiler, a, Rc::new(Next::Empty))?);
-                Ok(Decoder::FixedSlice(*sz, da))
-            }
             Format::Bits(a) => {
                 let da = Box::new(Decoder::compile_next(compiler, a, Rc::new(Next::Empty))?);
                 Ok(Decoder::Bits(da))
@@ -2270,13 +2254,6 @@ impl Decoder {
                 let (slice, input) = input
                     .split_at(size)
                     .ok_or(ParseError::overrun(size, input.offset))?;
-                let (v, _) = a.parse(program, scope, slice)?;
-                Ok((v, input))
-            }
-            Decoder::FixedSlice(size, a) => {
-                let (slice, input) = input
-                    .split_at(*size)
-                    .ok_or(ParseError::overrun(*size, input.offset))?;
                 let (v, _) = a.parse(program, scope, slice)?;
                 Ok((v, input))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1307,24 +1307,24 @@ impl<'a> MatchTreeStep<'a> {
         }
     }
 
-    fn union_branch(&mut self, mut bs: ByteSet, new_next: Rc<Next<'a>>) {
-        let mut new_branches = Vec::new();
-        for (bs0, next) in self.branches.iter_mut() {
+    fn union_branch(&mut self, mut bs: ByteSet, next: Rc<Next<'a>>) {
+        let mut branches = Vec::new();
+        for (bs0, next0) in self.branches.iter_mut() {
             let common = bs0.intersection(&bs);
             if !common.is_empty() {
                 let orig = bs0.difference(&bs);
                 if !orig.is_empty() {
-                    new_branches.push((orig, next.clone()));
+                    branches.push((orig, next0.clone()));
                 }
                 *bs0 = common;
-                *next = Rc::new(Next::Union(next.clone(), new_next.clone()));
+                *next0 = Rc::new(Next::Union(next0.clone(), next.clone()));
                 bs = bs.difference(bs0);
             }
         }
         if !bs.is_empty() {
-            self.branches.push((bs, new_next));
+            self.branches.push((bs, next));
         }
-        self.branches.append(&mut new_branches);
+        self.branches.append(&mut branches);
     }
 
     fn union(mut self, other: MatchTreeStep<'a>) -> MatchTreeStep<'a> {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -141,7 +141,7 @@ fn check_covered(
             check_covered(module, path, format)?;
         }
         Format::Peek(_) => {} // FIXME
-        Format::Slice(_, format) | Format::FixedSlice(_, format) => {
+        Format::Slice(_, format) => {
             check_covered(module, path, format)?;
         }
 
@@ -232,9 +232,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_flat(value, format),
-            Format::Slice(_, format) | Format::FixedSlice(_, format) => {
-                self.write_flat(value, format)
-            }
+            Format::Slice(_, format) => self.write_flat(value, format),
             Format::Bits(format) => self.write_flat(value, format),
             Format::WithRelativeOffset(_, format) => self.write_flat(value, format),
             Format::Compute(_expr) => Ok(()),

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -140,7 +140,8 @@ fn check_covered(
         | Format::RepeatUntilSeq(_, format) => {
             check_covered(module, path, format)?;
         }
-        Format::Peek(_) => {} // FIXME
+        Format::Peek(_) => {}    // FIXME
+        Format::PeekNot(_) => {} // FIXME
         Format::Slice(_, format) => {
             check_covered(module, path, format)?;
         }
@@ -232,6 +233,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_flat(value, format),
+            Format::PeekNot(format) => self.write_flat(value, format),
             Format::Slice(_, format) => self.write_flat(value, format),
             Format::Bits(format) => self.write_flat(value, format),
             Format::WithRelativeOffset(_, format) => self.write_flat(value, format),

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -115,6 +115,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_decoded_value(value, format),
+            Format::PeekNot(_format) => self.write_value(value),
             Format::Slice(_, format) => self.write_decoded_value(value, format),
             Format::Bits(format) => self.write_decoded_value(value, format),
             Format::WithRelativeOffset(_, format) => self.write_decoded_value(value, format),
@@ -701,10 +702,6 @@ impl<'module, W: io::Write> Context<'module, W> {
     fn write_format(&mut self, format: &Format) -> io::Result<()> {
         match format {
             Format::Union(_) => write!(&mut self.writer, "_ |...| _"),
-            Format::Peek(format) => {
-                write!(&mut self.writer, "peek ")?;
-                self.write_atomic_format(format)
-            }
             Format::Repeat(format) => {
                 write!(&mut self.writer, "repeat ")?;
                 self.write_atomic_format(format)
@@ -729,6 +726,14 @@ impl<'module, W: io::Write> Context<'module, W> {
                 write!(&mut self.writer, "repeat-until-seq ")?;
                 self.write_atomic_expr(len)?;
                 write!(&mut self.writer, " ")?;
+                self.write_atomic_format(format)
+            }
+            Format::Peek(format) => {
+                write!(&mut self.writer, "peek ")?;
+                self.write_atomic_format(format)
+            }
+            Format::PeekNot(format) => {
+                write!(&mut self.writer, "peek-not ")?;
                 self.write_atomic_format(format)
             }
             Format::Slice(len, format) => {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -115,9 +115,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected sequence"),
             },
             Format::Peek(format) => self.write_decoded_value(value, format),
-            Format::Slice(_, format) | Format::FixedSlice(_, format) => {
-                self.write_decoded_value(value, format)
-            }
+            Format::Slice(_, format) => self.write_decoded_value(value, format),
             Format::Bits(format) => self.write_decoded_value(value, format),
             Format::WithRelativeOffset(_, format) => self.write_decoded_value(value, format),
             Format::Compute(_expr) => self.write_value(value),
@@ -737,10 +735,6 @@ impl<'module, W: io::Write> Context<'module, W> {
                 write!(&mut self.writer, "slice ")?;
                 self.write_atomic_expr(len)?;
                 write!(&mut self.writer, " ")?;
-                self.write_atomic_format(format)
-            }
-            Format::FixedSlice(size, format) => {
-                write!(&mut self.writer, "slice {size} ")?;
                 self.write_atomic_format(format)
             }
             Format::Bits(format) => {


### PR DESCRIPTION
However this breaks tar unless filename is constrained to always begin with a specific character ('a') that distinguishes tar from other formats like PNG and JPEG.