### PR TITLE
Value::Branch, to remember the branch taken in union and match formats

### DIFF
--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -34,7 +34,7 @@ pub fn main(module: &mut FormatModule) -> FormatRef {
         record([
             (
                 "data",
-                Format::NondetUnion(vec![
+                Format::UnionNondet(vec![
                     ("gif".into(), gif.call()),
                     ("gzip".into(), gzip.call()),
                     ("jpeg".into(), jpeg.call()),

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -18,7 +18,7 @@ pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
 pub fn alts<Label: Into<Cow<'static, str>>>(
     fields: impl IntoIterator<Item = (Label, Format)>,
 ) -> Format {
-    Format::Union(
+    Format::UnionVariant(
         (fields.into_iter())
             .map(|(label, format)| (label.into(), format))
             .collect(),

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -25,8 +25,8 @@ pub fn alts<Label: Into<Cow<'static, str>>>(
     )
 }
 
-pub fn iso_alts(branches: impl IntoIterator<Item = Format>) -> Format {
-    Format::IsoUnion(branches.into_iter().collect())
+pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
+    Format::Union(branches.into_iter().collect())
 }
 
 pub fn record<Label: Into<Cow<'static, str>>>(

--- a/src/bin/doodle/format/jpeg.rs
+++ b/src/bin/doodle/format/jpeg.rs
@@ -353,7 +353,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
     // MCU: Minimum coded unit
     let mcu = module.define_format(
         "jpeg.mcu",
-        Format::IsoUnion(vec![
+        Format::Union(vec![
             not_byte(0xFF),
             Format::Map(
                 Box::new(tuple([is_byte(0xFF), is_byte(0x00)])),

--- a/src/bin/doodle/format/utf8.rs
+++ b/src/bin/doodle/format/utf8.rs
@@ -53,7 +53,7 @@ pub fn main(module: &mut FormatModule, _base: &BaseModule) -> FormatRef {
     );
 
     let utf8_3 = Format::Map(
-        Box::new(iso_alts([
+        Box::new(union([
             tuple([
                 drop_n_msb(4, is_byte(0xE0)),
                 drop_n_msb(2, byte_in(0xA0..=0xBF)),
@@ -88,7 +88,7 @@ pub fn main(module: &mut FormatModule, _base: &BaseModule) -> FormatRef {
     );
 
     let utf8_4 = Format::Map(
-        Box::new(iso_alts([
+        Box::new(union([
             tuple([
                 drop_n_msb(5, is_byte(0xF0)),
                 drop_n_msb(2, byte_in(0x90..=0xBF)),
@@ -124,7 +124,7 @@ pub fn main(module: &mut FormatModule, _base: &BaseModule) -> FormatRef {
     let utf8_char = module.define_format(
         "utf8.char",
         Format::Map(
-            Box::new(iso_alts([utf8_1, utf8_2, utf8_3, utf8_4])),
+            Box::new(union([utf8_1, utf8_2, utf8_3, utf8_4])),
             Expr::Lambda(
                 "codepoint".into(),
                 Box::new(Expr::AsChar(Box::new(var("codepoint")))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2644,20 +2644,26 @@ impl Decoder {
             }
             Decoder::Match(head, branches) => {
                 let head = head.eval(scope);
-                for (pattern, decoder) in branches {
+                for (index, (pattern, decoder)) in branches.iter().enumerate() {
                     if let Some(pattern_scope) = head.matches(scope, pattern) {
                         let (v, input) = decoder.parse(program, &pattern_scope, input)?;
-                        return Ok((v, input));
+                        return Ok((Value::Branch(index, Box::new(v)), input));
                     }
                 }
                 panic!("non-exhaustive patterns");
             }
             Decoder::MatchVariant(head, branches) => {
                 let head = head.eval(scope);
-                for (pattern, label, decoder) in branches {
+                for (index, (pattern, label, decoder)) in branches.iter().enumerate() {
                     if let Some(pattern_scope) = head.matches(scope, pattern) {
                         let (v, input) = decoder.parse(program, &pattern_scope, input)?;
-                        return Ok((Value::Variant(label.clone(), Box::new(v)), input));
+                        return Ok((
+                            Value::Branch(
+                                index,
+                                Box::new(Value::Variant(label.clone(), Box::new(v))),
+                            ),
+                            input,
+                        ));
                     }
                 }
                 panic!("exhaustive patterns");

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -124,7 +124,7 @@ fn check_covered(
             check_covered(module, path, format)?;
             path.pop();
         }
-        Format::UnionVariant(branches) | Format::NondetUnion(branches) => {
+        Format::UnionVariant(branches) | Format::UnionNondet(branches) => {
             for (label, format) in branches {
                 path.push(label.clone());
                 check_covered(module, path, format)?;
@@ -217,7 +217,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected variant"),
             },
-            Format::UnionVariant(branches) | Format::NondetUnion(branches) => match value {
+            Format::UnionVariant(branches) | Format::UnionNondet(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index].1;
                     match value.as_ref() {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -218,13 +218,22 @@ impl<'module, W: io::Write> Context<'module, W> {
                 _ => panic!("expected variant"),
             },
             Format::Union(branches) | Format::NondetUnion(branches) => match value {
-                Value::Variant(label, value) => {
-                    let (_, format) = branches.iter().find(|(l, _)| l == label).unwrap();
+                Value::Branch(index, value) => {
+                    let format = &branches[*index].1;
+                    match value.as_ref() {
+                        Value::Variant(_label, value) => self.write_flat(scope, value, format),
+                        _ => panic!("expected variant"),
+                    }
+                }
+                _ => panic!("expected branch"),
+            },
+            Format::IsoUnion(branches) => match value {
+                Value::Branch(index, value) => {
+                    let format = &branches[*index];
                     self.write_flat(scope, value, format)
                 }
-                _ => panic!("expected variant"),
+                _ => panic!("expected branch"),
             },
-            Format::IsoUnion(_) => Ok(()), // FIXME
             Format::Tuple(formats) => match value {
                 Value::Tuple(values) => {
                     for (index, value) in values.iter().enumerate() {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -223,7 +223,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                         panic!("expected variant label {label}, found {label2}");
                     }
                 }
-                _ => panic!("expected variant"),
+                _ => panic!("expected variant, found {value:?}"),
             },
             Format::UnionVariant(branches) | Format::UnionNondet(branches) => match value {
                 Value::Branch(index, value) => {
@@ -233,17 +233,17 @@ impl<'module, W: io::Write> Context<'module, W> {
                             assert_eq!(label, label2);
                             self.write_flat(scope, value, format)
                         }
-                        _ => panic!("expected variant"),
+                        _ => panic!("expected variant, found {value:?}"),
                     }
                 }
-                _ => panic!("expected branch"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::Union(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index];
                     self.write_flat(scope, value, format)
                 }
-                _ => panic!("expected branch"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::Tuple(formats) => match value {
                 Value::Tuple(values) => {
@@ -253,7 +253,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                     }
                     Ok(())
                 }
-                _ => panic!("expected tuple"),
+                _ => panic!("expected tuple, found {value:?}"),
             },
             Format::Record(format_fields) => match value {
                 Value::Record(value_fields) => {
@@ -265,7 +265,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                     }
                     Ok(())
                 }
-                _ => panic!("expected record"),
+                _ => panic!("expected record, found {value:?}"),
             },
             Format::Repeat(format)
             | Format::Repeat1(format)
@@ -278,7 +278,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                     }
                     Ok(())
                 }
-                _ => panic!("expected sequence"),
+                _ => panic!("expected sequence, found {value:?}"),
             },
             Format::Peek(format) => self.write_flat(scope, value, format),
             Format::PeekNot(format) => self.write_flat(scope, value, format),
@@ -297,7 +297,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                     }
                     panic!("pattern match failure");
                 }
-                _ => panic!("expected branch value"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::MatchVariant(head, branches) => match value {
                 Value::Branch(index, value) => {
@@ -308,13 +308,13 @@ impl<'module, W: io::Write> Context<'module, W> {
                             assert_eq!(label, label2);
                             self.write_flat(&pattern_scope, value, format)?;
                         } else {
-                            panic!("expected variant value");
+                            panic!("expected variant, found {value:?}");
                         }
                         return Ok(());
                     }
                     panic!("pattern match failure");
                 }
-                _ => panic!("expected branch value"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::Dynamic(_) => Ok(()), // FIXME
             Format::Apply(_) => Ok(()),   // FIXME

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -124,7 +124,7 @@ fn check_covered(
             check_covered(module, path, format)?;
             path.pop();
         }
-        Format::Union(branches) | Format::NondetUnion(branches) => {
+        Format::UnionVariant(branches) | Format::NondetUnion(branches) => {
             for (label, format) in branches {
                 path.push(label.clone());
                 check_covered(module, path, format)?;
@@ -217,7 +217,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected variant"),
             },
-            Format::Union(branches) | Format::NondetUnion(branches) => match value {
+            Format::UnionVariant(branches) | Format::NondetUnion(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index].1;
                     match value.as_ref() {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -131,7 +131,7 @@ fn check_covered(
                 path.pop();
             }
         }
-        Format::IsoUnion(branches) => {
+        Format::Union(branches) => {
             for format in branches {
                 check_covered(module, path, format)?;
             }
@@ -227,7 +227,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected branch"),
             },
-            Format::IsoUnion(branches) => match value {
+            Format::Union(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index];
                     self.write_flat(scope, value, format)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -144,7 +144,7 @@ impl<'module> MonoidalPrinter<'module> {
                     let format = &branches[*n];
                     self.is_atomic_value(value, Some(format))
                 }
-                Some(Format::UnionVariant(branches)) => {
+                Some(Format::UnionVariant(branches)) | Some(Format::UnionNondet(branches)) => {
                     let format = &branches[*n].1;
                     self.is_atomic_value(value, Some(format))
                 }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -140,7 +140,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
             }
             Value::Branch(n, value) => match format {
-                Some(Format::IsoUnion(branches)) => {
+                Some(Format::Union(branches)) => {
                     let format = &branches[*n];
                     self.is_atomic_value(value, Some(format))
                 }
@@ -226,7 +226,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
                 _ => panic!("expected branch, found {value:?}"),
             },
-            Format::IsoUnion(branches) => match value {
+            Format::Union(branches) => match value {
                 Value::Branch(n, value) => {
                     let format = &branches[*n];
                     self.compile_decoded_value(scope, value, format)
@@ -1024,7 +1024,7 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::FORMAT_COMPOUND,
             ),
-            Format::UnionVariant(_) | Format::UnionNondet(_) | Format::IsoUnion(_) => cond_paren(
+            Format::UnionVariant(_) | Format::UnionNondet(_) | Format::Union(_) => cond_paren(
                 Fragment::String("_ |...| _".into()),
                 prec,
                 Precedence::FORMAT_COMPOUND,

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -263,7 +263,7 @@ impl<'module> MonoidalPrinter<'module> {
                     let format = &branches[*n];
                     self.compile_decoded_value(scope, value, format)
                 }
-                _ => panic!("expected branch value, found {value:?}"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::Tuple(formats) => match value {
                 Value::Tuple(values) => {
@@ -331,7 +331,7 @@ impl<'module> MonoidalPrinter<'module> {
                     }
                     panic!("pattern match failure");
                 }
-                _ => panic!("expected branch value"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::MatchVariant(head, branches) => match value {
                 Value::Branch(index, value) => {
@@ -342,13 +342,13 @@ impl<'module> MonoidalPrinter<'module> {
                             assert_eq!(label, label2);
                             frag.encat(self.compile_decoded_value(&pattern_scope, value, format));
                         } else {
-                            panic!("expected variant value");
+                            panic!("expected variant, found {value:?}");
                         }
                         return frag;
                     }
                     panic!("pattern match failure");
                 }
-                _ => panic!("expected branch value"),
+                _ => panic!("expected branch, found {value:?}"),
             },
             Format::Dynamic(_) => self.compile_value(scope, value),
             Format::Apply(_) => self.compile_value(scope, value),

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -214,7 +214,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
                 _ => panic!("expected variant, found {value:?}"),
             },
-            Format::UnionVariant(branches) | Format::NondetUnion(branches) => match value {
+            Format::UnionVariant(branches) | Format::UnionNondet(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index].1;
                     match value.as_ref() {
@@ -1024,7 +1024,7 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::FORMAT_COMPOUND,
             ),
-            Format::UnionVariant(_) | Format::NondetUnion(_) | Format::IsoUnion(_) => cond_paren(
+            Format::UnionVariant(_) | Format::UnionNondet(_) | Format::IsoUnion(_) => cond_paren(
                 Fragment::String("_ |...| _".into()),
                 prec,
                 Precedence::FORMAT_COMPOUND,

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -144,7 +144,7 @@ impl<'module> MonoidalPrinter<'module> {
                     let format = &branches[*n];
                     self.is_atomic_value(value, Some(format))
                 }
-                Some(Format::Union(branches)) => {
+                Some(Format::UnionVariant(branches)) => {
                     let format = &branches[*n].1;
                     self.is_atomic_value(value, Some(format))
                 }
@@ -214,7 +214,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
                 _ => panic!("expected variant, found {value:?}"),
             },
-            Format::Union(branches) | Format::NondetUnion(branches) => match value {
+            Format::UnionVariant(branches) | Format::NondetUnion(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index].1;
                     match value.as_ref() {
@@ -1024,7 +1024,7 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::FORMAT_COMPOUND,
             ),
-            Format::Union(_) | Format::NondetUnion(_) | Format::IsoUnion(_) => cond_paren(
+            Format::UnionVariant(_) | Format::NondetUnion(_) | Format::IsoUnion(_) => cond_paren(
                 Fragment::String("_ |...| _".into()),
                 prec,
                 Precedence::FORMAT_COMPOUND,


### PR DESCRIPTION
This value is semantically transparent and only exists to trace the path of execution that created it, however it may be necessary for display purposes, to ensure we know the correct format.