### PR TITLE
Add variant Format::Described

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -233,3 +233,21 @@ impl Display for Fragment {
         }
     }
 }
+
+impl From<&'static str> for Fragment {
+    fn from(value: &'static str) -> Self {
+        Self::String(Cow::Borrowed(value))
+    }
+}
+
+impl From<String> for Fragment {
+    fn from(value: String) -> Self {
+        Self::String(Cow::Owned(value))
+    }
+}
+
+impl From<char> for Fragment {
+    fn from(value: char) -> Self {
+        Self::Char(value)
+    }
+}

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -165,6 +165,9 @@ fn check_covered(
             }
         }
         Format::Dynamic(_) => {} // FIXME
+        Format::Described(format, _comment) => {
+            check_covered(module, path, format)?;
+        }
     }
     Ok(())
 }
@@ -269,6 +272,11 @@ impl<'module, W: io::Write> Context<'module, W> {
                 Ok(())
             }
             Format::Dynamic(_) => Ok(()), // FIXME
+            Format::Described(f, comment) => {
+                self.write_flat(value, f)?;
+                write!(&mut self.writer, "/* {comment} */")?;
+                Ok(())
+            }
         }
     }
 }


### PR DESCRIPTION
Currently unused, intended to allow for end-user-visible descriptions of complex or ambiguous-interpretation Formats, over in-source comments that are harder to find and less useful for downstream interepretation.