### PR TITLE
Take Decoders out of Scope and put them Value instead.

### DIFF
--- a/src/bin/doodle/main.rs
+++ b/src/bin/doodle/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
 
             match output {
                 FileOutput::Debug => println!("{value:?}"),
-                FileOutput::Json => serde_json::to_writer(std::io::stdout(), &value).unwrap(),
+                FileOutput::Json => unimplemented!(),
                 FileOutput::Tree => {
                     doodle::output::tree::print_decoded_value(&module, &value, &format)
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -623,7 +623,7 @@ struct MatchTreeLevel<'a> {
     branches: Vec<(ByteSet, HashSet<(usize, Rc<Next<'a>>)>)>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct MatchTree {
     accept: Option<usize>,
     branches: Vec<(ByteSet, MatchTree)>,

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -175,7 +175,7 @@ impl<'module> MonoidalPrinter<'module> {
                 None => self.is_atomic_value(value, None),
                 f => panic!("expected format suitable for branch: {f:?}"),
             },
-            Value::Format(_) => false,
+            Value::Format(_, _) => false,
         }
     }
 
@@ -380,7 +380,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
             }
             Value::Branch(_n, value) => self.compile_value(scope, value),
-            Value::Format(f) => self.compile_format(f, Default::default()),
+            Value::Format(f, _cell) => self.compile_format(f, Default::default()),
         }
     }
 


### PR DESCRIPTION
This simplifies Scope at the cost of complicating Value; we don't really want the cached Decoder object to interfere with comparing, hashing, debug printing, or JSON serialising Value!