### PR TITLE
Immutable scopes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ impl std::fmt::Display for ParseError {
 impl std::error::Error for ParseError {}
 
 impl ParseError {
-    pub fn fail(scope: &Scope, input: ReadCtxt<'_>) -> Self {
+    pub fn fail(scope: &Scope<'_>, input: ReadCtxt<'_>) -> Self {
         let bindings = scope.iter().collect::<Vec<_>>();
         let buffer = input.input.to_owned();
         let offset = input.offset;

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -268,8 +268,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Match(head, branches) => {
                 let head = head.eval(scope);
                 for (pattern, format) in branches {
-                    let mut pattern_scope = Scope::child(scope);
-                    if head.matches(&mut pattern_scope, pattern) {
+                    if let Some(pattern_scope) = head.matches(scope, pattern) {
                         self.write_flat(&pattern_scope, value, format)?;
                         return Ok(());
                     }
@@ -279,8 +278,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::MatchVariant(head, branches) => {
                 let head = head.eval(scope);
                 for (pattern, _label, format) in branches {
-                    let mut pattern_scope = Scope::child(scope);
-                    if head.matches(&mut pattern_scope, pattern) {
+                    if let Some(pattern_scope) = head.matches(scope, pattern) {
                         if let Value::Variant(_label, value) = value {
                             self.write_flat(&pattern_scope, value, format)?;
                         } else {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -256,8 +256,7 @@ impl<'module> MonoidalPrinter<'module> {
             Format::Match(head, branches) => {
                 let head = head.eval(&scope);
                 for (pattern, format) in branches {
-                    let mut pattern_scope = Scope::child(scope);
-                    if head.matches(&mut pattern_scope, pattern) {
+                    if let Some(pattern_scope) = head.matches(scope, pattern) {
                         frag.encat(self.compile_decoded_value(&pattern_scope, value, format));
                         return frag;
                     }
@@ -267,8 +266,7 @@ impl<'module> MonoidalPrinter<'module> {
             Format::MatchVariant(head, branches) => {
                 let head = head.eval(&scope);
                 for (pattern, _label, format) in branches {
-                    let mut pattern_scope = Scope::child(scope);
-                    if head.matches(&mut pattern_scope, pattern) {
+                    if let Some(pattern_scope) = head.matches(scope, pattern) {
                         if let Value::Variant(_label, value) = value {
                             frag.encat(self.compile_decoded_value(&pattern_scope, value, format));
                         } else {


### PR DESCRIPTION
Create a child scope when you need one and simply discard it when done, this makes scope handling much more robust, without the risk of an early exit leaving the parent scope in an inconsistent state.