### PR TITLE
General improvements to Fragment type

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -111,7 +111,6 @@ impl Fragment {
     }
 
     /// Joins two fragments with appropriate whitespace:
-    ///   - If `self` is empty, returns `other` unconditionally
     ///   - If `other` fits on a single line with no trailing newline, joins with `' '`, with a newline at the very end
     ///   - Otherwise, joins with `'\n'`
     fn join_with_wsp(self, other: Self) -> Self {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1202,11 +1202,14 @@ enum BitwiseLevel {
 /// Intransitive partial relation over operator subclasses
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Relation {
+    /// `.<`
     Inferior,
-    /// .<
-    Congruent, // .=
-    Superior, // .>
-    Disjoint, // ><
+    /// `.=`
+    Congruent,
+    /// ``.>`
+    Superior,
+    /// ``><``
+    Disjoint,
 }
 
 trait IntransitiveOrd {


### PR DESCRIPTION
Adds methods to `output::Fragment`, with the expectation that they might soon be useful, even if not currently used anywhere.

Improves documentation of Fragment type.

Minor fix to comments on `tree::Relation` enum variants.