### PR TITLE
Fixes for tar, pretty-printing

### DIFF
--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -71,10 +71,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::ItemVar(level, _args) => {
                 let fmt_name = self.module.get_name(*level);
 
-                if self.flags.pretty_ascii_strings
-                    && (fmt_name == "base.asciiz-string"
-                        || (fmt_name.contains("ascii") && fmt_name.contains("string")))
-                {
+                if self.flags.pretty_ascii_strings && name_is_ascii_string(fmt_name) {
                     self.write_ascii_string(value)
                 } else if self.flags.pretty_ascii_strings && fmt_name.starts_with("base.ascii-char")
                 {
@@ -328,7 +325,7 @@ impl<'module, W: io::Write> Context<'module, W> {
     fn is_ascii_string_format(&self, format: &Format) -> bool {
         match format {
             Format::ItemVar(level, _args) => {
-                self.module.get_name(*level) == "base.asciiz-string"
+                name_is_ascii_string(self.module.get_name(*level))
                     || self.is_ascii_string_format(self.module.get_format(*level))
             }
             Format::Tuple(formats) => self.is_ascii_tuple_format(formats),
@@ -840,6 +837,11 @@ impl<'module, W: io::Write> Context<'module, W> {
     }
 }
 
+#[inline]
+fn name_is_ascii_string(name: &str) -> bool {
+    name.contains("ascii") && name.contains("string")
+}
+
 pub struct MonoidalPrinter<'module> {
     gutter: Vec<Column>,
     preview_len: Option<usize>,
@@ -871,7 +873,7 @@ impl<'module> MonoidalPrinter<'module> {
     fn is_ascii_string_format(&self, format: &Format) -> bool {
         match format {
             Format::ItemVar(level, _args) => {
-                self.module.get_name(*level) == "base.asciiz-string"
+                name_is_ascii_string(self.module.get_name(*level))
                     || self.is_ascii_string_format(self.module.get_format(*level))
             }
             Format::Tuple(formats) => self.is_ascii_tuple_format(formats),
@@ -974,13 +976,9 @@ impl<'module> MonoidalPrinter<'module> {
             Format::ItemVar(level, _args) => {
                 let fmt_name = self.module.get_name(*level);
 
-                if self.flags.pretty_ascii_strings
-                    && (fmt_name == "base.asciiz-string"
-                        || (fmt_name.contains("ascii") && fmt_name.contains("string")))
-                {
+                if self.flags.pretty_ascii_strings && name_is_ascii_string(fmt_name) {
                     self.compile_ascii_string(value)
-                } else if self.flags.pretty_ascii_strings
-                    && self.module.get_name(*level).starts_with("base.ascii-char")
+                } else if self.flags.pretty_ascii_strings && fmt_name.starts_with("base.ascii-char")
                 {
                     frag.encat(Fragment::Char('\''));
                     frag.encat(self.compile_ascii_char(value));

--- a/tests/expected/decode/test.gif.stdout
+++ b/tests/expected/decode/test.gif.stdout
@@ -10,7 +10,7 @@
 │       │   │   ├── flags <- base.u8 := 244
 │       │   │   ├── bg-color-index <- base.u8 := 0
 │       │   │   └── pixel-aspect-ratio <- base.u8 := 0
-│       │   └── global-color-table <- match ((descriptor.flags & 128) != 0) { ... } :=
+│       │   └── global-color-table <- match (descriptor.flags & 128 != 0) { ... } :=
 │       │       └──    r   g   b
 │       │              0   0   0
 │       │            162 161 162
@@ -65,7 +65,7 @@
 │       │                   │   ├── image-width <- base.u16le := 50
 │       │                   │   ├── image-height <- base.u16le := 50
 │       │                   │   └── flags <- base.u8 := 0
-│       │                   ├── local-color-table <- match ((descriptor.flags & 128) != 0) { ... } := ()
+│       │                   ├── local-color-table <- match (descriptor.flags & 128 != 0) { ... } := ()
 │       │                   └── data <- gif.table-based-image-data :=
 │       │                       ├── lzw-min-code-size <- base.u8 := 5
 │       │                       ├── image-data <- repeat gif.subblock :=

--- a/tests/expected/decode/test.png.stdout
+++ b/tests/expected/decode/test.png.stdout
@@ -108,6 +108,6 @@
 │       └── iend <- png.iend :=
 │           ├── length <- base.u32be := 0
 │           ├── tag <- png.iend-tag
-│           ├── data <- slice length png.iend-data := ()
+│           ├── data <- slice length png.iend-data
 │           └── crc <- base.u32be := 2923585666
 └── end <- end-of-input

--- a/tests/expected/decode/test.webp.stdout
+++ b/tests/expected/decode/test.webp.stdout
@@ -19,7 +19,7 @@
 │       │       │   │   ├── 7 <- base.u8 := 58
 │       │       │   │   ├── 8 <- base.u8 := 0
 │       │       │   │   └── 9 <- base.u8 := 0
-│       │       │   └── pad <- match ((length % 2) == 0) { ... } := ()
+│       │       │   └── pad <- match (length % 2 == 0) { ... } := ()
 │       │       ├── 1 <- riff.chunk :=
 │       │       │   ├── tag <- riff.tag := "VP8L"
 │       │       │   ├── length <- base.u32le := 963
@@ -36,7 +36,7 @@
 │       │       │   │   ├── 9 <- base.u8 := 173
 │       │       │   │   ~
 │       │       │   │   └── 962 <- base.u8 := 13
-│       │       │   └── pad <- match ((length % 2) == 0) { ... } := 0
+│       │       │   └── pad <- match (length % 2 == 0) { ... } := 0
 │       │       └── 2 <- riff.chunk :=
 │       │           ├── tag <- riff.tag := "EXIF"
 │       │           ├── length <- base.u32le := 138
@@ -53,6 +53,6 @@
 │       │           │   ├── 9 <- base.u8 := 42
 │       │           │   ~
 │       │           │   └── 137 <- base.u8 := 0
-│       │           └── pad <- match ((length % 2) == 0) { ... } := ()
-│       └── pad <- match ((length % 2) == 0) { ... } := ()
+│       │           └── pad <- match (length % 2 == 0) { ... } := ()
+│       └── pad <- match (length % 2 == 0) { ... } := ()
 └── end <- end-of-input


### PR DESCRIPTION
Fixes various minor nits in the tar format definition, adjusts pretty-printing rules to handle more combinatorial Formats as ASCII string/characters, and similarly to treat more combinatorial Formats as "implied values" (i.e. can be omitted from tree printing)