### PR TITLE
Let bindings, separate kinds for values and formats

### DIFF
--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -239,179 +239,179 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         "deflate.fixed_huffman",
         record([
             (
-                "format",
-                Format::Dynamic(DynFormat::Huffman(fixed_code_lengths(), None)),
-            ),
-            (
                 "codes",
-                repeat_until_last(
-                    Expr::Lambda(
-                        "x".into(),
-                        Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".into(),
-                            )))),
-                            Box::new(Expr::U16(256)),
-                        )),
-                    ),
-                    record([
-                        ("code", Format::Apply("format".into())),
-                        (
-                            "extra",
-                            Format::MatchVariant(
-                                var("code"),
-                                vec![
-                                    (
-                                        Pattern::U16(257),
-                                        "some".into(),
-                                        length_record_fixed(3, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(258),
-                                        "some".into(),
-                                        length_record_fixed(4, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(259),
-                                        "some".into(),
-                                        length_record_fixed(5, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(260),
-                                        "some".into(),
-                                        length_record_fixed(6, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(261),
-                                        "some".into(),
-                                        length_record_fixed(7, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(262),
-                                        "some".into(),
-                                        length_record_fixed(8, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(263),
-                                        "some".into(),
-                                        length_record_fixed(9, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(264),
-                                        "some".into(),
-                                        length_record_fixed(10, base, 0),
-                                    ),
-                                    (
-                                        Pattern::U16(265),
-                                        "some".into(),
-                                        length_record_fixed(11, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(266),
-                                        "some".into(),
-                                        length_record_fixed(13, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(267),
-                                        "some".into(),
-                                        length_record_fixed(15, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(268),
-                                        "some".into(),
-                                        length_record_fixed(17, base, 1),
-                                    ),
-                                    (
-                                        Pattern::U16(269),
-                                        "some".into(),
-                                        length_record_fixed(19, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(270),
-                                        "some".into(),
-                                        length_record_fixed(23, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(271),
-                                        "some".into(),
-                                        length_record_fixed(27, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(272),
-                                        "some".into(),
-                                        length_record_fixed(31, base, 2),
-                                    ),
-                                    (
-                                        Pattern::U16(273),
-                                        "some".into(),
-                                        length_record_fixed(35, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(274),
-                                        "some".into(),
-                                        length_record_fixed(43, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(275),
-                                        "some".into(),
-                                        length_record_fixed(51, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(276),
-                                        "some".into(),
-                                        length_record_fixed(59, base, 3),
-                                    ),
-                                    (
-                                        Pattern::U16(277),
-                                        "some".into(),
-                                        length_record_fixed(67, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(278),
-                                        "some".into(),
-                                        length_record_fixed(83, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(279),
-                                        "some".into(),
-                                        length_record_fixed(99, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(280),
-                                        "some".into(),
-                                        length_record_fixed(115, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(281),
-                                        "some".into(),
-                                        length_record_fixed(131, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(282),
-                                        "some".into(),
-                                        length_record_fixed(163, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(283),
-                                        "some".into(),
-                                        length_record_fixed(195, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(284),
-                                        "some".into(),
-                                        length_record_fixed(227, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(285),
-                                        "some".into(),
-                                        length_record_fixed(258, base, 0),
-                                    ),
-                                    (Pattern::Wildcard, "none".into(), Format::EMPTY),
-                                ],
-                            ),
+                Format::Dynamic(
+                    "format".into(),
+                    DynFormat::Huffman(fixed_code_lengths(), None),
+                    Box::new(repeat_until_last(
+                        Expr::Lambda(
+                            "x".into(),
+                            Box::new(Expr::Eq(
+                                Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                    Box::new(var("x")),
+                                    "code".into(),
+                                )))),
+                                Box::new(Expr::U16(256)),
+                            )),
                         ),
-                    ]),
+                        record([
+                            ("code", Format::Apply("format".into())),
+                            (
+                                "extra",
+                                Format::MatchVariant(
+                                    var("code"),
+                                    vec![
+                                        (
+                                            Pattern::U16(257),
+                                            "some".into(),
+                                            length_record_fixed(3, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(258),
+                                            "some".into(),
+                                            length_record_fixed(4, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(259),
+                                            "some".into(),
+                                            length_record_fixed(5, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(260),
+                                            "some".into(),
+                                            length_record_fixed(6, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(261),
+                                            "some".into(),
+                                            length_record_fixed(7, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(262),
+                                            "some".into(),
+                                            length_record_fixed(8, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(263),
+                                            "some".into(),
+                                            length_record_fixed(9, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(264),
+                                            "some".into(),
+                                            length_record_fixed(10, base, 0),
+                                        ),
+                                        (
+                                            Pattern::U16(265),
+                                            "some".into(),
+                                            length_record_fixed(11, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(266),
+                                            "some".into(),
+                                            length_record_fixed(13, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(267),
+                                            "some".into(),
+                                            length_record_fixed(15, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(268),
+                                            "some".into(),
+                                            length_record_fixed(17, base, 1),
+                                        ),
+                                        (
+                                            Pattern::U16(269),
+                                            "some".into(),
+                                            length_record_fixed(19, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(270),
+                                            "some".into(),
+                                            length_record_fixed(23, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(271),
+                                            "some".into(),
+                                            length_record_fixed(27, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(272),
+                                            "some".into(),
+                                            length_record_fixed(31, base, 2),
+                                        ),
+                                        (
+                                            Pattern::U16(273),
+                                            "some".into(),
+                                            length_record_fixed(35, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(274),
+                                            "some".into(),
+                                            length_record_fixed(43, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(275),
+                                            "some".into(),
+                                            length_record_fixed(51, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(276),
+                                            "some".into(),
+                                            length_record_fixed(59, base, 3),
+                                        ),
+                                        (
+                                            Pattern::U16(277),
+                                            "some".into(),
+                                            length_record_fixed(67, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(278),
+                                            "some".into(),
+                                            length_record_fixed(83, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(279),
+                                            "some".into(),
+                                            length_record_fixed(99, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(280),
+                                            "some".into(),
+                                            length_record_fixed(115, base, 4),
+                                        ),
+                                        (
+                                            Pattern::U16(281),
+                                            "some".into(),
+                                            length_record_fixed(131, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(282),
+                                            "some".into(),
+                                            length_record_fixed(163, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(283),
+                                            "some".into(),
+                                            length_record_fixed(195, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(284),
+                                            "some".into(),
+                                            length_record_fixed(227, base, 5),
+                                        ),
+                                        (
+                                            Pattern::U16(285),
+                                            "some".into(),
+                                            length_record_fixed(258, base, 0),
+                                        ),
+                                        (Pattern::Wildcard, "none".into(), Format::EMPTY),
+                                    ],
+                                ),
+                            ),
+                        ]),
+                    )),
                 ),
             ),
             (
@@ -482,159 +482,159 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 repeat_count(add(var("hclen"), Expr::U8(4)), bits3.clone()),
             ),
             (
-                "code-length-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("code-length-alphabet-code-lengths"),
-                    Some(Expr::Seq(vec![
-                        Expr::U8(16),
-                        Expr::U8(17),
-                        Expr::U8(18),
-                        Expr::U8(0),
-                        Expr::U8(8),
-                        Expr::U8(7),
-                        Expr::U8(9),
-                        Expr::U8(6),
-                        Expr::U8(10),
-                        Expr::U8(5),
-                        Expr::U8(11),
-                        Expr::U8(4),
-                        Expr::U8(12),
-                        Expr::U8(3),
-                        Expr::U8(13),
-                        Expr::U8(2),
-                        Expr::U8(14),
-                        Expr::U8(1),
-                        Expr::U8(15),
-                    ])),
-                )),
-            ),
-            (
                 "literal-length-distance-alphabet-code-lengths",
-                repeat_until_seq(
-                    Expr::Lambda(
-                        "y".into(),
-                        Box::new(Expr::Gte(
-                            Box::new(Expr::SeqLength(Box::new(Expr::FlatMapAccum(
-                                Box::new(Expr::Lambda(
-                                    "x".into(),
-                                    Box::new(Expr::Match(
-                                        Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
-                                            Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
-                                            "code".into(),
-                                        )))),
-                                        vec![
-                                            (
-                                                Pattern::U8(16),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(3),
-                                                        )),
-                                                        Box::new(Expr::Match(
-                                                            Box::new(Expr::TupleProj(
-                                                                Box::new(var("x")),
-                                                                0,
-                                                            )),
-                                                            vec![(
-                                                                Pattern::Variant(
-                                                                    "some".into(),
-                                                                    Box::new(Pattern::Binding(
-                                                                        "y".into(),
-                                                                    )),
-                                                                ),
-                                                                Expr::Var("y".into()),
-                                                            )],
-                                                        )),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::U8(17),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(3),
-                                                        )),
-                                                        Box::new(Expr::U8(0)),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::U8(18),
-                                                Expr::Tuple(vec![
-                                                    Expr::TupleProj(Box::new(var("x")), 0),
-                                                    Expr::Dup(
-                                                        Box::new(add(
-                                                            Expr::RecordProj(
-                                                                Box::new(Expr::TupleProj(
-                                                                    Box::new(var("x")),
-                                                                    1,
-                                                                )),
-                                                                "extra".into(),
-                                                            ),
-                                                            Expr::U8(11),
-                                                        )),
-                                                        Box::new(Expr::U8(0)),
-                                                    ),
-                                                ]),
-                                            ),
-                                            (
-                                                Pattern::Binding("v".into()),
-                                                Expr::Tuple(vec![
-                                                    Expr::Variant(
-                                                        "some".into(),
-                                                        Box::new(var("v")),
-                                                    ),
-                                                    Expr::Seq(vec![var("v")]),
-                                                ]),
-                                            ),
-                                        ],
-                                    )),
-                                )),
-                                Box::new(Expr::Variant("none".into(), Box::new(Expr::UNIT))),
-                                ValueType::Union(vec![
-                                    ("none".into(), ValueType::Tuple(vec![])),
-                                    ("some".into(), ValueType::U8),
-                                ]),
-                                Box::new(var("y")),
-                            )))),
-                            Box::new(add(
-                                Expr::AsU32(Box::new(add(var("hlit"), var("hdist")))),
-                                Expr::U32(258),
-                            )),
-                        )),
+                Format::Dynamic(
+                    "code-length-alphabet-format".into(),
+                    DynFormat::Huffman(
+                        var("code-length-alphabet-code-lengths"),
+                        Some(Expr::Seq(vec![
+                            Expr::U8(16),
+                            Expr::U8(17),
+                            Expr::U8(18),
+                            Expr::U8(0),
+                            Expr::U8(8),
+                            Expr::U8(7),
+                            Expr::U8(9),
+                            Expr::U8(6),
+                            Expr::U8(10),
+                            Expr::U8(5),
+                            Expr::U8(11),
+                            Expr::U8(4),
+                            Expr::U8(12),
+                            Expr::U8(3),
+                            Expr::U8(13),
+                            Expr::U8(2),
+                            Expr::U8(14),
+                            Expr::U8(1),
+                            Expr::U8(15),
+                        ])),
                     ),
-                    record([
-                        ("code", Format::Apply("code-length-alphabet-format".into())),
-                        (
-                            "extra",
-                            Format::Match(
-                                Expr::AsU8(Box::new(var("code"))),
-                                vec![
-                                    (Pattern::U8(16), bits2.clone()),
-                                    (Pattern::U8(17), bits3.clone()),
-                                    (Pattern::U8(18), bits7.clone()),
-                                    (Pattern::Wildcard, Format::Compute(Expr::U8(0))),
-                                ],
-                            ),
+                    Box::new(repeat_until_seq(
+                        Expr::Lambda(
+                            "y".into(),
+                            Box::new(Expr::Gte(
+                                Box::new(Expr::SeqLength(Box::new(Expr::FlatMapAccum(
+                                    Box::new(Expr::Lambda(
+                                        "x".into(),
+                                        Box::new(Expr::Match(
+                                            Box::new(Expr::AsU8(Box::new(Expr::RecordProj(
+                                                Box::new(Expr::TupleProj(Box::new(var("x")), 1)),
+                                                "code".into(),
+                                            )))),
+                                            vec![
+                                                (
+                                                    Pattern::U8(16),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(3),
+                                                            )),
+                                                            Box::new(Expr::Match(
+                                                                Box::new(Expr::TupleProj(
+                                                                    Box::new(var("x")),
+                                                                    0,
+                                                                )),
+                                                                vec![(
+                                                                    Pattern::Variant(
+                                                                        "some".into(),
+                                                                        Box::new(Pattern::Binding(
+                                                                            "y".into(),
+                                                                        )),
+                                                                    ),
+                                                                    Expr::Var("y".into()),
+                                                                )],
+                                                            )),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::U8(17),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(3),
+                                                            )),
+                                                            Box::new(Expr::U8(0)),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::U8(18),
+                                                    Expr::Tuple(vec![
+                                                        Expr::TupleProj(Box::new(var("x")), 0),
+                                                        Expr::Dup(
+                                                            Box::new(add(
+                                                                Expr::RecordProj(
+                                                                    Box::new(Expr::TupleProj(
+                                                                        Box::new(var("x")),
+                                                                        1,
+                                                                    )),
+                                                                    "extra".into(),
+                                                                ),
+                                                                Expr::U8(11),
+                                                            )),
+                                                            Box::new(Expr::U8(0)),
+                                                        ),
+                                                    ]),
+                                                ),
+                                                (
+                                                    Pattern::Binding("v".into()),
+                                                    Expr::Tuple(vec![
+                                                        Expr::Variant(
+                                                            "some".into(),
+                                                            Box::new(var("v")),
+                                                        ),
+                                                        Expr::Seq(vec![var("v")]),
+                                                    ]),
+                                                ),
+                                            ],
+                                        )),
+                                    )),
+                                    Box::new(Expr::Variant("none".into(), Box::new(Expr::UNIT))),
+                                    ValueType::Union(vec![
+                                        ("none".into(), ValueType::Tuple(vec![])),
+                                        ("some".into(), ValueType::U8),
+                                    ]),
+                                    Box::new(var("y")),
+                                )))),
+                                Box::new(add(
+                                    Expr::AsU32(Box::new(add(var("hlit"), var("hdist")))),
+                                    Expr::U32(258),
+                                )),
+                            )),
                         ),
-                    ]),
+                        record([
+                            ("code", Format::Apply("code-length-alphabet-format".into())),
+                            (
+                                "extra",
+                                Format::Match(
+                                    Expr::AsU8(Box::new(var("code"))),
+                                    vec![
+                                        (Pattern::U8(16), bits2.clone()),
+                                        (Pattern::U8(17), bits3.clone()),
+                                        (Pattern::U8(18), bits7.clone()),
+                                        (Pattern::Wildcard, Format::Compute(Expr::U8(0))),
+                                    ],
+                                ),
+                            ),
+                        ]),
+                    )),
                 ),
             ),
             (
@@ -749,100 +749,186 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 )),
             ),
             (
-                "distance-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("distance-alphabet-code-lengths-value"),
-                    None,
-                )),
-            ),
-            (
-                "literal-length-alphabet-format",
-                Format::Dynamic(DynFormat::Huffman(
-                    var("literal-length-alphabet-code-lengths-value"),
-                    None,
-                )),
-            ),
-            (
                 "codes",
-                repeat_until_last(
-                    Expr::Lambda(
-                        "x".into(),
-                        Box::new(Expr::Eq(
-                            Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
-                                Box::new(var("x")),
-                                "code".into(),
-                            )))),
-                            Box::new(Expr::U16(256)),
-                        )),
-                    ),
-                    record([
-                        (
-                            "code",
-                            Format::Apply("literal-length-alphabet-format".into()),
-                        ),
-                        (
-                            "extra",
-                            Format::MatchVariant(
-                                var("code"),
-                                vec![
-                                    (Pattern::U16(257), "some".into(), length_record(3, base, 0)),
-                                    (Pattern::U16(258), "some".into(), length_record(4, base, 0)),
-                                    (Pattern::U16(259), "some".into(), length_record(5, base, 0)),
-                                    (Pattern::U16(260), "some".into(), length_record(6, base, 0)),
-                                    (Pattern::U16(261), "some".into(), length_record(7, base, 0)),
-                                    (Pattern::U16(262), "some".into(), length_record(8, base, 0)),
-                                    (Pattern::U16(263), "some".into(), length_record(9, base, 0)),
-                                    (Pattern::U16(264), "some".into(), length_record(10, base, 0)),
-                                    (Pattern::U16(265), "some".into(), length_record(11, base, 1)),
-                                    (Pattern::U16(266), "some".into(), length_record(13, base, 1)),
-                                    (Pattern::U16(267), "some".into(), length_record(15, base, 1)),
-                                    (Pattern::U16(268), "some".into(), length_record(17, base, 1)),
-                                    (Pattern::U16(269), "some".into(), length_record(19, base, 2)),
-                                    (Pattern::U16(270), "some".into(), length_record(23, base, 2)),
-                                    (Pattern::U16(271), "some".into(), length_record(27, base, 2)),
-                                    (Pattern::U16(272), "some".into(), length_record(31, base, 2)),
-                                    (Pattern::U16(273), "some".into(), length_record(35, base, 3)),
-                                    (Pattern::U16(274), "some".into(), length_record(43, base, 3)),
-                                    (Pattern::U16(275), "some".into(), length_record(51, base, 3)),
-                                    (Pattern::U16(276), "some".into(), length_record(59, base, 3)),
-                                    (Pattern::U16(277), "some".into(), length_record(67, base, 4)),
-                                    (Pattern::U16(278), "some".into(), length_record(83, base, 4)),
-                                    (Pattern::U16(279), "some".into(), length_record(99, base, 4)),
-                                    (
-                                        Pattern::U16(280),
-                                        "some".into(),
-                                        length_record(115, base, 4),
-                                    ),
-                                    (
-                                        Pattern::U16(281),
-                                        "some".into(),
-                                        length_record(131, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(282),
-                                        "some".into(),
-                                        length_record(163, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(283),
-                                        "some".into(),
-                                        length_record(195, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(284),
-                                        "some".into(),
-                                        length_record(227, base, 5),
-                                    ),
-                                    (
-                                        Pattern::U16(285),
-                                        "some".into(),
-                                        length_record(258, base, 0),
-                                    ),
-                                    (Pattern::Wildcard, "none".into(), Format::EMPTY),
-                                ],
+                Format::Dynamic(
+                    "distance-alphabet-format".into(),
+                    DynFormat::Huffman(var("distance-alphabet-code-lengths-value"), None),
+                    Box::new(Format::Dynamic(
+                        "literal-length-alphabet-format".into(),
+                        DynFormat::Huffman(var("literal-length-alphabet-code-lengths-value"), None),
+                        Box::new(repeat_until_last(
+                            Expr::Lambda(
+                                "x".into(),
+                                Box::new(Expr::Eq(
+                                    Box::new(Expr::AsU16(Box::new(Expr::RecordProj(
+                                        Box::new(var("x")),
+                                        "code".into(),
+                                    )))),
+                                    Box::new(Expr::U16(256)),
+                                )),
                             ),
-                        ),
-                    ]),
+                            record([
+                                (
+                                    "code",
+                                    Format::Apply("literal-length-alphabet-format".into()),
+                                ),
+                                (
+                                    "extra",
+                                    Format::MatchVariant(
+                                        var("code"),
+                                        vec![
+                                            (
+                                                Pattern::U16(257),
+                                                "some".into(),
+                                                length_record(3, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(258),
+                                                "some".into(),
+                                                length_record(4, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(259),
+                                                "some".into(),
+                                                length_record(5, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(260),
+                                                "some".into(),
+                                                length_record(6, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(261),
+                                                "some".into(),
+                                                length_record(7, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(262),
+                                                "some".into(),
+                                                length_record(8, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(263),
+                                                "some".into(),
+                                                length_record(9, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(264),
+                                                "some".into(),
+                                                length_record(10, base, 0),
+                                            ),
+                                            (
+                                                Pattern::U16(265),
+                                                "some".into(),
+                                                length_record(11, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(266),
+                                                "some".into(),
+                                                length_record(13, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(267),
+                                                "some".into(),
+                                                length_record(15, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(268),
+                                                "some".into(),
+                                                length_record(17, base, 1),
+                                            ),
+                                            (
+                                                Pattern::U16(269),
+                                                "some".into(),
+                                                length_record(19, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(270),
+                                                "some".into(),
+                                                length_record(23, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(271),
+                                                "some".into(),
+                                                length_record(27, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(272),
+                                                "some".into(),
+                                                length_record(31, base, 2),
+                                            ),
+                                            (
+                                                Pattern::U16(273),
+                                                "some".into(),
+                                                length_record(35, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(274),
+                                                "some".into(),
+                                                length_record(43, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(275),
+                                                "some".into(),
+                                                length_record(51, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(276),
+                                                "some".into(),
+                                                length_record(59, base, 3),
+                                            ),
+                                            (
+                                                Pattern::U16(277),
+                                                "some".into(),
+                                                length_record(67, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(278),
+                                                "some".into(),
+                                                length_record(83, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(279),
+                                                "some".into(),
+                                                length_record(99, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(280),
+                                                "some".into(),
+                                                length_record(115, base, 4),
+                                            ),
+                                            (
+                                                Pattern::U16(281),
+                                                "some".into(),
+                                                length_record(131, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(282),
+                                                "some".into(),
+                                                length_record(163, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(283),
+                                                "some".into(),
+                                                length_record(195, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(284),
+                                                "some".into(),
+                                                length_record(227, base, 5),
+                                            ),
+                                            (
+                                                Pattern::U16(285),
+                                                "some".into(),
+                                                length_record(258, base, 0),
+                                            ),
+                                            (Pattern::Wildcard, "none".into(), Format::EMPTY),
+                                        ],
+                                    ),
+                                ),
+                            ]),
+                        )),
+                    )),
                 ),
             ),
             (

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -400,7 +400,7 @@ impl Expr {
         }
     }
 
-    fn eval_value<'a>(&self, scope: &'a Scope<'a>) -> Value {
+    pub fn eval_value<'a>(&self, scope: &'a Scope<'a>) -> Value {
         self.eval(scope).coerce_mapped_value().clone()
     }
 
@@ -441,6 +441,7 @@ enum Decoder {
     WithRelativeOffset(Expr, Box<Decoder>),
     Map(Box<Decoder>, Expr),
     Compute(Expr),
+    Let(Cow<'static, str>, Expr, Box<Decoder>),
     Match(Expr, Vec<(Pattern, Decoder)>),
     MatchVariant(Expr, Vec<(Pattern, Cow<'static, str>, Decoder)>),
     Dynamic(DynFormat),
@@ -923,6 +924,10 @@ impl Decoder {
                 Ok(Decoder::Map(da, expr.clone()))
             }
             Format::Compute(expr) => Ok(Decoder::Compute(expr.clone())),
+            Format::Let(name, expr, a) => {
+                let da = Box::new(Decoder::compile_next(compiler, a, next.clone())?);
+                Ok(Decoder::Let(name.clone(), expr.clone(), da))
+            }
             Format::Match(head, branches) => {
                 let branches = branches
                     .iter()
@@ -1169,6 +1174,12 @@ impl Decoder {
             Decoder::Compute(expr) => {
                 let v = expr.eval_value(scope);
                 Ok((v, input))
+            }
+            Decoder::Let(name, expr, d) => {
+                let v = expr.eval_value(scope);
+                let mut let_scope = Scope::child(scope);
+                let_scope.push(name.clone(), v);
+                d.parse(program, &let_scope, input)
             }
             Decoder::Match(head, branches) => {
                 let head = head.eval(scope);

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -21,7 +21,6 @@ pub enum Value {
     Seq(Vec<Value>),
     Mapped(Box<Value>, Box<Value>),
     Branch(usize, Box<Value>),
-    Format(Box<Format>),
 }
 
 impl Value {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use crate::byte_set::ByteSet;
-use crate::decoder::{Scope, Value};
+use crate::decoder::{Scope, ScopeEntry};
 use crate::read::ReadCtxt;
 
 use std::borrow::Cow;
@@ -9,7 +9,7 @@ pub type ParseResult<T> = Result<T, ParseError>;
 #[derive(Debug)]
 pub enum ParseError {
     Fail {
-        bindings: Vec<(Cow<'static, str>, Value)>,
+        bindings: Vec<(Cow<'static, str>, ScopeEntry)>,
         buffer: Vec<u8>,
         offset: usize,
     },
@@ -91,7 +91,7 @@ impl ParseError {
     pub fn fail(scope: &Scope<'_>, input: ReadCtxt<'_>) -> Self {
         let bindings = scope
             .iter()
-            .map(|(name, value)| (name.clone(), value.clone()))
+            .map(|(name, entry)| (name.clone(), entry.clone()))
             .collect::<Vec<_>>();
         let buffer = input.input.to_owned();
         let offset = input.offset;

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -185,8 +185,8 @@ fn check_covered(
                 check_covered(module, path, format)?;
             }
         }
-        Format::Dynamic(_) => {} // FIXME
-        Format::Apply(_) => {}   // FIXME
+        Format::Dynamic(_name, _dynformat, format) => check_covered(module, path, format)?,
+        Format::Apply(_) => {}
     }
     Ok(())
 }
@@ -322,8 +322,12 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected branch, found {value:?}"),
             },
-            Format::Dynamic(_) => Ok(()), // FIXME
-            Format::Apply(_) => Ok(()),   // FIXME
+            Format::Dynamic(name, _dynformat, format) => {
+                let mut child_scope = Scope::child(scope);
+                child_scope.push(name.clone(), Value::Tuple(vec![]));
+                self.write_flat(&child_scope, value, format)
+            }
+            Format::Apply(_) => Ok(()), // FIXME
         }
     }
 }

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -174,6 +174,7 @@ fn check_covered(
         Format::WithRelativeOffset(_, _) => {} // FIXME
         Format::Map(format, _expr) => check_covered(module, path, format)?,
         Format::Compute(_expr) => {}
+        Format::Let(_name, _expr, format) => check_covered(module, path, format)?,
         Format::Match(_head, branches) => {
             for (_pattern, format) in branches {
                 check_covered(module, path, format)?;
@@ -286,6 +287,12 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::WithRelativeOffset(_, format) => self.write_flat(scope, value, format),
             Format::Map(_format, _expr) => Ok(()),
             Format::Compute(_expr) => Ok(()),
+            Format::Let(name, expr, format) => {
+                let v = expr.eval_value(&scope);
+                let mut let_scope = Scope::child(scope);
+                let_scope.push(name.clone(), v);
+                self.write_flat(&let_scope, value, format)
+            }
             Format::Match(head, branches) => match value {
                 Value::Branch(index, value) => {
                     let head = head.eval(scope);

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -178,7 +178,6 @@ impl<'module> MonoidalPrinter<'module> {
                 None => self.is_atomic_value(value, None),
                 f => panic!("expected format suitable for branch: {f:?}"),
             },
-            Value::Format(_) => false,
         }
     }
 
@@ -396,7 +395,6 @@ impl<'module> MonoidalPrinter<'module> {
                 }
             }
             Value::Branch(_n, value) => self.compile_value(scope, value),
-            Value::Format(f) => self.compile_format(f, Default::default()),
         }
     }
 

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -361,8 +361,11 @@ impl<'module> MonoidalPrinter<'module> {
                 _ => panic!("expected branch, found {value:?}"),
             },
             Format::Dynamic(name, _dynformat, format) => {
+                // TODO this scope entry should never be accessed while printing.
+                // In future we could potentially save the generated dynamic format
+                // as a new type of value if we wanted to optionally display it.
                 let mut child_scope = Scope::child(scope);
-                child_scope.push(name.clone(), Value::Tuple(vec![])); // FIXME?
+                child_scope.push(name.clone(), Value::Tuple(vec![]));
                 self.compile_decoded_value(&child_scope, value, format)
             }
             Format::Apply(_) => self.compile_value(scope, value),

--- a/tests/expected/decode/test1.gz.stdout
+++ b/tests/expected/decode/test1.gz.stdout
@@ -15,8 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- dynamic format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 72
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test2.gz.stdout
+++ b/tests/expected/decode/test2.gz.stdout
@@ -15,8 +15,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- dynamic format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test3.gz.stdout
+++ b/tests/expected/decode/test3.gz.stdout
@@ -15,8 +15,7 @@
 │       │   │   │       ├── final <- base.bit := 1
 │       │   │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │       │   │   │       └── data <- match type { ... } :=
-│       │   │   │           ├── format <- dynamic := _ |...| _
-│       │   │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│       │   │   │           ├── codes <- dynamic format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │       │   │   │           │   ├── 0 :=
 │       │   │   │           │   │   ├── code <- apply := 72
 │       │   │   │           │   │   └── extra <- match code { ... } := ()
@@ -108,8 +107,7 @@
 │           │   │       ├── final <- base.bit := 1
 │           │   │       ├── type <- map (bits -> bits.1 << 1 | bits.0) (...) := 1
 │           │   │       └── data <- match type { ... } :=
-│           │   │           ├── format <- dynamic := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- dynamic format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 104
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test4.gz.stdout
+++ b/tests/expected/decode/test4.gz.stdout
@@ -31,8 +31,7 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 14 := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- dynamic code-length-alphabet-format huffman (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 5
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -106,9 +105,7 @@
 │           │   │   │       │   ├── 9 := 4
 │           │   │   │       │   ~
 │           │   │   │       │   └── 28 := 8
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- dynamic distance-alphabet-format huffman (dynamic literal-length-alphabet-format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 255
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -176,8 +173,7 @@
 │           │   │   │       │   ├── 9 := 6
 │           │   │   │       │   ~
 │           │   │   │       │   └── 18 := 6
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- dynamic code-length-alphabet-format huffman (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 6
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -251,9 +247,7 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 29 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- dynamic distance-alphabet-format huffman (dynamic literal-length-alphabet-format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 207
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -321,8 +315,7 @@
 │           │   │           │   ├── 9 := 5
 │           │   │           │   ~
 │           │   │           │   └── 16 := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │           ├── literal-length-distance-alphabet-code-lengths <- dynamic code-length-alphabet-format huffman (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 7
 │           │   │           │   │   └── extra <- match (as-u8 code) { ... } := 0
@@ -396,9 +389,7 @@
 │           │   │           │   ├── 9 := 7
 │           │   │           │   ~
 │           │   │           │   └── 29 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- dynamic distance-alphabet-format huffman (dynamic literal-length-alphabet-format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 252
 │           │   │           │   │   └── extra <- match code { ... } := ()

--- a/tests/expected/decode/test5.gz.stdout
+++ b/tests/expected/decode/test5.gz.stdout
@@ -31,8 +31,7 @@
 │           │   │   │       │   ├── 9 := 3
 │           │   │   │       │   ~
 │           │   │   │       │   └── 13 := 5
-│           │   │   │       ├── code-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │   │       ├── literal-length-distance-alphabet-code-lengths <- dynamic code-length-alphabet-format huffman (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 17
 │           │   │   │       │   │   └── extra <- match (as-u8 code) { ... } := 7
@@ -106,9 +105,7 @@
 │           │   │   │       │   ├── 9 := 7
 │           │   │   │       │   ~
 │           │   │   │       │   └── 27 := 6
-│           │   │   │       ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── literal-length-alphabet-format <- dynamic := _ |...| _
-│           │   │   │       ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │   │       ├── codes <- dynamic distance-alphabet-format huffman (dynamic literal-length-alphabet-format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │   │       │   ├── 0 :=
 │           │   │   │       │   │   ├── code <- apply := 35
 │           │   │   │       │   │   └── extra <- match code { ... } := ()
@@ -176,8 +173,7 @@
 │           │   │           │   ├── 9 := 3
 │           │   │           │   ~
 │           │   │           │   └── 13 := 5
-│           │   │           ├── code-length-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-distance-alphabet-code-lengths <- repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... } :=
+│           │   │           ├── literal-length-distance-alphabet-code-lengths <- dynamic code-length-alphabet-format huffman (repeat-until-seq (y -> seq-length (flat-map-accum (x -> match as-u8 (x.1.code) { ... }, { none := (...) }) y) >= as-u32 (hlit + hdist) + 258) { ... }) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 18
 │           │   │           │   │   └── extra <- match (as-u8 code) { ... } := 37
@@ -251,9 +247,7 @@
 │           │   │           │   ├── 9 := 0
 │           │   │           │   ~
 │           │   │           │   └── 28 := 5
-│           │   │           ├── distance-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── literal-length-alphabet-format <- dynamic := _ |...| _
-│           │   │           ├── codes <- repeat-until-last (x -> as-u16 (x.code) == 256) { ... } :=
+│           │   │           ├── codes <- dynamic distance-alphabet-format huffman (dynamic literal-length-alphabet-format huffman (repeat-until-last (x -> as-u16 (x.code) == 256) { ... })) :=
 │           │   │           │   ├── 0 :=
 │           │   │           │   │   ├── code <- apply := 50
 │           │   │           │   │   └── extra <- match code { ... } := ()


### PR DESCRIPTION
This improves on #121 by adding as simple kind system that separates format types from value types.

Expression evaluation can only return a value type, not a format type. In particular variables can only evaluate to values, not formats. This makes it impossible to put a format in a record or a tuple or pattern match on formats or anything like that.

Let bindings work for value types, `let name := expr in format` behaves as you would expect.

Dynamic bindings compile a dynamic format: `dynamic name := format in format` will compile the specified dynamic format to a decoder that can be applied by name.

Compiled decoders live in the scope, stored in a ScopeEntry that is either a value or a decoder.

As far as I can tell this scheme is sound and seems a lot easier to prove that it's sound.