### PR TITLE
Refactoring, documentation, and clippy-informed cleanup

### DIFF
--- a/src/bin/doodle/format/gif.rs
+++ b/src/bin/doodle/format/gif.rs
@@ -78,7 +78,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     );
 
     // 19. Global Color Table
-    let global_color_table = color_table.clone();
+    let global_color_table = color_table;
 
     // 20. Image Descriptor
     let image_descriptor = module.define_format(
@@ -100,7 +100,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     );
 
     // 21. Local Color Table
-    let local_color_table = color_table.clone();
+    let local_color_table = color_table;
 
     // 22. Table Based Image Data
     let table_based_image_data = module.define_format(

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -157,10 +157,10 @@ impl From<RangeInclusive<u8>> for ByteSet {
         // because the values are adjacent, we can optimize if they are within the same quadrant
         let lo = value.start();
         let hi = value.end();
-        if hi < lo {
-            return ByteSet::empty();
-        } else if hi == lo {
-            return ByteSet::from([*lo]);
+        match lo.cmp(hi) {
+            std::cmp::Ordering::Less => (),
+            std::cmp::Ordering::Equal => return ByteSet::from([*lo]),
+            std::cmp::Ordering::Greater => return ByteSet::empty(),
         }
         let start_ix = *lo >> 6;
         let end_ix = *hi >> 6;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -374,11 +374,15 @@ impl Expr {
             },
             Expr::U32Be(bytes) => match bytes.infer_type(scope)?.unwrap_tuple_type().as_slice() {
                 [ValueType::U8, ValueType::U8, ValueType::U8, ValueType::U8] => Ok(ValueType::U32),
-                other => Err(format!("U32Be: expected (U8, U8, U8, U8), found {other:#?}")),
+                other => Err(format!(
+                    "U32Be: expected (U8, U8, U8, U8), found {other:#?}"
+                )),
             },
             Expr::U32Le(bytes) => match bytes.infer_type(scope)?.unwrap_tuple_type().as_slice() {
                 [ValueType::U8, ValueType::U8, ValueType::U8, ValueType::U8] => Ok(ValueType::U32),
-                other => Err(format!("U32Le: expected (U8, U8, U8, U8), found {other:#?}")),
+                other => Err(format!(
+                    "U32Le: expected (U8, U8, U8, U8), found {other:#?}"
+                )),
             },
             Expr::SeqLength(seq) => match seq.infer_type(scope)? {
                 ValueType::Seq(_t) => Ok(ValueType::U32),
@@ -389,10 +393,14 @@ impl Expr {
                     let start_type = start.infer_type(scope)?;
                     let length_type = length.infer_type(scope)?;
                     if !start_type.is_numeric_type() {
-                        return Err(format!("SubSeq start must be numeric, found {start_type:?}"));
+                        return Err(format!(
+                            "SubSeq start must be numeric, found {start_type:?}"
+                        ));
                     }
                     if !length_type.is_numeric_type() {
-                        return Err(format!("SubSeq length must be numeric, found {length_type:?}"));
+                        return Err(format!(
+                            "SubSeq length must be numeric, found {length_type:?}"
+                        ));
                     }
                     Ok(ValueType::Seq(t))
                 }
@@ -462,7 +470,6 @@ impl Expr {
         }
     }
 }
-
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub enum DynFormat {
@@ -568,7 +575,6 @@ pub enum Format {
     /// Apply a dynamic format from a named variable in the scope
     Apply(Cow<'static, str>),
 }
-
 
 impl Format {
     pub const EMPTY: Format = Format::Tuple(Vec::new());
@@ -753,7 +759,6 @@ impl Format {
         }
     }
 }
-
 
 #[derive(Copy, Clone)]
 pub struct FormatRef(usize);
@@ -943,7 +948,9 @@ impl FormatModule {
                 match lengths_expr.infer_type(scope)? {
                     ValueType::Seq(t) => match &*t {
                         ValueType::U8 | ValueType::U16 => {}
-                        other => return Err(format!("Huffman: expected U8 or U16, found {other:?}")),
+                        other => {
+                            return Err(format!("Huffman: expected U8 or U16, found {other:?}"))
+                        }
                     },
                     other => return Err(format!("Huffman: expected Seq, found {other:?}")),
                 }
@@ -1003,7 +1010,6 @@ struct MatchTreeLevel<'a> {
 }
 
 type LevelBranch<'a> = HashSet<(usize, Rc<Next<'a>>)>;
-
 
 /// A byte-level prefix-tree evaluated to a fixed depth.
 ///

--- a/src/output.rs
+++ b/src/output.rs
@@ -140,7 +140,7 @@ impl Fragment {
                 match sep {
                     None => (),
                     Some(join) => {
-                        if items.len() >= 1 && !join.fits_inline() {
+                        if !items.is_empty() && !join.fits_inline() {
                             return false;
                         }
                     }
@@ -277,7 +277,7 @@ impl Fragment {
                 match sep {
                     None => (),
                     Some(join) => {
-                        if items.len() >= 1 && !join.is_single_line(false) {
+                        if !items.is_empty() && !join.is_single_line(false) {
                             return false;
                         }
                     }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -387,10 +387,7 @@ impl<'module> MonoidalPrinter<'module> {
         }
     }
 
-    fn extract_string_field<'a>(
-        &self,
-        fields: &'a [FieldValue],
-    ) -> Option<&'a Value> {
+    fn extract_string_field<'a>(&self, fields: &'a [FieldValue]) -> Option<&'a Value> {
         fields
             .iter()
             .find_map(|(label, value)| (label == "string").then_some(value))
@@ -690,7 +687,10 @@ impl<'module> MonoidalPrinter<'module> {
     }
 
     fn is_indirect_format(&self, format: &Format) -> bool {
-        matches!(format, Format::ItemVar(..) | Format::Dynamic(..) | Format::Apply(..))
+        matches!(
+            format,
+            Format::ItemVar(..) | Format::Dynamic(..) | Format::Apply(..)
+        )
     }
 
     fn compile_field_value_continue(


### PR DESCRIPTION
Initial attempt at documenting undocumented items in the `MatchTree*` family, along with some minor reordering of items and blocks in `lib.rs`.

Also includes a number of disparate changes based on `clippy` suggestions. 