### PR TITLE
Assorted tweaks to `base.rs` and ByteSet

### DIFF
--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -78,7 +78,7 @@ pub fn is_bytes(bytes: &[u8]) -> Format {
 }
 
 /// ByteSet consisting of 0..=127, or the valid ASCII range (including control characters)
-pub const VALID_ASCII : ByteSet = ByteSet::from_bits([u64::MAX, u64::MAX, 0, 0]);
+pub const VALID_ASCII: ByteSet = ByteSet::from_bits([u64::MAX, u64::MAX, 0, 0]);
 
 pub struct BaseModule {
     bit: FormatRef,

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -65,6 +65,10 @@ pub fn is_byte(b: u8) -> Format {
     Format::Byte(ByteSet::from([b]))
 }
 
+pub fn repeat_byte(count: u32, b: u8) -> Format {
+    Format::RepeatCount(Expr::U32(count), Box::new(is_byte(b)))
+}
+
 pub fn not_byte(b: u8) -> Format {
     Format::Byte(!ByteSet::from([b]))
 }
@@ -72,6 +76,9 @@ pub fn not_byte(b: u8) -> Format {
 pub fn is_bytes(bytes: &[u8]) -> Format {
     tuple(bytes.iter().copied().map(is_byte))
 }
+
+/// ByteSet consisting of 0..=127, or the valid ASCII range (including control characters)
+pub const VALID_ASCII : ByteSet = ByteSet::from_bits([u64::MAX, u64::MAX, 0, 0]);
 
 pub struct BaseModule {
     bit: FormatRef,

--- a/src/bin/doodle/format/tar.rs
+++ b/src/bin/doodle/format/tar.rs
@@ -154,8 +154,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 ("gname", cstr_arr(32)),         // bytes 297 - 328
                 ("devmajor", o_numeric(8)),      // bytes 329 - 336
                 ("devminor", o_numeric(8)),      // bytes 337 - 344
-                ("prefix", prefix),              // bytes 345 - 500
-                ("pad", repeat_count(Expr::U16(12), is_byte(0x00))),
+                ("prefix", prefix),              // bytes 345 - 499
+                ("pad", repeat_byte(12, 0x00)),  // bytes 500 - 511
             ])),
         ),
     );

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -139,6 +139,12 @@ impl<'a> From<&'a [u8]> for ByteSet {
     }
 }
 
+impl From<ops::Range<u8>> for ByteSet {
+    fn from(value: ops::Range<u8>) -> Self {
+        ByteSet::from(value.start..=value.end - 1)
+    }
+}
+
 impl From<ops::RangeInclusive<u8>> for ByteSet {
     fn from(value: ops::RangeInclusive<u8>) -> Self {
         // because the values are adjacent, we can optimize if they are within the same quadrant

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -11,7 +11,6 @@ pub struct ByteSet {
 }
 
 impl ByteSet {
-    #[inline(always)]
     pub const fn new() -> ByteSet {
         ByteSet::empty()
     }
@@ -145,7 +144,11 @@ impl<'a> From<&'a [u8]> for ByteSet {
 
 impl From<ops::Range<u8>> for ByteSet {
     fn from(value: ops::Range<u8>) -> Self {
-        ByteSet::from(value.start..=value.end - 1)
+        if value.end <= value.start {
+            ByteSet::empty()
+        } else {
+            ByteSet::from(value.start..=value.end - 1)
+        }
     }
 }
 
@@ -154,6 +157,11 @@ impl From<ops::RangeInclusive<u8>> for ByteSet {
         // because the values are adjacent, we can optimize if they are within the same quadrant
         let lo = value.start();
         let hi = value.end();
+        if hi < lo {
+            return ByteSet::empty();
+        } else if hi == lo {
+            return ByteSet::from([*lo]);
+        }
         let start_ix = *lo / 64;
         let end_ix = *hi / 64;
         if start_ix == end_ix {

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -162,12 +162,12 @@ impl From<ops::RangeInclusive<u8>> for ByteSet {
         } else if hi == lo {
             return ByteSet::from([*lo]);
         }
-        let start_ix = *lo / 64;
-        let end_ix = *hi / 64;
+        let start_ix = *lo >> 6;
+        let end_ix = *hi >> 6;
         if start_ix == end_ix {
             let mut mask = 0u64;
             for i in value {
-                mask |= 1 << i % 64;
+                mask |= 1 << (i & 63);
             }
             let bits = match start_ix {
                 0 => [mask, 0, 0, 0],

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -157,18 +157,18 @@ impl From<ops::RangeInclusive<u8>> for ByteSet {
             for i in value {
                 mask |= 1 << (i % 64);
             }
-            match start_ix {
-                0 => ByteSet { bits: [mask, 0, 0, 0] },
-                1 => ByteSet { bits: [0, mask, 0, 0] },
-                2 => ByteSet { bits: [0, 0, mask, 0] },
-                3 => ByteSet { bits: [0, 0, 0, mask] },
-                _ => unreachable!("u8 / 64 not in range 0..=3 ??")
-            }
+            let bits = match start_ix {
+                0 => [mask, 0, 0, 0],
+                1 => [0, mask, 0, 0],
+                2 => [0, 0, mask, 0],
+                3 => [0, 0, 0, mask],
+                _ => unreachable!("u8 / 64 not in range 0..=3 ??"),
+            };
+            ByteSet { bits }
         } else {
             // Fall-back to FromIter implementation, which is less efficient in general
             value.collect::<ByteSet>()
         }
-
     }
 }
 
@@ -337,7 +337,6 @@ mod tests {
                                 }
         }
 
-
         proptest! {
             #[test]
             fn test_from_range_single_quadrant((start, end) in (0u8..=3).prop_flat_map(range_in_quadrant)) {
@@ -355,5 +354,4 @@ mod tests {
             }
         }
     }
-
 }


### PR DESCRIPTION
- Adds `repeat_byte` format helper function to `base.rs` when a particular byte is repeated a fixed number of times.
- Adds `VALID_ASCII : ByteSet` const value for future use
- Fixes off-by-one in offset comments of tar header
- Adds `#[inline]` attributes, const modifiers to selected ByteSet functions (particularly, so that `from_bits`, `empty`, and `full` can be used in `const` declarations)
- Adds optimized `From<RangeInclusive<u8>>` for ByteSet, as well as `From<&' [u8]>` and `FromIterator<u8>`. 