### PR TITLE
Nondeterministic unions

### DIFF
--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -30,13 +30,13 @@ pub fn main(module: &mut FormatModule) -> FormatRef {
         record([
             (
                 "data",
-                alts([
-                    ("gif", gif.call()),
-                    ("gzip", gzip.call()),
-                    ("jpeg", jpeg.call()),
-                    ("png", png.call()),
-                    ("riff", riff.call()),
-                    ("tar", tar.call()),
+                Format::NondetUnion(vec![
+                    ("gif".to_string(), gif.call()),
+                    ("gzip".to_string(), gzip.call()),
+                    ("jpeg".to_string(), jpeg.call()),
+                    ("png".to_string(), png.call()),
+                    ("riff".to_string(), riff.call()),
+                    ("tar".to_string(), tar.call()),
                 ]),
             ),
             ("end", Format::EndOfInput),

--- a/src/bin/doodle/format/tar.rs
+++ b/src/bin/doodle/format/tar.rs
@@ -110,34 +110,31 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
 
     let header = module.define_format(
         "tar.header",
-        tuple([
-            Format::Peek(Box::new(not_byte(0x00))),
-            Format::FixedSlice(
-                BLOCK_SIZE as usize,
-                Box::new(record([
-                    ("name", cstr_arr_opt0(100)),                       // bytes 0 - 99
-                    ("mode", cbytes(8)),                                // bytes 100 - 107
-                    ("uid", cbytes(8)),                                 // bytes 108 - 115
-                    ("gid", cbytes(8)),                                 // bytes 116 - 123
-                    ("size", size_field),                               // bytes 124 - 135
-                    ("mtime", cbytes(12)),                              // bytes 136 - 147
-                    ("chksum", cstr_arr(8)),                            // bytes 148 - 155
-                    ("typeflag", base.u8()),                            // byte 156
-                    ("linkname", cstr_arr_opt0(100)),                   // bytes 157 - 256
-                    ("magic", magic),                                   // bytes 257 - 262
-                    ("version", tuple([is_byte(b'0'), is_byte(b'0')])), // bytes 263 - 264
-                    ("uname", cstr_arr(32)),                            // bytes 265 - 296
-                    ("gname", cstr_arr(32)),                            // bytes 297 - 328
-                    ("devmajor", cbytes(8)),                            // bytes 329 - 336
-                    ("devminor", cbytes(8)),                            // bytes 337 - 344
-                    ("prefix", cstr_arr_opt0(155)),                     // bytes 345 - 500
-                    (
-                        "@padding",
-                        repeat_count(Expr::U16(12), Format::Byte(ByteSet::full())),
-                    ),
-                ])),
-            ),
-        ]),
+        Format::FixedSlice(
+            BLOCK_SIZE as usize,
+            Box::new(record([
+                ("name", cstr_arr_opt0(100)),                       // bytes 0 - 99
+                ("mode", cbytes(8)),                                // bytes 100 - 107
+                ("uid", cbytes(8)),                                 // bytes 108 - 115
+                ("gid", cbytes(8)),                                 // bytes 116 - 123
+                ("size", size_field),                               // bytes 124 - 135
+                ("mtime", cbytes(12)),                              // bytes 136 - 147
+                ("chksum", cstr_arr(8)),                            // bytes 148 - 155
+                ("typeflag", base.u8()),                            // byte 156
+                ("linkname", cstr_arr_opt0(100)),                   // bytes 157 - 256
+                ("magic", magic),                                   // bytes 257 - 262
+                ("version", tuple([is_byte(b'0'), is_byte(b'0')])), // bytes 263 - 264
+                ("uname", cstr_arr(32)),                            // bytes 265 - 296
+                ("gname", cstr_arr(32)),                            // bytes 297 - 328
+                ("devmajor", cbytes(8)),                            // bytes 329 - 336
+                ("devminor", cbytes(8)),                            // bytes 337 - 344
+                ("prefix", cstr_arr_opt0(155)),                     // bytes 345 - 500
+                (
+                    "@padding",
+                    repeat_count(Expr::U16(12), Format::Byte(ByteSet::full())),
+                ),
+            ])),
+        ),
     );
 
     let full_block = repeat_count(Expr::U32(BLOCK_SIZE), Format::Byte(ByteSet::full()));
@@ -161,7 +158,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     repeat_count(
                         Expr::Div(
                             Box::new(Expr::RecordProj(
-                                Box::new(Expr::TupleProj(Box::new(var("header")), 1)),
+                                Box::new(var("header")),
                                 "size".to_string(),
                             )),
                             Box::new(Expr::U32(BLOCK_SIZE)),
@@ -170,7 +167,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     ),
                     partial_block(Expr::Rem(
                         Box::new(Expr::RecordProj(
-                            Box::new(Expr::TupleProj(Box::new(var("header")), 1)),
+                            Box::new(var("header")),
                             "size".to_string(),
                         )),
                         Box::new(Expr::U32(BLOCK_SIZE)),

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -118,7 +118,7 @@ fn check_covered(
         Format::Byte(_) => {
             return Err(format!("uncovered byte: {:?}", path));
         }
-        Format::Union(branches) => {
+        Format::Union(branches) | Format::NondetUnion(branches) => {
             for (label, format) in branches {
                 path.push(label.clone());
                 check_covered(module, path, format)?;
@@ -192,7 +192,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::EndOfInput => Ok(()),
             Format::Align(_) => Ok(()),
             Format::Byte(_) => Ok(()),
-            Format::Union(branches) => match value {
+            Format::Union(branches) | Format::NondetUnion(branches) => match value {
                 Value::Variant(label, value) => {
                     let (_, format) = branches.iter().find(|(l, _)| l == label).unwrap();
                     self.write_flat(value, format)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -87,7 +87,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::EndOfInput => self.write_value(value),
             Format::Align(_) => self.write_value(value),
             Format::Byte(_) => self.write_value(value),
-            Format::Union(branches) => match value {
+            Format::Union(branches) | Format::NondetUnion(branches) => match value {
                 Value::Variant(label, value) => {
                     let (_, format) = branches.iter().find(|(l, _)| l == label).unwrap();
                     self.write_variant(label, value, Some(format))
@@ -716,7 +716,7 @@ impl<'module, W: io::Write> Context<'module, W> {
 
     fn write_format(&mut self, format: &Format) -> io::Result<()> {
         match format {
-            Format::Union(_) => write!(&mut self.writer, "_ |...| _"),
+            Format::Union(_) | Format::NondetUnion(_) => write!(&mut self.writer, "_ |...| _"),
             Format::Peek(format) => {
                 write!(&mut self.writer, "peek ")?;
                 self.write_atomic_format(format)
@@ -975,7 +975,7 @@ impl<'module> MonoidalPrinter<'module> {
             Format::EndOfInput => self.compile_value(value),
             Format::Align(_) => self.compile_value(value),
             Format::Byte(_) => self.compile_value(value),
-            Format::Union(branches) => match value {
+            Format::Union(branches) | Format::NondetUnion(branches) => match value {
                 Value::Variant(label, value) => {
                     let (_, format) = branches.iter().find(|(l, _)| l == label).unwrap();
                     self.compile_variant(label, value, Some(format))
@@ -1604,7 +1604,7 @@ impl<'module> MonoidalPrinter<'module> {
 
     fn compile_format(&mut self, format: &Format, prec: Precedence) -> Fragment {
         match format {
-            Format::Union(_) => cond_paren(
+            Format::Union(_) | Format::NondetUnion(_) => cond_paren(
                 Fragment::String("_ |...| _".into()),
                 prec,
                 Precedence::FORMAT_COMPOUND,


### PR DESCRIPTION
The simplest possible approach: it tries to parse each branch and takes the first one that succeeds. This will do exactly what we want for the one place where we currently use it: to distinguish between top-level file formats.

A smarter approach would be to run the branches in parallel and take the branch that proceeds the furthest without hitting an error, and to eliminate impossible branches earlier using a partial match tree, but that can wait.