### PR TITLE
ScopeIter changes

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -540,13 +540,13 @@ pub struct Scope<'a> {
     decoders: Vec<RefCell<Option<Decoder>>>,
 }
 
-pub struct ScopeIter {
-    name_iter: std::vec::IntoIter<Cow<'static, str>>,
-    value_iter: std::vec::IntoIter<Value>,
+pub struct ScopeIter<'a> {
+    name_iter: std::slice::Iter<'a, Cow<'static, str>>,
+    value_iter: std::slice::Iter<'a, Value>,
 }
 
-impl Iterator for ScopeIter {
-    type Item = (Cow<'static, str>, Value);
+impl<'a> Iterator for ScopeIter<'a> {
+    type Item = (&'a Cow<'static, str>, &'a Value);
 
     fn next(&mut self) -> Option<Self::Item> {
         match (self.name_iter.next(), self.value_iter.next()) {
@@ -556,15 +556,15 @@ impl Iterator for ScopeIter {
     }
 }
 
-impl<'a> IntoIterator for &Scope<'a> {
-    type Item = (Cow<'static, str>, Value);
+impl<'a> IntoIterator for &'a Scope<'a> {
+    type Item = (&'a Cow<'static, str>, &'a Value);
 
-    type IntoIter = ScopeIter;
+    type IntoIter = ScopeIter<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
         ScopeIter {
-            name_iter: self.names.clone().into_iter(),
-            value_iter: self.values.clone().into_iter(),
+            name_iter: self.names.iter(),
+            value_iter: self.values.iter(),
         }
     }
 }
@@ -595,7 +595,7 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (Cow<'static, str>, Value)> {
+    pub fn iter(&'a self) -> impl Iterator<Item = (&'a Cow<'static, str>, &'a Value)> {
         (&self).into_iter()
     }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -603,7 +603,7 @@ impl<'a> Scope<'a> {
         }
     }
 
-    pub fn iter(&'a self) -> impl Iterator<Item = (&'a Cow<'static, str>, &'a Value)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Cow<'static, str>, &Value)> {
         (&self).into_iter()
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,7 +89,10 @@ impl std::error::Error for ParseError {}
 
 impl ParseError {
     pub fn fail(scope: &Scope<'_>, input: ReadCtxt<'_>) -> Self {
-        let bindings = scope.iter().collect::<Vec<_>>();
+        let bindings = scope
+            .iter()
+            .map(|(name, value)| (name.clone(), value.clone()))
+            .collect::<Vec<_>>();
         let buffer = input.input.to_owned();
         let offset = input.offset;
         Self::Fail {


### PR DESCRIPTION
This changes ScopeIter so it doesn't clone the scope it iterates over and also reverses the direction of iteration and recurses into parent scopes, so innermost bindings will be returned first.