### PR TITLE
Format::IsoUnion

### DIFF
--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -126,6 +126,11 @@ fn check_covered(
                 path.pop();
             }
         }
+        Format::IsoUnion(branches) => {
+            for format in branches {
+                check_covered(module, path, format)?;
+            }
+        }
         Format::Tuple(formats) => {
             for format in formats {
                 check_covered(module, path, format)?;
@@ -202,6 +207,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected variant"),
             },
+            Format::IsoUnion(_) => Ok(()), // FIXME
             Format::Tuple(formats) => match value {
                 Value::Tuple(values) => {
                     for (index, value) in values.iter().enumerate() {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -194,6 +194,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
                 _ => panic!("expected variant, found {value:?}"),
             },
+            Format::IsoUnion(_branches) => self.compile_value(value),
             Format::Tuple(formats) => match value {
                 Value::Tuple(values) => {
                     if self.flags.pretty_ascii_strings && self.is_ascii_tuple_format(formats) {
@@ -898,7 +899,7 @@ impl<'module> MonoidalPrinter<'module> {
 
     fn compile_format(&mut self, format: &Format, prec: Precedence) -> Fragment {
         match format {
-            Format::Union(_) | Format::NondetUnion(_) => cond_paren(
+            Format::Union(_) | Format::NondetUnion(_) | Format::IsoUnion(_) => cond_paren(
                 Fragment::String("_ |...| _".into()),
                 prec,
                 Precedence::FORMAT_COMPOUND,

--- a/tests/expected/decode/test1.gz.stdout
+++ b/tests/expected/decode/test1.gz.stdout
@@ -15,7 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- { ... } := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := { ... }
+│           │   │           ├── format <- dynamic := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 72

--- a/tests/expected/decode/test2.gz.stdout
+++ b/tests/expected/decode/test2.gz.stdout
@@ -15,7 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- { ... } := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := { ... }
+│           │   │           ├── format <- dynamic := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 104

--- a/tests/expected/decode/test3.gz.stdout
+++ b/tests/expected/decode/test3.gz.stdout
@@ -15,7 +15,7 @@
 │       │   │   │       ├── final <- base.bit := 1
 │       │   │   │       ├── type <- { ... } := 1
 │       │   │   │       └── data <- match type { ... } :=
-│       │   │   │           ├── format <- dynamic := { ... }
+│       │   │   │           ├── format <- dynamic := _ |...| _
 │       │   │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │       │   │   │           │   ├── 0 <- { ... } :=
 │       │   │   │           │   │   ├── code <- apply := 72
@@ -108,7 +108,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- { ... } := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := { ... }
+│           │   │           ├── format <- dynamic := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 104

--- a/tests/expected/decode/test4.gz.stdout
+++ b/tests/expected/decode/test4.gz.stdout
@@ -31,7 +31,7 @@
 │           │   │   │       │   ├── 9 <- { ... } := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 14 <- { ... } := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 5
@@ -106,8 +106,8 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 28 := 8
-│           │   │   │       ├── distance-alphabet-format <- dynamic := { ... }
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 255
@@ -176,7 +176,7 @@
 │           │   │   │       │   ├── 9 <- { ... } := 6
 │           │   │   │       │   ~
 │           │   │   │       │   └── 18 <- { ... } := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 6
@@ -251,8 +251,8 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 29 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := { ... }
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 207
@@ -321,7 +321,7 @@
 │           │   │           │   ├── 9 <- { ... } := 5
 │           │   │           │   ~
 │           │   │           │   └── 16 <- { ... } := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := { ... }
+│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
 │           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 7
@@ -396,8 +396,8 @@
 │           │   │           │   ├── 9 := 7
 │           │   │           │   ~
 │           │   │           │   └── 29 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := { ... }
-│           │   │           ├── literal-length-alphabet-format <- dynamic := { ... }
+│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 252

--- a/tests/expected/decode/test5.gz.stdout
+++ b/tests/expected/decode/test5.gz.stdout
@@ -31,7 +31,7 @@
 │           │   │   │       │   ├── 9 <- { ... } := 3
 │           │   │   │       │   ~
 │           │   │   │       │   └── 13 <- { ... } := 5
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 17
@@ -106,8 +106,8 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 27 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := { ... }
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := { ... }
+│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 <- { ... } :=
 │           │   │   │       │   │   ├── code <- apply := 35
@@ -176,7 +176,7 @@
 │           │   │           │   ├── 9 <- { ... } := 3
 │           │   │           │   ~
 │           │   │           │   └── 13 <- { ... } := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := { ... }
+│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
 │           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 18
@@ -251,8 +251,8 @@
 │           │   │           │   ├── 9 := 0
 │           │   │           │   ~
 │           │   │           │   └── 28 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := { ... }
-│           │   │           ├── literal-length-alphabet-format <- dynamic := { ... }
+│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 <- { ... } :=
 │           │   │           │   │   ├── code <- apply := 50


### PR DESCRIPTION
This implements unions where all the branches have the same type, either because they match the same structure (for example three bytes in UTF-8) or because they match records with the same type for the `@value` field. Such unions can return the value directly without the need to wrap it in a variant for each branch.