### PR TITLE
Crude Rust type generation by extracting TypeDef/TypeRef from Decoder.

### DIFF
--- a/src/bin/doodle/main.rs
+++ b/src/bin/doodle/main.rs
@@ -17,6 +17,8 @@ enum FormatOutput {
     Debug,
     /// Serialize to JSON
     Json,
+    /// Generate Rust code
+    Rust,
 }
 
 #[derive(Copy, Clone, ValueEnum)]
@@ -53,11 +55,14 @@ fn main() -> Result<(), Box<dyn std::error::Error + 'static>> {
     match Command::parse() {
         Command::Format { output } => {
             let mut module = FormatModule::new();
-            let _ = format::main(&mut module);
+            let format = format::main(&mut module).call();
 
             match output {
                 FormatOutput::Debug => println!("{module:?}"),
                 FormatOutput::Json => serde_json::to_writer(std::io::stdout(), &module).unwrap(),
+                FormatOutput::Rust => {
+                    doodle::codegen::print_program(&module, &format);
+                }
             }
 
             Ok(())

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -1,0 +1,182 @@
+use crate::{Format, FormatModule, TypeScope, ValueType};
+use std::borrow::Cow;
+use std::collections::HashMap;
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub enum TypeRef {
+    Var(usize),
+    Empty,
+    Bool,
+    U8,
+    U16,
+    U32,
+    Tuple(Vec<TypeRef>),
+    Seq(Box<TypeRef>),
+    Char,
+}
+
+pub enum TypeDef {
+    Union(Vec<(Cow<'static, str>, TypeRef)>),
+    Record(Vec<(Cow<'static, str>, TypeRef)>),
+}
+
+pub struct Codegen {
+    typedefs: Vec<TypeDef>,
+    record_map: HashMap<Vec<(Cow<'static, str>, TypeRef)>, usize>,
+    union_map: HashMap<Vec<(Cow<'static, str>, TypeRef)>, usize>,
+}
+
+impl TypeRef {
+    #[allow(dead_code)]
+    fn to_value_type(&self, typedefs: &[TypeDef]) -> ValueType {
+        match self {
+            TypeRef::Var(n) => match &typedefs[*n] {
+                TypeDef::Union(ts) => ValueType::Union(
+                    ts.iter()
+                        .map(|(name, t)| (name.clone(), t.to_value_type(typedefs)))
+                        .collect(),
+                ),
+                TypeDef::Record(ts) => ValueType::Record(
+                    ts.iter()
+                        .map(|(name, t)| (name.clone(), t.to_value_type(typedefs)))
+                        .collect(),
+                ),
+            },
+            TypeRef::Empty => ValueType::Empty,
+            TypeRef::Bool => ValueType::Bool,
+            TypeRef::U8 => ValueType::U8,
+            TypeRef::U16 => ValueType::U16,
+            TypeRef::U32 => ValueType::U32,
+            TypeRef::Char => ValueType::Char,
+            TypeRef::Tuple(ts) => {
+                ValueType::Tuple(ts.iter().map(|t| t.to_value_type(typedefs)).collect())
+            }
+            TypeRef::Seq(t) => ValueType::Seq(Box::new(t.to_value_type(typedefs))),
+        }
+    }
+}
+
+impl Codegen {
+    pub fn new() -> Self {
+        let typedefs = Vec::new();
+        let record_map = HashMap::new();
+        let union_map = HashMap::new();
+        Codegen {
+            typedefs,
+            record_map,
+            union_map,
+        }
+    }
+
+    pub fn make_typedefs(&mut self, module: &FormatModule, format: &Format) -> TypeRef {
+        let t = module.infer_format_type(&TypeScope::new(), format).unwrap();
+        self.typeref_from_value_type(&t)
+    }
+
+    pub fn add_typedef(&mut self, t: TypeDef) -> TypeRef {
+        let n = self.typedefs.len();
+        self.typedefs.push(t);
+        TypeRef::Var(n)
+    }
+
+    fn typeref_from_value_type(&mut self, t: &ValueType) -> TypeRef {
+        match t {
+            ValueType::Any => panic!("ValueType::Any"),
+            ValueType::Empty => TypeRef::Empty,
+            ValueType::Bool => TypeRef::Bool,
+            ValueType::U8 => TypeRef::U8,
+            ValueType::Char => TypeRef::Char,
+            ValueType::U16 => TypeRef::U16,
+            ValueType::U32 => TypeRef::U32,
+            ValueType::Tuple(ts) => {
+                TypeRef::Tuple(ts.iter().map(|t| self.typeref_from_value_type(t)).collect())
+            }
+            ValueType::Record(fields) => {
+                let fs: Vec<_> = fields
+                    .iter()
+                    .map(|(label, t)| (label.clone(), self.typeref_from_value_type(t)))
+                    .collect();
+                let n = if let Some(n) = self.record_map.get(&fs) {
+                    *n
+                } else {
+                    let t = TypeDef::Record(fs.clone());
+                    let n = self.typedefs.len();
+                    self.typedefs.push(t);
+                    self.record_map.insert(fs, n);
+                    n
+                };
+                TypeRef::Var(n)
+            }
+            ValueType::Union(branches) => {
+                let bs: Vec<_> = branches
+                    .iter()
+                    .map(|(label, t)| (label.clone(), self.typeref_from_value_type(t)))
+                    .collect();
+                let n = if let Some(n) = self.union_map.get(&bs) {
+                    *n
+                } else {
+                    let t = TypeDef::Union(bs.clone());
+                    let n = self.typedefs.len();
+                    self.typedefs.push(t);
+                    self.union_map.insert(bs, n);
+                    n
+                };
+                TypeRef::Var(n)
+            }
+            ValueType::Seq(t) => TypeRef::Seq(Box::new(self.typeref_from_value_type(t))),
+        }
+    }
+}
+
+pub fn print_program(module: &FormatModule, format: &Format) {
+    let mut codegen = Codegen::new();
+    let _t = codegen.make_typedefs(module, format);
+    for (i, t) in codegen.typedefs.iter().enumerate() {
+        match t {
+            TypeDef::Union(branches) => {
+                println!("enum Type{i} {{");
+                for (i, (label, t)) in branches.iter().enumerate() {
+                    print!("    Branch{i}(");
+                    print_typeref(t);
+                    println!("), // {label}");
+                }
+                println!("}}");
+            }
+            TypeDef::Record(fields) => {
+                println!("struct Type{i} {{");
+                for (i, (label, t)) in fields.iter().enumerate() {
+                    print!("    field{i}: ");
+                    print_typeref(t);
+                    println!(", // {label}");
+                }
+                println!("}}");
+            }
+        }
+        println!();
+    }
+}
+
+fn print_typeref(t: &TypeRef) {
+    match t {
+        TypeRef::Var(n) => print!("Type{n}"),
+        TypeRef::Empty => print!("Empty"),
+        TypeRef::Bool => print!("bool"),
+        TypeRef::U8 => print!("u8"),
+        TypeRef::U16 => print!("u16"),
+        TypeRef::U32 => print!("u32"),
+        TypeRef::Char => print!("char"),
+        TypeRef::Tuple(ts) => {
+            print!("(");
+            for t in ts {
+                print_typeref(t);
+                print!(",");
+            }
+            print!(")");
+        }
+        TypeRef::Seq(t) => {
+            print!("Vec<");
+            print_typeref(t);
+            print!(">");
+        }
+    }
+}

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1,7 +1,7 @@
 use crate::byte_set::ByteSet;
 use crate::error::{ParseError, ParseResult};
 use crate::read::ReadCtxt;
-use crate::{DynFormat, Expr, Format, FormatModule, MatchTree, Next, Pattern, ValueType};
+use crate::{DynFormat, Expr, Format, FormatModule, MatchTree, Next, Pattern};
 use crate::{IntoLabel, Label};
 use serde::Serialize;
 use std::borrow::Cow;
@@ -443,35 +443,14 @@ pub enum Decoder {
     Apply(Label),
 }
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
-pub enum TypeRef {
-    Var(usize),
-    Empty,
-    Bool,
-    U8,
-    U16,
-    U32,
-    Tuple(Vec<TypeRef>),
-    Seq(Box<TypeRef>),
-    Char,
-}
-
-pub enum TypeDef {
-    //Equiv(TypeRef),
-    Union(Vec<(Label, TypeRef)>),
-    Record(Vec<(Label, TypeRef)>),
-}
-
 pub struct Program {
-    typedefs: Vec<TypeDef>,
-    decoders: Vec<Decoder>,
+    pub decoders: Vec<Decoder>,
 }
 
 impl Program {
     fn new() -> Self {
-        let typedefs = Vec::new();
         let decoders = Vec::new();
-        Program { typedefs, decoders }
+        Program { decoders }
     }
 
     pub fn run<'input>(&self, input: ReadCtxt<'input>) -> ParseResult<(Value, ReadCtxt<'input>)> {
@@ -482,8 +461,6 @@ impl Program {
 pub struct Compiler<'a> {
     module: &'a FormatModule,
     program: Program,
-    record_map: HashMap<Vec<(Label, TypeRef)>, usize>,
-    union_map: HashMap<Vec<(Label, TypeRef)>, usize>,
     decoder_map: HashMap<(usize, Rc<Next<'a>>), usize>,
     compile_queue: Vec<(&'a Format, Rc<Next<'a>>, usize)>,
 }
@@ -491,15 +468,11 @@ pub struct Compiler<'a> {
 impl<'a> Compiler<'a> {
     fn new(module: &'a FormatModule) -> Self {
         let program = Program::new();
-        let record_map = HashMap::new();
-        let union_map = HashMap::new();
         let decoder_map = HashMap::new();
         let compile_queue = Vec::new();
         Compiler {
             module,
             program,
-            record_map,
-            union_map,
             decoder_map,
             compile_queue,
         }
@@ -507,15 +480,6 @@ impl<'a> Compiler<'a> {
 
     pub fn compile(module: &FormatModule, format: &Format) -> Result<Program, String> {
         let mut compiler = Compiler::new(module);
-        // type
-        /*
-        let mut scope = TypeScope::new();
-        let t = TypeRef::from_value_type(
-            &mut compiler,
-            &module.infer_format_type(&mut scope, format)?,
-        );
-        */
-        // decoder
         compiler.queue_compile(format, Rc::new(Next::Empty));
         while let Some((f, next, n)) = compiler.compile_queue.pop() {
             let d = Decoder::compile_next(&mut compiler, f, next)?;
@@ -529,12 +493,6 @@ impl<'a> Compiler<'a> {
         self.program.decoders.push(Decoder::Fail);
         self.compile_queue.push((f, next, n));
         n
-    }
-
-    pub fn add_typedef(&mut self, t: TypeDef) -> TypeRef {
-        let n = self.program.typedefs.len();
-        self.program.typedefs.push(t);
-        TypeRef::Var(n)
     }
 }
 
@@ -682,88 +640,6 @@ impl<'a> DecoderScope<'a> {
             ScopeEntry::Decoder(self.decoder.clone()),
         ));
         self.parent.get_bindings(bindings);
-    }
-}
-
-impl TypeRef {
-    #[allow(dead_code)]
-    fn from_value_type(compiler: &mut Compiler<'_>, t: &ValueType) -> Self {
-        match t {
-            ValueType::Any => panic!("ValueType::Any"),
-            ValueType::Empty => TypeRef::Empty,
-            ValueType::Bool => TypeRef::Bool,
-            ValueType::U8 => TypeRef::U8,
-            ValueType::Char => TypeRef::Char,
-            ValueType::U16 => TypeRef::U16,
-            ValueType::U32 => TypeRef::U32,
-            ValueType::Tuple(ts) => TypeRef::Tuple(
-                ts.iter()
-                    .map(|t| Self::from_value_type(compiler, t))
-                    .collect(),
-            ),
-            ValueType::Record(fields) => {
-                let fs: Vec<_> = fields
-                    .iter()
-                    .map(|(label, t)| (label.clone(), Self::from_value_type(compiler, t)))
-                    .collect();
-                let n = if let Some(n) = compiler.record_map.get(&fs) {
-                    *n
-                } else {
-                    let t = TypeDef::Record(fs.clone());
-                    let n = compiler.program.typedefs.len();
-                    compiler.program.typedefs.push(t);
-                    compiler.record_map.insert(fs, n);
-                    n
-                };
-                TypeRef::Var(n)
-            }
-            ValueType::Union(branches) => {
-                let bs: Vec<_> = branches
-                    .iter()
-                    .map(|(label, t)| (label.clone(), Self::from_value_type(compiler, t)))
-                    .collect();
-                let n = if let Some(n) = compiler.union_map.get(&bs) {
-                    *n
-                } else {
-                    let t = TypeDef::Union(bs.clone());
-                    let n = compiler.program.typedefs.len();
-                    compiler.program.typedefs.push(t);
-                    compiler.union_map.insert(bs, n);
-                    n
-                };
-                TypeRef::Var(n)
-            }
-            ValueType::Seq(t) => TypeRef::Seq(Box::new(Self::from_value_type(compiler, t))),
-        }
-    }
-
-    #[allow(dead_code)]
-    fn to_value_type(&self, typedefs: &[TypeDef]) -> ValueType {
-        match self {
-            TypeRef::Var(n) => match &typedefs[*n] {
-                //TypeDef::Equiv(t) => t.to_value_type(typedefs),
-                TypeDef::Union(ts) => ValueType::Union(
-                    ts.iter()
-                        .map(|(name, t)| (name.clone(), t.to_value_type(typedefs)))
-                        .collect(),
-                ),
-                TypeDef::Record(ts) => ValueType::Record(
-                    ts.iter()
-                        .map(|(name, t)| (name.clone(), t.to_value_type(typedefs)))
-                        .collect(),
-                ),
-            },
-            TypeRef::Empty => ValueType::Empty,
-            TypeRef::Bool => ValueType::Bool,
-            TypeRef::U8 => ValueType::U8,
-            TypeRef::U16 => ValueType::U16,
-            TypeRef::U32 => ValueType::U32,
-            TypeRef::Char => ValueType::Char,
-            TypeRef::Tuple(ts) => {
-                ValueType::Tuple(ts.iter().map(|t| t.to_value_type(typedefs)).collect())
-            }
-            TypeRef::Seq(t) => ValueType::Seq(Box::new(t.to_value_type(typedefs))),
-        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use crate::read::ReadCtxt;
 
 pub mod bounds;
 pub mod byte_set;
+pub mod codegen;
 pub mod decoder;
 pub mod error;
 


### PR DESCRIPTION
An improvement on codegen2, this has no dependencies on Decoder and just generates Rust types from the FormatModule as a starting point.