### PR TITLE
Introduce Label alias for Cow<'static, str> in lib

### DIFF
--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,13 +1,12 @@
 use doodle::byte_set::ByteSet;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
+use doodle::etc;
 
-use std::borrow::Cow;
-
-pub fn var<Name: Into<Cow<'static, str>>>(name: Name) -> Expr {
+pub fn var<Name: Into<etc::Label>>(name: Name) -> Expr {
     Expr::Var(name.into())
 }
 
-pub fn bind<Name: Into<Cow<'static, str>>>(name: Name) -> Pattern {
+pub fn bind<Name: Into<etc::Label>>(name: Name) -> Pattern {
     Pattern::Binding(name.into())
 }
 
@@ -15,7 +14,7 @@ pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
     Format::Tuple(formats.into_iter().collect())
 }
 
-pub fn alts<Label: Into<Cow<'static, str>>>(
+pub fn alts<Label: Into<etc::Label>>(
     fields: impl IntoIterator<Item = (Label, Format)>,
 ) -> Format {
     Format::UnionVariant(
@@ -29,7 +28,7 @@ pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
     Format::Union(branches.into_iter().collect())
 }
 
-pub fn record<Label: Into<Cow<'static, str>>>(
+pub fn record<Label: Into<etc::Label>>(
     fields: impl IntoIterator<Item = (Label, Format)>,
 ) -> Format {
     Format::Record(

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,12 +1,12 @@
 use doodle::byte_set::ByteSet;
-use doodle::etc;
+use doodle::etc::IntoLabel;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
 
-pub fn var<Name: Into<etc::Label>>(name: Name) -> Expr {
+pub fn var<Name: IntoLabel>(name: Name) -> Expr {
     Expr::Var(name.into())
 }
 
-pub fn bind<Name: Into<etc::Label>>(name: Name) -> Pattern {
+pub fn bind<Name: IntoLabel>(name: Name) -> Pattern {
     Pattern::Binding(name.into())
 }
 
@@ -14,7 +14,7 @@ pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
     Format::Tuple(formats.into_iter().collect())
 }
 
-pub fn alts<Label: Into<etc::Label>>(fields: impl IntoIterator<Item = (Label, Format)>) -> Format {
+pub fn alts<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
     Format::UnionVariant(
         (fields.into_iter())
             .map(|(label, format)| (label.into(), format))
@@ -26,8 +26,8 @@ pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
     Format::Union(branches.into_iter().collect())
 }
 
-pub fn record<Label: Into<etc::Label>>(
-    fields: impl IntoIterator<Item = (Label, Format)>,
+pub fn record<Name: IntoLabel>(
+    fields: impl IntoIterator<Item = (Name, Format)>,
 ) -> Format {
     Format::Record(
         (fields.into_iter())

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,6 +1,6 @@
 use doodle::byte_set::ByteSet;
-use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
 use doodle::etc;
+use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
 
 pub fn var<Name: Into<etc::Label>>(name: Name) -> Expr {
     Expr::Var(name.into())
@@ -14,9 +14,7 @@ pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
     Format::Tuple(formats.into_iter().collect())
 }
 
-pub fn alts<Label: Into<etc::Label>>(
-    fields: impl IntoIterator<Item = (Label, Format)>,
-) -> Format {
+pub fn alts<Label: Into<etc::Label>>(fields: impl IntoIterator<Item = (Label, Format)>) -> Format {
     Format::UnionVariant(
         (fields.into_iter())
             .map(|(label, format)| (label.into(), format))

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,5 +1,5 @@
 use doodle::byte_set::ByteSet;
-use doodle::etc::IntoLabel;
+use doodle::IntoLabel;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
 
 pub fn var<Name: IntoLabel>(name: Name) -> Expr {
@@ -26,9 +26,7 @@ pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
     Format::Union(branches.into_iter().collect())
 }
 
-pub fn record<Name: IntoLabel>(
-    fields: impl IntoIterator<Item = (Name, Format)>,
-) -> Format {
+pub fn record<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
     Format::Record(
         (fields.into_iter())
             .map(|(label, format)| (label.into(), format))

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -439,7 +439,7 @@ pub enum Decoder {
     WithRelativeOffset(Expr, Box<Decoder>),
     Map(Box<Decoder>, Expr),
     Compute(Expr),
-    Let(Cow<'static, str>, Expr, Box<Decoder>),
+    Let(etc::Label, Expr, Box<Decoder>),
     Match(Expr, Vec<(Pattern, Decoder)>),
     Dynamic(etc::Label, DynFormat, Box<Decoder>),
     Apply(etc::Label),
@@ -520,7 +520,7 @@ impl<'a> Compiler<'a> {
         // decoder
         compiler.queue_compile(format, Rc::new(Next::Empty));
         while let Some((f, next, n)) = compiler.compile_queue.pop() {
-            let d = Decoder::compile_next(&mut compiler, &f, next)?;
+            let d = Decoder::compile_next(&mut compiler, f, next)?;
             compiler.program.decoders[n] = d;
         }
         Ok(compiler.program)
@@ -621,7 +621,7 @@ impl<'a> Scope<'a> {
         self.entries.push(ScopeEntry::Value(v));
     }
 
-    fn push_decoder(&mut self, name: Cow<'static, str>, d: Decoder) {
+    fn push_decoder(&mut self, name: etc::Label, d: Decoder) {
         self.names.push(name);
         self.entries.push(ScopeEntry::Decoder(d));
     }
@@ -1197,7 +1197,7 @@ impl Decoder {
             }
             Decoder::Apply(name) => {
                 let d = scope.get_decoder_by_name(name);
-                d.parse(program, &scope, input)
+                d.parse(program, scope, input)
             }
         }
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,7 +1,8 @@
 use crate::byte_set::ByteSet;
 use crate::error::{ParseError, ParseResult};
+use crate::etc::{Label, IntoLabel};
 use crate::read::ReadCtxt;
-use crate::{etc, DynFormat, Expr, Format, FormatModule, MatchTree, Next, Pattern, ValueType};
+use crate::{DynFormat, Expr, Format, FormatModule, MatchTree, Next, Pattern, ValueType};
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -16,8 +17,8 @@ pub enum Value {
     U32(u32),
     Char(char),
     Tuple(Vec<Value>),
-    Record(Vec<(etc::Label, Value)>),
-    Variant(etc::Label, Box<Value>),
+    Record(Vec<(Label, Value)>),
+    Variant(Label, Box<Value>),
     Seq(Vec<Value>),
     Mapped(Box<Value>, Box<Value>),
     Branch(usize, Box<Value>),
@@ -26,8 +27,8 @@ pub enum Value {
 impl Value {
     pub const UNIT: Value = Value::Tuple(Vec::new());
 
-    pub fn record<Label: Into<etc::Label>>(
-        fields: impl IntoIterator<Item = (Label, Value)>,
+    pub fn record<Name: IntoLabel>(
+        fields: impl IntoIterator<Item = (Name, Value)>,
     ) -> Value {
         Value::Record(
             fields
@@ -37,7 +38,7 @@ impl Value {
         )
     }
 
-    pub fn variant(label: impl Into<etc::Label>, value: impl Into<Box<Value>>) -> Value {
+    pub fn variant(label: impl IntoLabel, value: impl Into<Box<Value>>) -> Value {
         Value::Variant(label.into(), value.into())
     }
 
@@ -417,16 +418,16 @@ impl Expr {
 /// Decoders with a fixed amount of lookahead
 #[derive(Clone, Debug)]
 pub enum Decoder {
-    Call(usize, Vec<(etc::Label, Expr)>),
+    Call(usize, Vec<(Label, Expr)>),
     Fail,
     EndOfInput,
     Align(usize),
     Byte(ByteSet),
-    Variant(etc::Label, Box<Decoder>),
+    Variant(Label, Box<Decoder>),
     Parallel(Vec<Decoder>),
     Branch(MatchTree, Vec<Decoder>),
     Tuple(Vec<Decoder>),
-    Record(Vec<(etc::Label, Decoder)>),
+    Record(Vec<(Label, Decoder)>),
     While(MatchTree, Box<Decoder>),
     Until(MatchTree, Box<Decoder>),
     RepeatCount(Expr, Box<Decoder>),
@@ -439,10 +440,10 @@ pub enum Decoder {
     WithRelativeOffset(Expr, Box<Decoder>),
     Map(Box<Decoder>, Expr),
     Compute(Expr),
-    Let(etc::Label, Expr, Box<Decoder>),
+    Let(Label, Expr, Box<Decoder>),
     Match(Expr, Vec<(Pattern, Decoder)>),
-    Dynamic(etc::Label, DynFormat, Box<Decoder>),
-    Apply(etc::Label),
+    Dynamic(Label, DynFormat, Box<Decoder>),
+    Apply(Label),
 }
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
@@ -460,8 +461,8 @@ pub enum TypeRef {
 
 pub enum TypeDef {
     //Equiv(TypeRef),
-    Union(Vec<(etc::Label, TypeRef)>),
-    Record(Vec<(etc::Label, TypeRef)>),
+    Union(Vec<(Label, TypeRef)>),
+    Record(Vec<(Label, TypeRef)>),
 }
 
 pub struct Program {
@@ -484,8 +485,8 @@ impl Program {
 pub struct Compiler<'a> {
     module: &'a FormatModule,
     program: Program,
-    record_map: HashMap<Vec<(etc::Label, TypeRef)>, usize>,
-    union_map: HashMap<Vec<(etc::Label, TypeRef)>, usize>,
+    record_map: HashMap<Vec<(Label, TypeRef)>, usize>,
+    union_map: HashMap<Vec<(Label, TypeRef)>, usize>,
     decoder_map: HashMap<(usize, Rc<Next<'a>>), usize>,
     compile_queue: Vec<(&'a Format, Rc<Next<'a>>, usize)>,
 }
@@ -548,18 +549,18 @@ pub enum ScopeEntry {
 
 pub struct Scope<'a> {
     parent: Option<&'a Scope<'a>>,
-    names: Vec<etc::Label>,
+    names: Vec<Label>,
     entries: Vec<ScopeEntry>,
 }
 
 pub struct ScopeIter<'a> {
     parent: Option<&'a Scope<'a>>,
-    name_iter: std::iter::Rev<std::slice::Iter<'a, etc::Label>>,
+    name_iter: std::iter::Rev<std::slice::Iter<'a, Label>>,
     entry_iter: std::iter::Rev<std::slice::Iter<'a, ScopeEntry>>,
 }
 
 impl<'a> Iterator for ScopeIter<'a> {
-    type Item = (&'a etc::Label, &'a ScopeEntry);
+    type Item = (&'a Label, &'a ScopeEntry);
 
     fn next(&mut self) -> Option<Self::Item> {
         match (self.name_iter.next(), self.entry_iter.next()) {
@@ -576,7 +577,7 @@ impl<'a> Iterator for ScopeIter<'a> {
 }
 
 impl<'a> IntoIterator for &'a Scope<'a> {
-    type Item = (&'a etc::Label, &'a ScopeEntry);
+    type Item = (&'a Label, &'a ScopeEntry);
 
     type IntoIter = ScopeIter<'a>;
 
@@ -612,16 +613,16 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&etc::Label, &ScopeEntry)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Label, &ScopeEntry)> {
         self.into_iter()
     }
 
-    pub fn push(&mut self, name: etc::Label, v: Value) {
+    pub fn push(&mut self, name: Label, v: Value) {
         self.names.push(name);
         self.entries.push(ScopeEntry::Value(v));
     }
 
-    fn push_decoder(&mut self, name: etc::Label, d: Decoder) {
+    fn push_decoder(&mut self, name: Label, d: Decoder) {
         self.names.push(name);
         self.entries.push(ScopeEntry::Decoder(d));
     }
@@ -1315,9 +1316,11 @@ fn inflate(codes: &[Value]) -> Vec<Value> {
 #[cfg(test)]
 #[allow(clippy::redundant_clone)]
 mod tests {
+    use crate::etc::IntoLabel;
+
     use super::*;
 
-    fn alts<Label: Into<etc::Label>>(fields: impl IntoIterator<Item = (Label, Format)>) -> Format {
+    fn alts<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
         Format::UnionVariant(
             (fields.into_iter())
                 .map(|(label, format)| (label.into(), format))
@@ -1325,8 +1328,8 @@ mod tests {
         )
     }
 
-    fn record<Label: Into<etc::Label>>(
-        fields: impl IntoIterator<Item = (Label, Format)>,
+    fn record<Name: IntoLabel>(
+        fields: impl IntoIterator<Item = (Name, Format)>,
     ) -> Format {
         Format::Record(
             (fields.into_iter())

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,8 +1,8 @@
 use crate::byte_set::ByteSet;
 use crate::error::{ParseError, ParseResult};
-use crate::etc::{Label, IntoLabel};
 use crate::read::ReadCtxt;
 use crate::{DynFormat, Expr, Format, FormatModule, MatchTree, Next, Pattern, ValueType};
+use crate::{IntoLabel, Label};
 use serde::Serialize;
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -27,9 +27,7 @@ pub enum Value {
 impl Value {
     pub const UNIT: Value = Value::Tuple(Vec::new());
 
-    pub fn record<Name: IntoLabel>(
-        fields: impl IntoIterator<Item = (Name, Value)>,
-    ) -> Value {
+    pub fn record<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Value)>) -> Value {
         Value::Record(
             fields
                 .into_iter()
@@ -1316,7 +1314,7 @@ fn inflate(codes: &[Value]) -> Vec<Value> {
 #[cfg(test)]
 #[allow(clippy::redundant_clone)]
 mod tests {
-    use crate::etc::IntoLabel;
+    use crate::IntoLabel;
 
     use super::*;
 
@@ -1328,9 +1326,7 @@ mod tests {
         )
     }
 
-    fn record<Name: IntoLabel>(
-        fields: impl IntoIterator<Item = (Name, Format)>,
-    ) -> Format {
+    fn record<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
         Format::Record(
             (fields.into_iter())
                 .map(|(label, format)| (label.into(), format))

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,14 @@
 use crate::byte_set::ByteSet;
 use crate::decoder::{Scope, ScopeEntry};
+use crate::etc::Label;
 use crate::read::ReadCtxt;
-
-use std::borrow::Cow;
 
 pub type ParseResult<T> = Result<T, ParseError>;
 
 #[derive(Debug)]
 pub enum ParseError {
     Fail {
-        bindings: Vec<(Cow<'static, str>, ScopeEntry)>,
+        bindings: Vec<(Label, ScopeEntry)>,
         buffer: Vec<u8>,
         offset: usize,
     },

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
 use crate::byte_set::ByteSet;
 use crate::decoder::{Scope, ScopeEntry};
-use crate::etc::Label;
 use crate::read::ReadCtxt;
+use crate::Label;
 
 pub type ParseResult<T> = Result<T, ParseError>;
 

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -1,0 +1,1 @@
+pub(crate) type Label = std::borrow::Cow<'static, str>;

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -1,1 +1,5 @@
 pub type Label = std::borrow::Cow<'static, str>;
+
+pub trait IntoLabel: Into<Label> {}
+
+impl<T> IntoLabel for T where T: Into<Label> {}

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -1,1 +1,1 @@
-pub(crate) type Label = std::borrow::Cow<'static, str>;
+pub type Label = std::borrow::Cow<'static, str>;

--- a/src/etc.rs
+++ b/src/etc.rs
@@ -1,5 +1,0 @@
-pub type Label = std::borrow::Cow<'static, str>;
-
-pub trait IntoLabel: Into<Label> {}
-
-impl<T> IntoLabel for T where T: Into<Label> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -709,10 +709,7 @@ impl Format {
         }
     }
 
-    fn union_depends_on_next(
-        branches: &[(etc::Label, Format)],
-        module: &FormatModule,
-    ) -> bool {
+    fn union_depends_on_next(branches: &[(etc::Label, Format)], module: &FormatModule) -> bool {
         let mut fs = Vec::with_capacity(branches.len());
         for (_label, f) in branches {
             if f.depends_on_next(module) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@ use std::collections::HashSet;
 use std::ops::Add;
 use std::rc::Rc;
 
-use etc::{Label, IntoLabel};
 use serde::Serialize;
 
 use crate::bounds::Bounds;
@@ -16,9 +15,15 @@ pub mod bounds;
 pub mod byte_set;
 pub mod decoder;
 pub mod error;
-pub mod etc;
+
 pub mod output;
 pub mod read;
+
+pub type Label = std::borrow::Cow<'static, str>;
+
+pub trait IntoLabel: Into<Label> {}
+
+impl<T> IntoLabel for T where T: Into<Label> {}
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 #[serde(tag = "tag", content = "data")]
@@ -589,9 +594,7 @@ pub enum Format {
 impl Format {
     pub const EMPTY: Format = Format::Tuple(Vec::new());
 
-    pub fn alts<Name: IntoLabel>(
-        fields: impl IntoIterator<Item = (Name, Format)>,
-    ) -> Format {
+    pub fn alts<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
         Format::UnionVariant(
             (fields.into_iter())
                 .map(|(label, format)| (label.into(), format))
@@ -599,9 +602,7 @@ impl Format {
         )
     }
 
-    pub fn record<Name: IntoLabel>(
-        fields: impl IntoIterator<Item = (Name, Format)>,
-    ) -> Format {
+    pub fn record<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
         Format::Record(
             (fields.into_iter())
                 .map(|(label, format)| (label.into(), format))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::new_without_default)]
 #![deny(rust_2018_idioms)]
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::ops::Add;
 use std::rc::Rc;
@@ -16,7 +15,7 @@ pub mod bounds;
 pub mod byte_set;
 pub mod decoder;
 pub mod error;
-mod etc;
+pub mod etc;
 pub mod output;
 pub mod read;
 
@@ -575,15 +574,15 @@ pub enum Format {
     /// Compute a value
     Compute(Expr),
     /// Let binding
-    Let(Cow<'static, str>, Expr, Box<Format>),
+    Let(etc::Label, Expr, Box<Format>),
     /// Pattern match on an expression
     Match(Expr, Vec<(Pattern, Format)>),
     /// Pattern match on an expression and return a variant
     MatchVariant(Expr, Vec<(Pattern, etc::Label, Format)>),
     /// Format generated dynamically
-    Dynamic(Cow<'static, str>, DynFormat, Box<Format>),
+    Dynamic(etc::Label, DynFormat, Box<Format>),
     /// Apply a dynamic format from a named variable in the scope
-    Apply(Cow<'static, str>),
+    Apply(etc::Label),
 }
 
 impl Format {
@@ -711,7 +710,7 @@ impl Format {
     }
 
     fn union_depends_on_next(
-        branches: &[(Cow<'static, str>, Format)],
+        branches: &[(etc::Label, Format)],
         module: &FormatModule,
     ) -> bool {
         let mut fs = Vec::with_capacity(branches.len());
@@ -1475,7 +1474,7 @@ impl MatchTree {
 
 pub struct TypeScope<'a> {
     parent: Option<&'a TypeScope<'a>>,
-    names: Vec<Cow<'static, str>>,
+    names: Vec<etc::Label>,
     types: Vec<ValueKind>,
 }
 
@@ -1507,7 +1506,7 @@ impl<'a> TypeScope<'a> {
         self.types.push(ValueKind::Value(t));
     }
 
-    fn push_format(&mut self, name: Cow<'static, str>, t: ValueType) {
+    fn push_format(&mut self, name: etc::Label, t: ValueType) {
         self.names.push(name);
         self.types.push(ValueKind::Format(t));
     }

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,7 +3,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::etc;
+use crate::etc::Label;
 
 pub mod flat;
 pub mod tree;
@@ -34,7 +34,7 @@ pub enum Fragment {
     Empty,
     Symbol(Symbol),
     Char(char),
-    String(etc::Label),
+    String(Label),
     DebugAtom(Rc<dyn fmt::Debug>),
     DisplayAtom(Rc<dyn fmt::Display>),
     Group(Box<Fragment>),

--- a/src/output.rs
+++ b/src/output.rs
@@ -3,7 +3,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::etc::Label;
+use crate::Label;
 
 pub mod flat;
 pub mod tree;

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,9 @@
 use std::{
-    borrow::{Borrow, Cow},
     fmt::{self, Write},
     rc::Rc,
 };
+
+use crate::etc;
 
 pub mod flat;
 pub mod tree;
@@ -33,7 +34,7 @@ pub enum Fragment {
     Empty,
     Symbol(Symbol),
     Char(char),
-    String(Cow<'static, str>),
+    String(etc::Label),
     DebugAtom(Rc<dyn fmt::Debug>),
     DisplayAtom(Rc<dyn fmt::Display>),
     Group(Box<Fragment>),
@@ -353,7 +354,7 @@ impl fmt::Display for Fragment {
             Fragment::Empty => Ok(()),
             Fragment::Char(c) => f.write_char(*c),
             Fragment::Symbol(symb) => symb.fmt(f),
-            Fragment::String(s) => f.write_str(s.borrow()),
+            Fragment::String(s) => f.write_str(s.as_ref()),
             Fragment::DebugAtom(atom) => fmt::Debug::fmt(&atom, f),
             Fragment::DisplayAtom(atom) => fmt::Display::fmt(&atom, f),
             Fragment::Group(frag) => frag.fmt(f),

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::decoder::{Scope, Value};
-use crate::etc;
+use crate::etc::Label;
 use crate::{Format, FormatModule};
 
 pub fn print_decoded_value(module: &FormatModule, value: &Value, format: &Format) {
@@ -108,7 +108,7 @@ fn is_show_format(name: &str) -> Option<&'static str> {
 
 fn check_covered(
     module: &FormatModule,
-    path: &mut Vec<etc::Label>,
+    path: &mut Vec<Label>,
     format: &Format,
 ) -> Result<(), String> {
     match format {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::decoder::{Scope, Value};
-use crate::etc::Label;
+use crate::Label;
 use crate::{Format, FormatModule};
 
 pub fn print_decoded_value(module: &FormatModule, value: &Value, format: &Format) {

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -1,7 +1,7 @@
-use std::borrow::Cow;
 use std::io;
 
 use crate::decoder::{Scope, Value};
+use crate::etc;
 use crate::{Format, FormatModule};
 
 pub fn print_decoded_value(module: &FormatModule, value: &Value, format: &Format) {
@@ -108,7 +108,7 @@ fn is_show_format(name: &str) -> Option<&'static str> {
 
 fn check_covered(
     module: &FormatModule,
-    path: &mut Vec<Cow<'static, str>>,
+    path: &mut Vec<etc::Label>,
     format: &Format,
 ) -> Result<(), String> {
     match format {
@@ -288,7 +288,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Map(_format, _expr) => Ok(()),
             Format::Compute(_expr) => Ok(()),
             Format::Let(name, expr, format) => {
-                let v = expr.eval_value(&scope);
+                let v = expr.eval_value(scope);
                 let mut let_scope = Scope::child(scope);
                 let_scope.push(name.clone(), v);
                 self.write_flat(&let_scope, value, format)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -326,7 +326,7 @@ impl<'module> MonoidalPrinter<'module> {
             }
             Format::Compute(_expr) => self.compile_value(scope, value),
             Format::Let(name, expr, format) => {
-                let v = expr.eval_value(&scope);
+                let v = expr.eval_value(scope);
                 let mut let_scope = Scope::child(scope);
                 let_scope.push(name.clone(), v);
                 self.compile_decoded_value(&let_scope, value, format)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{Scope, Value};
+use crate::etc;
 use crate::{DynFormat, Expr, Format, FormatModule};
 
 use super::{Fragment, FragmentBuilder, Symbol};
@@ -50,7 +51,7 @@ pub struct MonoidalPrinter<'module> {
     module: &'module FormatModule,
 }
 
-type Field<T> = (Cow<'static, str>, T);
+type Field<T> = (etc::Label, T);
 type FieldFormat = Field<Format>;
 type FieldValue = Field<Value>;
 
@@ -578,7 +579,7 @@ impl<'module> MonoidalPrinter<'module> {
     fn compile_table(
         &mut self,
         cols: &[usize],
-        header: &[Cow<'static, str>],
+        header: &[etc::Label],
         rows: &[Vec<String>],
     ) -> Fragment {
         let mut frags = FragmentBuilder::new();

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{Scope, Value};
-use crate::etc::Label;
+use crate::Label;
 use crate::{DynFormat, Expr, Format, FormatModule};
 
 use super::{Fragment, FragmentBuilder, Symbol};

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{Scope, Value};
-use crate::etc;
+use crate::etc::Label;
 use crate::{DynFormat, Expr, Format, FormatModule};
 
 use super::{Fragment, FragmentBuilder, Symbol};
@@ -51,7 +51,7 @@ pub struct MonoidalPrinter<'module> {
     module: &'module FormatModule,
 }
 
-type Field<T> = (etc::Label, T);
+type Field<T> = (Label, T);
 type FieldFormat = Field<Format>;
 type FieldValue = Field<Value>;
 
@@ -579,7 +579,7 @@ impl<'module> MonoidalPrinter<'module> {
     fn compile_table(
         &mut self,
         cols: &[usize],
-        header: &[etc::Label],
+        header: &[Label],
         rows: &[Vec<String>],
     ) -> Fragment {
         let mut frags = FragmentBuilder::new();


### PR DESCRIPTION
Many sites within `lib.rs` and modules that extend or rely on related API details currently have `Cow<'static, str>` as a stand-in for `String`. This PR simply aliases the majority of such instances that share the same semantic intent as `etc::Label`, where `Label` is a simple type-alias defined in a new `etc.rs` submodule of `lib.rs`.

This is more of a stylistic change than anything and can easily be skipped if there is there is no compelling reason to adopt this alias.