### PR TITLE
Handle dynamic formats with Let bindings

### DIFF
--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -239,179 +239,179 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         "deflate.fixed_huffman",
         record([
             (
-                "format",
-                Format::Compute(Expr::Huffman(Box::new(fixed_code_lengths()), None)),
-            ),
-            (
                 "codes",
-                repeat_until_last(
-                    Expr::Lambda(
-                        "x".into(),
-                        Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".into(),
-                            )))),
-                            Box::new(Expr::U16(256)),
-                        )),
-                    ),
-                    record([
-                        ("code", Format::Apply("format".into())),
-                        (
-                            "extra",
-                            Format::MatchVariant(
-                                var("code"),
-                                vec![
-                                    (
-                                        Pattern::U16(257),
-                                        "some".into(),
-                                        length_record_fixed(3, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(258),
-                                        "some".into(),
-                                        length_record_fixed(4, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(259),
-                                        "some".into(),
-                                        length_record_fixed(5, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(260),
-                                        "some".into(),
-                                        length_record_fixed(6, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(261),
-                                        "some".into(),
-                                        length_record_fixed(7, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(262),
-                                        "some".into(),
-                                        length_record_fixed(8, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(263),
-                                        "some".into(),
-                                        length_record_fixed(9, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(264),
-                                        "some".into(),
-                                        length_record_fixed(10, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(265),
-                                        "some".into(),
-                                        length_record_fixed(11, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(266),
-                                        "some".into(),
-                                        length_record_fixed(13, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(267),
-                                        "some".into(),
-                                        length_record_fixed(15, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(268),
-                                        "some".into(),
-                                        length_record_fixed(17, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(269),
-                                        "some".into(),
-                                        length_record_fixed(19, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(270),
-                                        "some".into(),
-                                        length_record_fixed(23, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(271),
-                                        "some".into(),
-                                        length_record_fixed(27, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(272),
-                                        "some".into(),
-                                        length_record_fixed(31, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(273),
-                                        "some".into(),
-                                        length_record_fixed(35, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(274),
-                                        "some".into(),
-                                        length_record_fixed(43, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(275),
-                                        "some".into(),
-                                        length_record_fixed(51, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(276),
-                                        "some".into(),
-                                        length_record_fixed(59, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(277),
-                                        "some".into(),
-                                        length_record_fixed(67, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(278),
-                                        "some".into(),
-                                        length_record_fixed(83, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(279),
-                                        "some".into(),
-                                        length_record_fixed(99, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(280),
-                                        "some".into(),
-                                        length_record_fixed(115, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(281),
-                                        "some".into(),
-                                        length_record_fixed(131, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(282),
-                                        "some".into(),
-                                        length_record_fixed(163, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(283),
-                                        "some".into(),
-                                        length_record_fixed(195, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(284),
-                                        "some".into(),
-                                        length_record_fixed(227, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(285),
-                                        "some".into(),
-                                        length_record_fixed(258, base, 0),
-                                    ),
-                                    (Pattern::Wildcard, "none".into(), Format::EMPTY),
-                                ],
-                            ),
+                Format::Let(
+                    "format".into(),
+                    Expr::Huffman(Box::new(fixed_code_lengths()), None),
+                    Box::new(repeat_until_last(
+                        Expr::Lambda(
+                            "x".into(),
+                            Box::new(Expr::Eq(
+                                Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                    Box::new(var("x")),
+                                    "code".into(),
+                                )))),
+                                Box::new(Expr::U16(256)),
+                            )),
                         ),
-                    ]),
+                        record([
+                            ("code", Format::Apply("format".into())),
+                            (
+                                "extra",
+                                Format::MatchVariant(
+                                    var("code"),
+                                    vec![
+                                        (
+                                            Pattern::U16(257),
+                                            "some".into(),
+                                            length_record_fixed(3, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(258),
+                                            "some".into(),
+                                            length_record_fixed(4, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(259),
+                                            "some".into(),
+                                            length_record_fixed(5, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(260),
+                                            "some".into(),
+                                            length_record_fixed(6, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(261),
+                                            "some".into(),
+                                            length_record_fixed(7, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(262),
+                                            "some".into(),
+                                            length_record_fixed(8, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(263),
+                                            "some".into(),
+                                            length_record_fixed(9, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(264),
+                                            "some".into(),
+                                            length_record_fixed(10, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(265),
+                                            "some".into(),
+                                            length_record_fixed(11, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(266),
+                                            "some".into(),
+                                            length_record_fixed(13, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(267),
+                                            "some".into(),
+                                            length_record_fixed(15, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(268),
+                                            "some".into(),
+                                            length_record_fixed(17, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(269),
+                                            "some".into(),
+                                            length_record_fixed(19, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(270),
+                                            "some".into(),
+                                            length_record_fixed(23, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(271),
+                                            "some".into(),
+                                            length_record_fixed(27, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(272),
+                                            "some".into(),
+                                            length_record_fixed(31, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(273),
+                                            "some".into(),
+                                            length_record_fixed(35, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(274),
+                                            "some".into(),
+                                            length_record_fixed(43, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(275),
+                                            "some".into(),
+                                            length_record_fixed(51, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(276),
+                                            "some".into(),
+                                            length_record_fixed(59, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(277),
+                                            "some".into(),
+                                            length_record_fixed(67, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(278),
+                                            "some".into(),
+                                            length_record_fixed(83, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(279),
+                                            "some".into(),
+                                            length_record_fixed(99, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(280),
+                                            "some".into(),
+                                            length_record_fixed(115, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(281),
+                                            "some".into(),
+                                            length_record_fixed(131, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(282),
+                                            "some".into(),
+                                            length_record_fixed(163, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(283),
+                                            "some".into(),
+                                            length_record_fixed(195, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(284),
+                                            "some".into(),
+                                            length_record_fixed(227, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(285),
+                                            "some".into(),
+                                            length_record_fixed(258, base, 0),
+                                        ),
+                                        (Pattern::Wildcard, "none".into(), Format::EMPTY),
+                                    ],
+                                ),
+                            ),
+                        ]),
+                    )),
                 ),
             ),
             (
@@ -482,159 +482,159 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 repeat_count(add(var("hclen"), Expr::U8(4)), bits3.clone()),
             ),
             (
-                "code-length-alphabet-format",
-                Format::Compute(Expr::Huffman(
-                    Box::new(var("code-length-alphabet-code-lengths")),
-                    Some(Box::new(Expr::Seq(vec![
-                        Expr::U8(16),
-                        Expr::U8(17),
-                        Expr::U8(18),
-                        Expr::U8(0),
-                        Expr::U8(8),
-                        Expr::U8(7),
-                        Expr::U8(9),
-                        Expr::U8(6),
-                        Expr::U8(10),
-                        Expr::U8(5),
-                        Expr::U8(11),
-                        Expr::U8(4),
-                        Expr::U8(12),
-                        Expr::U8(3),
-                        Expr::U8(13),
-                        Expr::U8(2),
-                        Expr::U8(14),
-                        Expr::U8(1),
-                        Expr::U8(15),
-                    ]))),
-                )),
-            ),
-            (
                 "literal-length-distance-alphabet-code-lengths",
-                repeat_until_seq(
-                    Expr::Lambda(
-                        "y".into(),
-                        Box::new(Expr::Gte(
-                            Box::new(Expr::SeqLength(Box::new(Expr::FlatMapAccum(
-                                Box::new(Expr::Lambda(
-                                    "x".into(),
-                                    Box::new(Expr::Match(
-                                        Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
-                                            Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
-                                            "code".into(),
-                                        )))),
-                                        vec![
-                                            (
-                                                Pattern::U8(16),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(3),
-                                                        )),
-                                                        Box::new(Expr::Match(
-                                                            Box::new(Expr::TupleProj(
-                                                                Box::new(var("x")),
-                                                                0,
-                                                            )),
-                                                            vec![(
-                                                                Pattern::Variant(
-                                                                    "some".into(),
-                                                                    Box::new(Pattern::Binding(
-                                                                        "y".into(),
-                                                                    )),
-                                                                ),
-                                                                Expr::Var("y".into()),
-                                                            )],
-                                                        )),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::U8(17),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(3),
-                                                        )),
-                                                        Box::new(Expr::U8(0)),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::U8(18),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(11),
-                                                        )),
-                                                        Box::new(Expr::U8(0)),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::Binding("v".into()),
-                                                Expr::Tuple(vec![
-                                                    Expr::Variant(
-                                                        "some".into(),
-                                                        Box::new(var("v")),
-                                                    ),
-                                                    Expr::Seq(vec![var("v")]),
-                                                ]),
-                                            ),
-                                        ],
-                                    )),
-                                )),
-                                Box::new(Expr::Variant("none".into(), Box::new(Expr::UNIT))),
-                                ValueType::Union(vec![
-                                    ("none".into(), ValueType::Tuple(vec![])),
-                                    ("some".into(), ValueType::U8),
-                                ]),
-                                Box::new(var("y")),
-                            )))),
-                            Box::new(add(
-                                Expr::AsU32(Box::new(add(var("hlit"), var("hdist")))),
-                                Expr::U32(258),
-                            )),
-                        )),
+                Format::Let(
+                    "code-length-alphabet-format".into(),
+                    Expr::Huffman(
+                        Box::new(var("code-length-alphabet-code-lengths")),
+                        Some(Box::new(Expr::Seq(vec![
+                            Expr::U8(16),
+                            Expr::U8(17),
+                            Expr::U8(18),
+                            Expr::U8(0),
+                            Expr::U8(8),
+                            Expr::U8(7),
+                            Expr::U8(9),
+                            Expr::U8(6),
+                            Expr::U8(10),
+                            Expr::U8(5),
+                            Expr::U8(11),
+                            Expr::U8(4),
+                            Expr::U8(12),
+                            Expr::U8(3),
+                            Expr::U8(13),
+                            Expr::U8(2),
+                            Expr::U8(14),
+                            Expr::U8(1),
+                            Expr::U8(15),
+                        ]))),
                     ),
-                    record([
-                        ("code", Format::Apply("code-length-alphabet-format".into())),
-                        (
-                            "extra",
-                            Format::Match(
-                                Expr::AsU8(Box::new(var("code"))),
-                                vec![
-                                    (Pattern::U8(16), bits2.clone()),
-                                    (Pattern::U8(17), bits3.clone()),
-                                    (Pattern::U8(18), bits7.clone()),
-                                    (Pattern::Wildcard, Format::Compute(Expr::U8(0))),
-                                ],
-                            ),
+                    Box::new(repeat_until_seq(
+                        Expr::Lambda(
+                            "y".into(),
+                            Box::new(Expr::Gte(
+                                Box::new(Expr::SeqLength(Box::new(Expr::FlatMapAccum(
+                                    Box::new(Expr::Lambda(
+                                        "x".into(),
+                                        Box::new(Expr::Match(
+                                            Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
+                                                Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
+                                                "code".into(),
+                                            )))),
+                                            vec![
+                                                (
+                                                    Pattern::U8(16),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(3),
+                                                            )),
+                                                            Box::new(Expr::Match(
+                                                                Box::new(Expr::TupleProj(
+                                                                    Box::new(var("x")),
+                                                                    0,
+                                                                )),
+                                                                vec![(
+                                                                    Pattern::Variant(
+                                                                        "some".into(),
+                                                                        Box::new(Pattern::Binding(
+                                                                            "y".into(),
+                                                                        )),
+                                                                    ),
+                                                                    Expr::Var("y".into()),
+                                                                )],
+                                                            )),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::U8(17),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(3),
+                                                            )),
+                                                            Box::new(Expr::U8(0)),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::U8(18),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(11),
+                                                            )),
+                                                            Box::new(Expr::U8(0)),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::Binding("v".into()),
+                                                    Expr::Tuple(vec![
+                                                        Expr::Variant(
+                                                            "some".into(),
+                                                            Box::new(var("v")),
+                                                        ),
+                                                        Expr::Seq(vec![var("v")]),
+                                                    ]),
+                                                ),
+                                            ],
+                                        )),
+                                    )),
+                                    Box::new(Expr::Variant("none".into(), Box::new(Expr::UNIT))),
+                                    ValueType::Union(vec![
+                                        ("none".into(), ValueType::Tuple(vec![])),
+                                        ("some".into(), ValueType::U8),
+                                    ]),
+                                    Box::new(var("y")),
+                                )))),
+                                Box::new(add(
+                                    Expr::AsU32(Box::new(add(var("hlit"), var("hdist")))),
+                                    Expr::U32(258),
+                                )),
+                            )),
                         ),
-                    ]),
+                        record([
+                            ("code", Format::Apply("code-length-alphabet-format".into())),
+                            (
+                                "extra",
+                                Format::Match(
+                                    Expr::AsU8(Box::new(var("code"))),
+                                    vec![
+                                        (Pattern::U8(16), bits2.clone()),
+                                        (Pattern::U8(17), bits3.clone()),
+                                        (Pattern::U8(18), bits7.clone()),
+                                        (Pattern::Wildcard, Format::Compute(Expr::U8(0))),
+                                    ],
+                                ),
+                            ),
+                        ]),
+                    )),
                 ),
             ),
             (
@@ -749,100 +749,189 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 )),
             ),
             (
-                "distance-alphabet-format",
-                Format::Compute(Expr::Huffman(
-                    Box::new(var("distance-alphabet-code-lengths-value")),
-                    None,
-                )),
-            ),
-            (
-                "literal-length-alphabet-format",
-                Format::Compute(Expr::Huffman(
-                    Box::new(var("literal-length-alphabet-code-lengths-value")),
-                    None,
-                )),
-            ),
-            (
                 "codes",
-                repeat_until_last(
-                    Expr::Lambda(
-                        "x".into(),
-                        Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".into(),
-                            )))),
-                            Box::new(Expr::U16(256)),
-                        )),
-                    ),
-                    record([
-                        (
-                            "code",
-                            Format::Apply("literal-length-alphabet-format".into()),
+                Format::Let(
+                    "distance-alphabet-format".into(),
+                    Expr::Huffman(Box::new(var("distance-alphabet-code-lengths-value")), None),
+                    Box::new(Format::Let(
+                        "literal-length-alphabet-format".into(),
+                        Expr::Huffman(
+                            Box::new(var("literal-length-alphabet-code-lengths-value")),
+                            None,
                         ),
-                        (
-                            "extra",
-                            Format::MatchVariant(
-                                var("code"),
-                                vec![
-                                    (Pattern::U16(257), "some".into(), length_record(3, base, 0)),
-                                    (Pattern::U16(258), "some".into(), length_record(4, base, 0)),
-                                    (Pattern::U16(259), "some".into(), length_record(5, base, 0)),
-                                    (Pattern::U16(260), "some".into(), length_record(6, base, 0)),
-                                    (Pattern::U16(261), "some".into(), length_record(7, base, 0)),
-                                    (Pattern::U16(262), "some".into(), length_record(8, base, 0)),
-                                    (Pattern::U16(263), "some".into(), length_record(9, base, 0)),
-                                    (Pattern::U16(264), "some".into(), length_record(10, base, 0)),
-                                    (Pattern::U16(265), "some".into(), length_record(11, base, 1)),
-                                    (Pattern::U16(266), "some".into(), length_record(13, base, 1)),
-                                    (Pattern::U16(267), "some".into(), length_record(15, base, 1)),
-                                    (Pattern::U16(268), "some".into(), length_record(17, base, 1)),
-                                    (Pattern::U16(269), "some".into(), length_record(19, base, 2)),
-                                    (Pattern::U16(270), "some".into(), length_record(23, base, 2)),
-                                    (Pattern::U16(271), "some".into(), length_record(27, base, 2)),
-                                    (Pattern::U16(272), "some".into(), length_record(31, base, 2)),
-                                    (Pattern::U16(273), "some".into(), length_record(35, base, 3)),
-                                    (Pattern::U16(274), "some".into(), length_record(43, base, 3)),
-                                    (Pattern::U16(275), "some".into(), length_record(51, base, 3)),
-                                    (Pattern::U16(276), "some".into(), length_record(59, base, 3)),
-                                    (Pattern::U16(277), "some".into(), length_record(67, base, 4)),
-                                    (Pattern::U16(278), "some".into(), length_record(83, base, 4)),
-                                    (Pattern::U16(279), "some".into(), length_record(99, base, 4)),
-                                    (
-                                        Pattern::U16(280),
-                                        "some".into(),
-                                        length_record(115, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(281),
-                                        "some".into(),
-                                        length_record(131, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(282),
-                                        "some".into(),
-                                        length_record(163, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(283),
-                                        "some".into(),
-                                        length_record(195, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(284),
-                                        "some".into(),
-                                        length_record(227, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(285),
-                                        "some".into(),
-                                        length_record(258, base, 0),
-                                    ),
-                                    (Pattern::Wildcard, "none".into(), Format::EMPTY),
-                                ],
+                        Box::new(repeat_until_last(
+                            Expr::Lambda(
+                                "x".into(),
+                                Box::new(Expr::Eq(
+                                    Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                        Box::new(var("x")),
+                                        "code".into(),
+                                    )))),
+                                    Box::new(Expr::U16(256)),
+                                )),
                             ),
-                        ),
-                    ]),
+                            record([
+                                (
+                                    "code",
+                                    Format::Apply("literal-length-alphabet-format".into()),
+                                ),
+                                (
+                                    "extra",
+                                    Format::MatchVariant(
+                                        var("code"),
+                                        vec![
+                                            (
+                                                Pattern::U16(257),
+                                                "some".into(),
+                                                length_record(3, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(258),
+                                                "some".into(),
+                                                length_record(4, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(259),
+                                                "some".into(),
+                                                length_record(5, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(260),
+                                                "some".into(),
+                                                length_record(6, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(261),
+                                                "some".into(),
+                                                length_record(7, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(262),
+                                                "some".into(),
+                                                length_record(8, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(263),
+                                                "some".into(),
+                                                length_record(9, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(264),
+                                                "some".into(),
+                                                length_record(10, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(265),
+                                                "some".into(),
+                                                length_record(11, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(266),
+                                                "some".into(),
+                                                length_record(13, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(267),
+                                                "some".into(),
+                                                length_record(15, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(268),
+                                                "some".into(),
+                                                length_record(17, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(269),
+                                                "some".into(),
+                                                length_record(19, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(270),
+                                                "some".into(),
+                                                length_record(23, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(271),
+                                                "some".into(),
+                                                length_record(27, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(272),
+                                                "some".into(),
+                                                length_record(31, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(273),
+                                                "some".into(),
+                                                length_record(35, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(274),
+                                                "some".into(),
+                                                length_record(43, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(275),
+                                                "some".into(),
+                                                length_record(51, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(276),
+                                                "some".into(),
+                                                length_record(59, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(277),
+                                                "some".into(),
+                                                length_record(67, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(278),
+                                                "some".into(),
+                                                length_record(83, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(279),
+                                                "some".into(),
+                                                length_record(99, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(280),
+                                                "some".into(),
+                                                length_record(115, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(281),
+                                                "some".into(),
+                                                length_record(131, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(282),
+                                                "some".into(),
+                                                length_record(163, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(283),
+                                                "some".into(),
+                                                length_record(195, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(284),
+                                                "some".into(),
+                                                length_record(227, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(285),
+                                                "some".into(),
+                                                length_record(258, base, 0),
+                                            ),
+                                            (Pattern::Wildcard, "none".into(), Format::EMPTY),
+                                        ],
+                                    ),
+                                ),
+                            ]),
+                        )),
+                    )),
                 ),
             ),
             (

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -1,4 +1,4 @@
-use doodle::{DynFormat, Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
+use doodle::{Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
 
 use crate::format::base::*;
 
@@ -240,7 +240,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         record([
             (
                 "format",
-                Format::Dynamic(DynFormat::Huffman(fixed_code_lengths(), None)),
+                Format::Compute(Expr::Huffman(Box::new(fixed_code_lengths()), None)),
             ),
             (
                 "codes",
@@ -483,9 +483,9 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "code-length-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("code-length-alphabet-code-lengths"),
-                    Some(Expr::Seq(vec![
+                Format::Compute(Expr::Huffman(
+                    Box::new(var("code-length-alphabet-code-lengths")),
+                    Some(Box::new(Expr::Seq(vec![
                         Expr::U8(16),
                         Expr::U8(17),
                         Expr::U8(18),
@@ -505,7 +505,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         Expr::U8(14),
                         Expr::U8(1),
                         Expr::U8(15),
-                    ])),
+                    ]))),
                 )),
             ),
             (
@@ -750,15 +750,15 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "distance-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("distance-alphabet-code-lengths-value"),
+                Format::Compute(Expr::Huffman(
+                    Box::new(var("distance-alphabet-code-lengths-value")),
                     None,
                 )),
             ),
             (
                 "literal-length-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("literal-length-alphabet-code-lengths-value"),
+                Format::Compute(Expr::Huffman(
+                    Box::new(var("literal-length-alphabet-code-lengths-value")),
                     None,
                 )),
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,9 @@ impl FormatModule {
                 let mut record_scope = TypeScope::child(scope);
                 for (label, f) in fields {
                     let t = self.infer_format_type(&record_scope, f)?;
+                    if let ValueType::Format(_) = &t {
+                        return Err(format!("cannot put Format in Record"));
+                    }
                     ts.push((label.clone(), t.clone()));
                     record_scope.push(label.clone(), t);
                 }

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -174,6 +174,7 @@ fn check_covered(
         Format::WithRelativeOffset(_, _) => {} // FIXME
         Format::Map(format, _expr) => check_covered(module, path, format)?,
         Format::Compute(_expr) => {}
+        Format::Let(_name, _expr, format) => check_covered(module, path, format)?,
         Format::Match(_head, branches) => {
             for (_pattern, format) in branches {
                 check_covered(module, path, format)?;
@@ -286,6 +287,12 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::WithRelativeOffset(_, format) => self.write_flat(scope, value, format),
             Format::Map(_format, _expr) => Ok(()),
             Format::Compute(_expr) => Ok(()),
+            Format::Let(name, expr, format) => {
+                let v = expr.eval_value(&scope);
+                let mut let_scope = Scope::child(scope);
+                let_scope.push(name.clone(), v);
+                self.write_flat(&let_scope, value, format)
+            }
             Format::Match(head, branches) => match value {
                 Value::Branch(index, value) => {
                     let head = head.eval(scope);

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -185,8 +185,7 @@ fn check_covered(
                 check_covered(module, path, format)?;
             }
         }
-        Format::Dynamic(_) => {} // FIXME
-        Format::Apply(_) => {}   // FIXME
+        Format::Apply(_) => {} // FIXME
     }
     Ok(())
 }
@@ -322,8 +321,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected branch, found {value:?}"),
             },
-            Format::Dynamic(_) => Ok(()), // FIXME
-            Format::Apply(_) => Ok(()),   // FIXME
+            Format::Apply(_) => Ok(()), // FIXME
         }
     }
 }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -322,6 +322,12 @@ impl<'module> MonoidalPrinter<'module> {
                 }
             }
             Format::Compute(_expr) => self.compile_value(scope, value),
+            Format::Let(name, expr, format) => {
+                let v = expr.eval_value(&scope);
+                let mut let_scope = Scope::child(scope);
+                let_scope.push(name.clone(), v);
+                self.compile_decoded_value(&let_scope, value, format)
+            }
             Format::Match(head, branches) => match value {
                 Value::Branch(index, value) => {
                     let head = head.eval(&scope);
@@ -1164,6 +1170,19 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::FORMAT_COMPOUND,
             ),
+            Format::Let(name, expr, format) => {
+                let expr_frag = self.compile_expr(expr, Precedence::ATOM);
+                cond_paren(
+                    self.compile_nested_format(
+                        "let",
+                        Some(&[Fragment::String(name.clone()), expr_frag]),
+                        format,
+                        prec,
+                    ),
+                    prec,
+                    Precedence::FORMAT_COMPOUND,
+                )
+            }
             Format::Match(head, _) | Format::MatchVariant(head, _) => cond_paren(
                 Fragment::String("match ".into())
                     .cat(self.compile_expr(head, Precedence::PROJ))

--- a/tests/expected/decode/test1.gz.stdout
+++ b/tests/expected/decode/test1.gz.stdout
@@ -15,7 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
+│           │   │           ├── format <- compute huffman [..] := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 72

--- a/tests/expected/decode/test1.gz.stdout
+++ b/tests/expected/decode/test1.gz.stdout
@@ -15,8 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- compute huffman [..] := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- let format (huffman [..]) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 72
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test2.gz.stdout
+++ b/tests/expected/decode/test2.gz.stdout
@@ -15,7 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
+│           │   │           ├── format <- compute huffman [..] := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104

--- a/tests/expected/decode/test2.gz.stdout
+++ b/tests/expected/decode/test2.gz.stdout
@@ -15,8 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- compute huffman [..] := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- let format (huffman [..]) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test3.gz.stdout
+++ b/tests/expected/decode/test3.gz.stdout
@@ -15,8 +15,7 @@
 │       │   │   │       ├── final <- base.bit := 1
 │       │   │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │       │   │   │       └── data <- match type { ... } :=
-│       │   │   │           ├── format <- compute huffman [..] := _ |...| _
-│       │   │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│       │   │   │           ├── codes <- let format (huffman [..]) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │       │   │   │           │   ├── 0 :=
 │       │   │   │           │   │   ├── code <- apply := 72
 │       │   │   │           │   │   └── extra <- match code { ... } := ()
@@ -108,8 +107,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- compute huffman [..] := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- let format (huffman [..]) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test3.gz.stdout
+++ b/tests/expected/decode/test3.gz.stdout
@@ -15,7 +15,7 @@
 │       │   │   │       ├── final <- base.bit := 1
 │       │   │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │       │   │   │       └── data <- match type { ... } :=
-│       │   │   │           ├── format <- dynamic := _ |...| _
+│       │   │   │           ├── format <- compute huffman [..] := _ |...| _
 │       │   │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │       │   │   │           │   ├── 0 :=
 │       │   │   │           │   │   ├── code <- apply := 72
@@ -108,7 +108,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
+│           │   │           ├── format <- compute huffman [..] := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104

--- a/tests/expected/decode/test4.gz.stdout
+++ b/tests/expected/decode/test4.gz.stdout
@@ -31,8 +31,7 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 14 := 6
-│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- let code-length-alphabet-format (huffman ([..]) code-length-alphabet-code-lengths) (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 5
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -106,9 +105,7 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 28 := 8
-│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- let distance-alphabet-format (huffman distance-alphabet-code-lengths-value) (let literal-length-alphabet-format (huffman literal-length-alphabet-code-lengths-value) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 255
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -176,8 +173,7 @@
 │           │   │   │       │   ├── 9 := 6
 │           │   │   │       │   ~
 │           │   │   │       │   └── 18 := 6
-│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- let code-length-alphabet-format (huffman ([..]) code-length-alphabet-code-lengths) (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 6
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -251,9 +247,7 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 29 := 6
-│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- let distance-alphabet-format (huffman distance-alphabet-code-lengths-value) (let literal-length-alphabet-format (huffman literal-length-alphabet-code-lengths-value) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 207
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -321,8 +315,7 @@
 │           │   │           │   ├── 9 := 5
 │           │   │           │   ~
 │           │   │           │   └── 16 := 5
-│           │   │           ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
-│           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │           ├── literal-length-distance-alphabet-code-lengths <- let code-length-alphabet-format (huffman ([..]) code-length-alphabet-code-lengths) (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 7
 │           │   │           │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -396,9 +389,7 @@
 │           │   │           │   ├── 9 := 7
 │           │   │           │   ~
 │           │   │           │   └── 29 := 5
-│           │   │           ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- let distance-alphabet-format (huffman distance-alphabet-code-lengths-value) (let literal-length-alphabet-format (huffman literal-length-alphabet-code-lengths-value) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 252
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test4.gz.stdout
+++ b/tests/expected/decode/test4.gz.stdout
@@ -31,7 +31,7 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 14 := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 5
@@ -106,8 +106,8 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 28 := 8
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 255
@@ -176,7 +176,7 @@
 │           │   │   │       │   ├── 9 := 6
 │           │   │   │       │   ~
 │           │   │   │       │   └── 18 := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 6
@@ -251,8 +251,8 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 29 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 207
@@ -321,7 +321,7 @@
 │           │   │           │   ├── 9 := 5
 │           │   │           │   ~
 │           │   │           │   └── 16 := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
 │           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 7
@@ -396,8 +396,8 @@
 │           │   │           │   ├── 9 := 7
 │           │   │           │   ~
 │           │   │           │   └── 29 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
+│           │   │           ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 252

--- a/tests/expected/decode/test5.gz.stdout
+++ b/tests/expected/decode/test5.gz.stdout
@@ -31,8 +31,7 @@
 │           │   │   │       │   ├── 9 := 3
 │           │   │   │       │   ~
 │           │   │   │       │   └── 13 := 5
-│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- let code-length-alphabet-format (huffman ([..]) code-length-alphabet-code-lengths) (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 17
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 7
@@ -106,9 +105,7 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 27 := 6
-│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- let distance-alphabet-format (huffman distance-alphabet-code-lengths-value) (let literal-length-alphabet-format (huffman literal-length-alphabet-code-lengths-value) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 35
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -176,8 +173,7 @@
 │           │   │           │   ├── 9 := 3
 │           │   │           │   ~
 │           │   │           │   └── 13 := 5
-│           │   │           ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
-│           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │           ├── literal-length-distance-alphabet-code-lengths <- let code-length-alphabet-format (huffman ([..]) code-length-alphabet-code-lengths) (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 18
 │           │   │           │   │   └── extra <- match (as-u8 code) { ... } := 37
@@ -251,9 +247,7 @@
 │           │   │           │   ├── 9 := 0
 │           │   │           │   ~
 │           │   │           │   └── 28 := 5
-│           │   │           ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- let distance-alphabet-format (huffman distance-alphabet-code-lengths-value) (let literal-length-alphabet-format (huffman literal-length-alphabet-code-lengths-value) (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 50
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test5.gz.stdout
+++ b/tests/expected/decode/test5.gz.stdout
@@ -31,7 +31,7 @@
 │           │   │   │       │   ├── 9 := 3
 │           │   │   │       │   ~
 │           │   │   │       │   └── 13 := 5
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
 │           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 17
@@ -106,8 +106,8 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 27 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
+│           │   │   │       ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
+│           │   │   │       ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
 │           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 35
@@ -176,7 +176,7 @@
 │           │   │           │   ├── 9 := 3
 │           │   │           │   ~
 │           │   │           │   └── 13 := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── code-length-alphabet-format <- compute huffman ([..]) code-length-alphabet-code-lengths := _ |...| _
 │           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 18
@@ -251,8 +251,8 @@
 │           │   │           │   ├── 9 := 0
 │           │   │           │   ~
 │           │   │           │   └── 28 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
+│           │   │           ├── distance-alphabet-format <- compute huffman distance-alphabet-code-lengths-value := _ |...| _
+│           │   │           ├── literal-length-alphabet-format <- compute huffman literal-length-alphabet-code-lengths-value := _ |...| _
 │           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 50


### PR DESCRIPTION
The way this works is that there is a new `Format::Let(name, expr, format)` construct for let bindings which can only be used to bind format values and is the _only_ way to bind format values; dynamic formats cannot be record fields any more.

With these invariants in place, we can take decoders out of the scope and place them on a separate "dynstack" at runtime which only contains decoders created by format let bindings and thus can be directly indexed by integer offset.

Whether this is an improvement or not requires further consideration; it definitely simplifies scopes, but at the cost of introducing a new mutable scope-like thing. On the other hand, it doesn't need RefCell.

Edit: it's also unsound in the presence of pattern matching, which could pull a format out of a computed tuple field.