### PR TITLE
Codegen fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[test]]
+name = "generated"
+path = "sample_codegen.rs"
+bench = false
+
 
 [dev-dependencies]
 proptest = "1.1.0"

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,20 +1,210 @@
 use doodle::prelude::*;
 
-enum Type36 {
+struct Type7 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+enum Type23 {
+    dynamic_huffman {
+        hlit: u8,
+        hdist: u8,
+        hclen: u8,
+        code_length_alphabet_code_lengths: Vec<u8>,
+        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+        literal_length_alphabet_code_lengths_value: Vec<u8>,
+        distance_alphabet_code_lengths_value: Vec<u8>,
+        codes: Vec<Type18>,
+        codes_values: Vec<Type19>,
+    },
+    fixed_huffman {
+        codes: Vec<Type21>,
+        codes_values: Vec<Type19>,
+    },
+    uncompressed {
+        align: (),
+        len: u16,
+        nlen: u16,
+        bytes: Vec<u8>,
+        codes_values: Vec<Type22>,
+    },
+}
+
+struct Type29 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+struct Type45 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type44>,
+}
+
+enum Type58 {
+    color_type_3 { palette_index: u8 },
+    color_type_6 { red: u16, green: u16, blue: u16 },
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_4 { greyscale: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type86 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type62,
+    crc: u32,
+}
+
+struct Type88 {
+    marker: Type28,
+    length: u16,
+    data: Type37,
+}
+
+struct Type101 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type18>,
+    codes_values: Vec<Type19>,
+}
+
+enum Type50 {
+    mcu(u8),
+    rst0 { ff: u8, marker: u8 },
+    rst1 { ff: u8, marker: u8 },
+    rst2 { ff: u8, marker: u8 },
+    rst3 { ff: u8, marker: u8 },
+    rst4 { ff: u8, marker: u8 },
+    rst5 { ff: u8, marker: u8 },
+    rst6 { ff: u8, marker: u8 },
+    rst7 { ff: u8, marker: u8 },
+}
+
+struct Type107 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type48 {
+    num_image_components: u8,
+    image_components: Vec<Type47>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+struct Type80 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type68,
+    pad: Type66,
+}
+
+struct Type39 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+struct Type105 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+struct Type103 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type59 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+enum Type30 {
     other(Vec<u8>),
-    xmp { xmp: Vec<u8> },
-    exif { padding: u8, exif: Type35 },
+    jfif {
+        version_major: u8,
+        version_minor: u8,
+        density_units: u8,
+        density_x: u16,
+        density_y: u16,
+        thumbnail_width: u8,
+        thumbnail_height: u8,
+        thumbnail_pixels: Vec<Vec<Type2>>,
+    },
+}
+
+struct Type65 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
+}
+
+struct Type93 {
+    marker: Type28,
+    length: u16,
+    data: Type41,
+}
+
+struct Type90 {
+    marker: Type28,
+    length: u16,
+    data: Type45,
+}
+
+struct Type71 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+struct Type67 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type66,
 }
 
 struct Type41 {
     class_table_id: u8,
     value: u8,
-}
-
-struct Type94 {
-    marker: Type28,
-    length: u16,
-    data: Type42,
 }
 
 struct Type82 {
@@ -24,11 +214,97 @@ struct Type82 {
     crc: u32,
 }
 
+struct Type95 {
+    marker: Type28,
+    length: u16,
+    data: Vec<u8>,
+}
+
+enum Type3 {
+    no(),
+    yes(Vec<Type2>),
+}
+
+struct Type61 {
+    palette_index: u8,
+}
+
+enum Type9 {
+    table_based_image {
+        descriptor: Type6,
+        local_color_table: Type3,
+        data: Type8,
+    },
+    plain_text_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        text_grid_left_position: u16,
+        text_grid_top_position: u16,
+        text_grid_width: u16,
+        text_grid_height: u16,
+        character_cell_width: u8,
+        character_cell_height: u8,
+        text_foreground_color_index: u8,
+        text_background_color_index: u8,
+        plain_text_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+struct Type15 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type44 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+enum Type54 {
+    some {
+        marker: Type28,
+        length: u16,
+        data: Type53,
+    },
+    none(),
+}
+
 struct Type64 {
     length: u32,
     tag: (u8, u8, u8, u8),
     data: Vec<u8>,
     crc: u32,
+}
+
+struct Type78 {
+    soi: Type28,
+    frame: Type55,
+    eoi: Type28,
+}
+
+struct Type100 {
+    codes: Vec<Type21>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type12 {
+    separator: u8,
+}
+
+struct Type89 {
+    marker: Type28,
+    length: u16,
+    data: Type53,
+}
+
+struct Type34 {
+    num_fields: u16,
+    fields: Vec<Type33>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
 }
 
 struct Type1 {
@@ -39,9 +315,109 @@ struct Type1 {
     pixel_aspect_ratio: u8,
 }
 
-struct Type7 {
-    len_bytes: u8,
-    data: Vec<u8>,
+struct Type69 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type91 {
+    marker: Type28,
+    length: u16,
+    data: Type39,
+}
+
+struct Type94 {
+    marker: Type28,
+    length: u16,
+    data: Type42,
+}
+
+struct Type81 {
+    contents: Vec<Type73>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
+}
+
+enum Type38 {
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
+}
+
+struct Type72 {
+    name: Type69,
+    mode: Type70,
+    uid: Type70,
+    gid: Type70,
+    size: u32,
+    mtime: Type70,
+    chksum: Type70,
+    typeflag: u8,
+    linkname: Type69,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type71,
+    gname: Type71,
+    devmajor: Type70,
+    devminor: Type70,
+    prefix: Type69,
+    pad: Vec<u8>,
+}
+
+struct Type87 {
+    marker: Type28,
+    length: u16,
+    data: Type31,
+}
+
+struct Type31 {
+    identifier: Type29,
+    data: Type30,
+}
+
+struct Type60 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type97 {
+    xmp: Vec<u8>,
+}
+
+struct Type85 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type60,
+    crc: u32,
+}
+
+struct Type49 {
+    marker: Type28,
+    length: u16,
+    data: Type48,
+}
+
+struct Type76 {
+    data: Type75,
+    end: (),
+}
+
+struct Type104 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type7>,
+    terminator: u8,
 }
 
 struct Type68 {
@@ -49,9 +425,399 @@ struct Type68 {
     chunks: Vec<Type67>,
 }
 
+struct Type53 {
+    num_lines: u16,
+}
+
+struct Type27 {
+    header: Type13,
+    fname: Type14,
+    data: Type25,
+    footer: Type26,
+}
+
+struct Type57 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type56,
+    crc: u32,
+}
+
+enum Type17 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u16,
+        distance_record: Type16,
+    },
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+enum Type36 {
+    other(Vec<u8>),
+    xmp { xmp: Vec<u8> },
+    exif { padding: u8, exif: Type35 },
+}
+
+struct Type18 {
+    code: u16,
+    extra: Type17,
+}
+
+struct Type56 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type70 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
+}
+
+struct Type106 {
+    descriptor: Type6,
+    local_color_table: Type3,
+    data: Type8,
+}
+
+struct Type52 {
+    segments: Vec<Type43>,
+    sos: Type49,
+    data: Type51,
+}
+
+struct Type73 {
+    header: Type72,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type13 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type16 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type84 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
+}
+
+struct Type96 {
+    padding: u8,
+    exif: Type35,
+}
+
+struct Type102 {
+    graphic_control_extension: Type5,
+    graphic_rendering_block: Type9,
+}
+
+struct Type42 {
+    restart_interval: u16,
+}
+
+enum Type63 {
+    bKGD {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type58,
+        crc: u32,
+    },
+    pHYs {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type59,
+        crc: u32,
+    },
+    PLTE {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Vec<Type2>,
+        crc: u32,
+    },
+    tIME {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type60,
+        crc: u32,
+    },
+    tRNS {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type62,
+        crc: u32,
+    },
+}
+
+struct Type79 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type57,
+    chunks: Vec<Type63>,
+    idat: Vec<Type64>,
+    more_chunks: Vec<Type63>,
+    iend: Type65,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type6 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type24 {
+    r#final: u8,
+    r#type: u8,
+    data: Type23,
+}
+
+enum Type10 {
+    application_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        identifier: Vec<u8>,
+        authentication_code: Vec<u8>,
+        application_data: Vec<Type7>,
+        terminator: u8,
+    },
+    comment_extension {
+        separator: u8,
+        label: u8,
+        comment_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+struct Type47 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
+}
+
+struct Type55 {
+    initial_segment: Type38,
+    segments: Vec<Type43>,
+    header: Type46,
+    scan: Type52,
+    dnl: Type54,
+    scans: Vec<Type52>,
+}
+
+enum Type11 {
+    graphic_block {
+        graphic_control_extension: Type5,
+        graphic_rendering_block: Type9,
+    },
+    special_purpose_block(Type10),
+}
+
+enum Type62 {
+    color_type_3(Vec<Type61>),
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+enum Type14 {
+    no(),
+    yes { string: Vec<u8>, null: u8 },
+}
+
+enum Type19 {
+    literal(u8),
+    reference { length: u16, distance: u16 },
+}
+
+struct Type35 {
+    byte_order: Type32,
+    magic: u16,
+    offset: u32,
+    ifd: Type34,
+}
+
+enum Type5 {
+    some {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        flags: u8,
+        delay_time: u16,
+        transparent_color_index: u8,
+        terminator: u8,
+    },
+    none(),
+}
+
+struct Type37 {
+    identifier: Type29,
+    data: Type36,
+}
+
+enum Type75 {
+    gif {
+        header: Type0,
+        logical_screen: Type4,
+        blocks: Vec<Type11>,
+        trailer: Type12,
+    },
+    gzip(Vec<Type27>),
+    jpeg {
+        soi: Type28,
+        frame: Type55,
+        eoi: Type28,
+    },
+    png {
+        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+        ihdr: Type57,
+        chunks: Vec<Type63>,
+        idat: Vec<Type64>,
+        more_chunks: Vec<Type63>,
+        iend: Type65,
+    },
+    riff {
+        tag: (u8, u8, u8, u8),
+        length: u32,
+        data: Type68,
+        pad: Type66,
+    },
+    tar {
+        contents: Vec<Type73>,
+        __padding: Vec<u8>,
+        __trailing: Vec<u8>,
+    },
+    text(Type74),
+}
+
+struct Type99 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type22>,
+}
+
 enum Type32 {
     le(u8, u8),
     be(u8, u8),
+}
+
+enum Type22 {
+    literal(u8),
+}
+
+enum Type46 {
+    sof0 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof1 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof2 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof3 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof5 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof6 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof7 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof9 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof10 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof11 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof13 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof14 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof15 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+}
+
+enum Type66 {
+    no(u8),
+    yes(),
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type59,
+    crc: u32,
+}
+
+struct Type92 {
+    marker: Type28,
+    length: u16,
+    data: Type40,
 }
 
 enum Type74 {
@@ -59,10 +825,49 @@ enum Type74 {
     utf8(Vec<char>),
 }
 
-struct Type88 {
-    marker: Type28,
-    length: u16,
-    data: Type37,
+struct Type8 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type28 {
+    ff: u8,
+    marker: u8,
+}
+
+enum Type20 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u8,
+        distance_record: Type16,
+    },
+}
+
+struct Type25 {
+    blocks: Vec<Type24>,
+    codes: Vec<Type19>,
+    inflate: Vec<u8>,
+}
+
+struct Type77 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type11>,
+    trailer: Type12,
+}
+
+struct Type26 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type40 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
 }
 
 enum Type43 {
@@ -173,650 +978,6 @@ enum Type43 {
     },
 }
 
-enum Type20 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u8,
-        distance_record: Type16,
-    },
-}
-
-struct Type61 {
-    palette_index: u8,
-}
-
-struct Type25 {
-    blocks: Vec<Type24>,
-    codes: Vec<Type19>,
-    inflate: Vec<u8>,
-}
-
-struct Type27 {
-    header: Type13,
-    fname: Type14,
-    data: Type25,
-    footer: Type26,
-}
-
-struct Type33 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type29 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-struct Type34 {
-    num_fields: u16,
-    fields: Vec<Type33>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-enum Type46 {
-    sof0 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof1 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof2 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof3 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof5 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof6 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof7 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof9 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof10 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof11 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof13 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof14 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof15 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-}
-
-struct Type80 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type68,
-    pad: Type66,
-}
-
-struct Type84 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
-}
-
-struct Type85 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type60,
-    crc: u32,
-}
-
-struct Type81 {
-    contents: Vec<Type73>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-struct Type90 {
-    marker: Type28,
-    length: u16,
-    data: Type45,
-}
-
-struct Type100 {
-    codes: Vec<Type21>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type79 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type57,
-    chunks: Vec<Type63>,
-    idat: Vec<Type64>,
-    more_chunks: Vec<Type63>,
-    iend: Type65,
-}
-
-struct Type103 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type78 {
-    soi: Type28,
-    frame: Type55,
-    eoi: Type28,
-}
-
-struct Type92 {
-    marker: Type28,
-    length: u16,
-    data: Type40,
-}
-
-struct Type45 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type44>,
-}
-
-enum Type3 {
-    no(),
-    yes(Vec<Type2>),
-}
-
-struct Type24 {
-    r#final: u8,
-    r#type: u8,
-    data: Type23,
-}
-
-struct Type8 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type55 {
-    initial_segment: Type38,
-    segments: Vec<Type43>,
-    header: Type46,
-    scan: Type52,
-    dnl: Type54,
-    scans: Vec<Type52>,
-}
-
-struct Type15 {
-    code: u16,
-    extra: u8,
-}
-
-enum Type58 {
-    color_type_3 { palette_index: u8 },
-    color_type_6 { red: u16, green: u16, blue: u16 },
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_4 { greyscale: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-struct Type59 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-struct Type48 {
-    num_image_components: u8,
-    image_components: Vec<Type47>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type51 {
-    scan_data: Vec<Type50>,
-    scan_data_stream: Vec<u8>,
-}
-
-struct Type35 {
-    byte_order: Type32,
-    magic: u16,
-    offset: u32,
-    ifd: Type34,
-}
-
-enum Type19 {
-    literal(u8),
-    reference { length: u16, distance: u16 },
-}
-
-struct Type12 {
-    separator: u8,
-}
-
-struct Type72 {
-    name: Type69,
-    mode: Type70,
-    uid: Type70,
-    gid: Type70,
-    size: u32,
-    mtime: Type70,
-    chksum: Type70,
-    typeflag: u8,
-    linkname: Type69,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type71,
-    gname: Type71,
-    devmajor: Type70,
-    devminor: Type70,
-    prefix: Type69,
-    pad: Vec<u8>,
-}
-
-struct Type95 {
-    marker: Type28,
-    length: u16,
-    data: Vec<u8>,
-}
-
-enum Type5 {
-    some {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        flags: u8,
-        delay_time: u16,
-        transparent_color_index: u8,
-        terminator: u8,
-    },
-    none(),
-}
-
-struct Type67 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type66,
-}
-
-enum Type54 {
-    some {
-        marker: Type28,
-        length: u16,
-        data: Type53,
-    },
-    none(),
-}
-
-struct Type42 {
-    restart_interval: u16,
-}
-
-struct Type73 {
-    header: Type72,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type93 {
-    marker: Type28,
-    length: u16,
-    data: Type41,
-}
-
-struct Type104 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type49 {
-    marker: Type28,
-    length: u16,
-    data: Type48,
-}
-
-struct Type31 {
-    identifier: Type29,
-    data: Type30,
-}
-
-enum Type38 {
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-}
-
-struct Type65 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: (),
-    crc: u32,
-}
-
-struct Type70 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-enum Type17 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u16,
-        distance_record: Type16,
-    },
-}
-
-struct Type86 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type62,
-    crc: u32,
-}
-
-struct Type60 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type96 {
-    padding: u8,
-    exif: Type35,
-}
-
-struct Type99 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type22>,
-}
-
-struct Type106 {
-    descriptor: Type6,
-    local_color_table: Type3,
-    data: Type8,
-}
-
-struct Type39 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-enum Type63 {
-    bKGD {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type58,
-        crc: u32,
-    },
-    pHYs {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type59,
-        crc: u32,
-    },
-    PLTE {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Vec<Type2>,
-        crc: u32,
-    },
-    tIME {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type60,
-        crc: u32,
-    },
-    tRNS {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type62,
-        crc: u32,
-    },
-}
-
-enum Type10 {
-    application_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        identifier: Vec<u8>,
-        authentication_code: Vec<u8>,
-        application_data: Vec<Type7>,
-        terminator: u8,
-    },
-    comment_extension {
-        separator: u8,
-        label: u8,
-        comment_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-enum Type14 {
-    no(),
-    yes { string: Vec<u8>, null: u8 },
-}
-
-struct Type18 {
-    code: u16,
-    extra: Type17,
-}
-
-struct Type57 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type56,
-    crc: u32,
-}
-
-struct Type13 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type76 {
-    data: Type75,
-    end: (),
-}
-
-struct Type28 {
-    ff: u8,
-    marker: u8,
-}
-
-enum Type75 {
-    gif {
-        header: Type0,
-        logical_screen: Type4,
-        blocks: Vec<Type11>,
-        trailer: Type12,
-    },
-    gzip(Vec<Type27>),
-    jpeg {
-        soi: Type28,
-        frame: Type55,
-        eoi: Type28,
-    },
-    png {
-        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-        ihdr: Type57,
-        chunks: Vec<Type63>,
-        idat: Vec<Type64>,
-        more_chunks: Vec<Type63>,
-        iend: Type65,
-    },
-    riff {
-        tag: (u8, u8, u8, u8),
-        length: u32,
-        data: Type68,
-        pad: Type66,
-    },
-    tar {
-        contents: Vec<Type73>,
-        __padding: Vec<u8>,
-        __trailing: Vec<u8>,
-    },
-    text(Type74),
-}
-
-struct Type69 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-struct Type77 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type11>,
-    trailer: Type12,
-}
-
-struct Type87 {
-    marker: Type28,
-    length: u16,
-    data: Type31,
-}
-
-struct Type91 {
-    marker: Type28,
-    length: u16,
-    data: Type39,
-}
-
-struct Type97 {
-    xmp: Vec<u8>,
-}
-
-struct Type21 {
-    code: u16,
-    extra: Type20,
-}
-
-enum Type9 {
-    table_based_image {
-        descriptor: Type6,
-        local_color_table: Type3,
-        data: Type8,
-    },
-    plain_text_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        text_grid_left_position: u16,
-        text_grid_top_position: u16,
-        text_grid_width: u16,
-        text_grid_height: u16,
-        character_cell_width: u8,
-        character_cell_height: u8,
-        text_foreground_color_index: u8,
-        text_background_color_index: u8,
-        plain_text_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type53 {
-    num_lines: u16,
-}
-
-struct Type52 {
-    segments: Vec<Type43>,
-    sos: Type49,
-    data: Type51,
-}
-
-struct Type47 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
-}
-
-enum Type62 {
-    color_type_3(Vec<Type61>),
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-struct Type71 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
 struct Type98 {
     version_major: u8,
     version_minor: u8,
@@ -828,182 +989,21 @@ struct Type98 {
     thumbnail_pixels: Vec<Vec<Type2>>,
 }
 
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
-struct Type26 {
-    crc: u32,
+struct Type33 {
+    tag: u16,
+    r#type: u16,
     length: u32,
+    offset_or_data: u32,
 }
 
-enum Type22 {
-    literal(u8),
+struct Type51 {
+    scan_data: Vec<Type50>,
+    scan_data_stream: Vec<u8>,
 }
 
-struct Type40 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-enum Type30 {
-    other(Vec<u8>),
-    jfif {
-        version_major: u8,
-        version_minor: u8,
-        density_units: u8,
-        density_x: u16,
-        density_y: u16,
-        thumbnail_width: u8,
-        thumbnail_height: u8,
-        thumbnail_pixels: Vec<Vec<Type2>>,
-    },
-}
-
-struct Type6 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type44 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-enum Type23 {
-    dynamic_huffman {
-        hlit: u8,
-        hdist: u8,
-        hclen: u8,
-        code_length_alphabet_code_lengths: Vec<u8>,
-        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-        literal_length_alphabet_code_lengths_value: Vec<u8>,
-        distance_alphabet_code_lengths_value: Vec<u8>,
-        codes: Vec<Type18>,
-        codes_values: Vec<Type19>,
-    },
-    fixed_huffman {
-        codes: Vec<Type21>,
-        codes_values: Vec<Type19>,
-    },
-    uncompressed {
-        align: (),
-        len: u16,
-        nlen: u16,
-        bytes: Vec<u8>,
-        codes_values: Vec<Type22>,
-    },
-}
-
-struct Type16 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-enum Type50 {
-    mcu(u8),
-    rst0 { ff: u8, marker: u8 },
-    rst1 { ff: u8, marker: u8 },
-    rst2 { ff: u8, marker: u8 },
-    rst3 { ff: u8, marker: u8 },
-    rst4 { ff: u8, marker: u8 },
-    rst5 { ff: u8, marker: u8 },
-    rst6 { ff: u8, marker: u8 },
-    rst7 { ff: u8, marker: u8 },
-}
-
-enum Type66 {
-    no(u8),
-    yes(),
-}
-
-struct Type56 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-struct Type89 {
-    marker: Type28,
-    length: u16,
-    data: Type53,
-}
-
-struct Type37 {
-    identifier: Type29,
-    data: Type36,
-}
-
-struct Type101 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type18>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type102 {
-    graphic_control_extension: Type5,
-    graphic_rendering_block: Type9,
-}
-
-struct Type105 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type107 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type7>,
-    terminator: u8,
-}
-
-enum Type11 {
-    graphic_block {
-        graphic_control_extension: Type5,
-        graphic_rendering_block: Type9,
-    },
-    special_purpose_block(Type10),
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type59,
-    crc: u32,
+struct Type21 {
+    code: u16,
+    extra: Type20,
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
@@ -1196,12 +1196,7 @@ fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-        ]);
+        let bs = ByteSet::full();
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1249,12 +1244,7 @@ fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-        ]);
+        let bs = ByteSet::full();
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1336,7 +1326,7 @@ fn Decoder27<'input>(
     input: &mut ParseCtxt<'input>,
 ) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::from_bits([0, 0, 512, 0]);
+        let bs = ByteSet::singleton(137);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1345,7 +1335,7 @@ fn Decoder27<'input>(
         }
     };
     let field1 = {
-        let bs = ByteSet::from_bits([0, 65536, 0, 0]);
+        let bs = ByteSet::singleton(80);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1354,7 +1344,7 @@ fn Decoder27<'input>(
         }
     };
     let field2 = {
-        let bs = ByteSet::from_bits([0, 16384, 0, 0]);
+        let bs = ByteSet::singleton(78);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1363,7 +1353,7 @@ fn Decoder27<'input>(
         }
     };
     let field3 = {
-        let bs = ByteSet::from_bits([0, 128, 0, 0]);
+        let bs = ByteSet::singleton(71);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1372,7 +1362,7 @@ fn Decoder27<'input>(
         }
     };
     let field4 = {
-        let bs = ByteSet::from_bits([8192, 0, 0, 0]);
+        let bs = ByteSet::singleton(13);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1381,7 +1371,7 @@ fn Decoder27<'input>(
         }
     };
     let field5 = {
-        let bs = ByteSet::from_bits([1024, 0, 0, 0]);
+        let bs = ByteSet::singleton(10);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1390,7 +1380,7 @@ fn Decoder27<'input>(
         }
     };
     let field6 = {
-        let bs = ByteSet::from_bits([67108864, 0, 0, 0]);
+        let bs = ByteSet::singleton(26);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1399,7 +1389,7 @@ fn Decoder27<'input>(
         }
     };
     let field7 = {
-        let bs = ByteSet::from_bits([1024, 0, 0, 0]);
+        let bs = ByteSet::singleton(10);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1476,7 +1466,7 @@ fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1485,7 +1475,7 @@ fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field1 = {
-        let bs = ByteSet::from_bits([0, 32, 0, 0]);
+        let bs = ByteSet::singleton(69);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1494,7 +1484,7 @@ fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field2 = {
-        let bs = ByteSet::from_bits([0, 16384, 0, 0]);
+        let bs = ByteSet::singleton(78);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1503,7 +1493,7 @@ fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field3 = {
-        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1520,7 +1510,7 @@ fn Decoder34<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1529,7 +1519,7 @@ fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field1 = {
-        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1538,7 +1528,7 @@ fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field2 = {
-        let bs = ByteSet::from_bits([0, 2, 0, 0]);
+        let bs = ByteSet::singleton(65);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1547,7 +1537,7 @@ fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field3 = {
-        let bs = ByteSet::from_bits([0, 1048576, 0, 0]);
+        let bs = ByteSet::singleton(84);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1669,7 +1659,7 @@ fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1678,7 +1668,7 @@ fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field1 = {
-        let bs = ByteSet::from_bits([0, 256, 0, 0]);
+        let bs = ByteSet::singleton(72);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1687,7 +1677,7 @@ fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field2 = {
-        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1696,7 +1686,7 @@ fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let field3 = {
-        let bs = ByteSet::from_bits([0, 262144, 0, 0]);
+        let bs = ByteSet::singleton(82);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1728,7 +1718,7 @@ fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1737,7 +1727,7 @@ fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 16777216]);
+        let bs = ByteSet::singleton(216);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1779,7 +1769,7 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1788,7 +1778,7 @@ fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 33554432]);
+        let bs = ByteSet::singleton(217);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1933,7 +1923,7 @@ fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1942,7 +1932,7 @@ fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 65536]);
+        let bs = ByteSet::singleton(208);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1955,7 +1945,7 @@ fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1964,7 +1954,7 @@ fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 131072]);
+        let bs = ByteSet::singleton(209);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1977,7 +1967,7 @@ fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1986,7 +1976,7 @@ fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 262144]);
+        let bs = ByteSet::singleton(210);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -1999,7 +1989,7 @@ fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2008,7 +1998,7 @@ fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 524288]);
+        let bs = ByteSet::singleton(211);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2021,7 +2011,7 @@ fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2030,7 +2020,7 @@ fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 1048576]);
+        let bs = ByteSet::singleton(212);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2043,7 +2033,7 @@ fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2052,7 +2042,7 @@ fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 2097152]);
+        let bs = ByteSet::singleton(213);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2065,7 +2055,7 @@ fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2074,7 +2064,7 @@ fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 4194304]);
+        let bs = ByteSet::singleton(214);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2087,7 +2077,7 @@ fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2096,7 +2086,7 @@ fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         }
     };
     let marker = {
-        let bs = ByteSet::from_bits([0, 0, 0, 8388608]);
+        let bs = ByteSet::singleton(215);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2785,7 +2775,7 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2798,7 +2788,7 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
     let padding = {
-        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2865,7 +2855,7 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -2976,12 +2966,7 @@ fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder123<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-        ]);
+        let bs = ByteSet::full();
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3099,7 +3084,7 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3143,7 +3128,7 @@ fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
     let separator = {
-        let bs = ByteSet::from_bits([576460752303423488, 0, 0, 0]);
+        let bs = ByteSet::singleton(59);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3175,7 +3160,7 @@ fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
     let separator = {
-        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3184,7 +3169,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let label = {
-        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3193,7 +3178,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let block_size = {
-        let bs = ByteSet::from_bits([2048, 0, 0, 0]);
+        let bs = ByteSet::singleton(11);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3227,7 +3212,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
     let separator = {
-        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3236,7 +3221,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let label = {
-        let bs = ByteSet::from_bits([0, 0, 0, 4611686018427387904]);
+        let bs = ByteSet::singleton(254);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3281,7 +3266,7 @@ fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3293,7 +3278,7 @@ fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type105> {
     let separator = {
-        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3302,7 +3287,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let label = {
-        let bs = ByteSet::from_bits([0, 0, 0, 144115188075855872]);
+        let bs = ByteSet::singleton(249);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3311,7 +3296,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let block_size = {
-        let bs = ByteSet::from_bits([16, 0, 0, 0]);
+        let bs = ByteSet::singleton(4);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3357,7 +3342,7 @@ fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
     let separator = {
-        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3366,7 +3351,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let label = {
-        let bs = ByteSet::from_bits([2, 0, 0, 0]);
+        let bs = ByteSet::singleton(1);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3375,7 +3360,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let block_size = {
-        let bs = ByteSet::from_bits([4096, 0, 0, 0]);
+        let bs = ByteSet::singleton(12);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b
@@ -3415,7 +3400,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
     let separator = {
-        let bs = ByteSet::from_bits([17592186044416, 0, 0, 0]);
+        let bs = ByteSet::singleton(44);
         let b = input.read_byte()?;
         if bs.contains(b) {
             b

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,3001 +1,3478 @@
 use doodle::prelude::*;
 
 struct Type86 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type62,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type62,
+    crc: u32,
 }
 
-enum Type23 { dynamic_huffman {
-hlit: u8,
-hdist: u8,
-hclen: u8,
-code_length_alphabet_code_lengths: Vec<u8>,
-literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-literal_length_alphabet_code_lengths_value: Vec<u8>,
-distance_alphabet_code_lengths_value: Vec<u8>,
-codes: Vec<Type18>,
-codes_values: Vec<Type19>
-}, fixed_huffman {
-codes: Vec<Type21>,
-codes_values: Vec<Type19>
-}, uncompressed {
-align: (),
-len: u16,
-nlen: u16,
-bytes: Vec<u8>,
-codes_values: Vec<Type22>
-} }
+enum Type23 {
+    dynamic_huffman {
+        hlit: u8,
+        hdist: u8,
+        hclen: u8,
+        code_length_alphabet_code_lengths: Vec<u8>,
+        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+        literal_length_alphabet_code_lengths_value: Vec<u8>,
+        distance_alphabet_code_lengths_value: Vec<u8>,
+        codes: Vec<Type18>,
+        codes_values: Vec<Type19>,
+    },
+    fixed_huffman {
+        codes: Vec<Type21>,
+        codes_values: Vec<Type19>,
+    },
+    uncompressed {
+        align: (),
+        len: u16,
+        nlen: u16,
+        bytes: Vec<u8>,
+        codes_values: Vec<Type22>,
+    },
+}
 
 struct Type92 {
-marker: Type28,
-length: u16,
-data: Type40
+    marker: Type28,
+    length: u16,
+    data: Type40,
 }
 
 struct Type84 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Vec<Type2>,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
 }
 
-enum Type30 { other(Vec<u8>), jfif {
-version_major: u8,
-version_minor: u8,
-density_units: u8,
-density_x: u16,
-density_y: u16,
-thumbnail_width: u8,
-thumbnail_height: u8,
-thumbnail_pixels: Vec<Vec<Type2>>
-} }
+enum Type30 {
+    other(Vec<u8>),
+    jfif {
+        version_major: u8,
+        version_minor: u8,
+        density_units: u8,
+        density_x: u16,
+        density_y: u16,
+        thumbnail_width: u8,
+        thumbnail_height: u8,
+        thumbnail_pixels: Vec<Vec<Type2>>,
+    },
+}
 
 struct Type99 {
-align: (),
-len: u16,
-nlen: u16,
-bytes: Vec<u8>,
-codes_values: Vec<Type22>
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type22>,
 }
 
 struct Type39 {
-precision_table_id: u8,
-elements: Vec<u8>
+    precision_table_id: u8,
+    elements: Vec<u8>,
 }
 
 struct Type100 {
-codes: Vec<Type21>,
-codes_values: Vec<Type19>
+    codes: Vec<Type21>,
+    codes_values: Vec<Type19>,
 }
 
 struct Type21 {
-code: u16,
-extra: Type20
+    code: u16,
+    extra: Type20,
 }
 
 struct Type7 {
-len_bytes: u8,
-data: Vec<u8>
+    len_bytes: u8,
+    data: Vec<u8>,
 }
 
-enum Type43 { dqt {
-marker: Type28,
-length: u16,
-data: Type39
-}, dht {
-marker: Type28,
-length: u16,
-data: Type40
-}, dac {
-marker: Type28,
-length: u16,
-data: Type41
-}, dri {
-marker: Type28,
-length: u16,
-data: Type42
-}, app0 {
-marker: Type28,
-length: u16,
-data: Type31
-}, app1 {
-marker: Type28,
-length: u16,
-data: Type37
-}, app2 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app3 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app4 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app5 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app6 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app7 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app8 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app9 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app10 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app11 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app12 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app13 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app14 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, app15 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}, com {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-} }
+enum Type43 {
+    dqt {
+        marker: Type28,
+        length: u16,
+        data: Type39,
+    },
+    dht {
+        marker: Type28,
+        length: u16,
+        data: Type40,
+    },
+    dac {
+        marker: Type28,
+        length: u16,
+        data: Type41,
+    },
+    dri {
+        marker: Type28,
+        length: u16,
+        data: Type42,
+    },
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
+    app2 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app3 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app4 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app5 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app6 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app7 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app8 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app9 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app10 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app11 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app12 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app13 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app14 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    app15 {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+    com {
+        marker: Type28,
+        length: u16,
+        data: Vec<u8>,
+    },
+}
 
 struct Type28 {
-ff: u8,
-marker: u8
+    ff: u8,
+    marker: u8,
 }
 
 struct Type57 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type56,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type56,
+    crc: u32,
 }
 
 struct Type77 {
-header: Type0,
-logical_screen: Type4,
-blocks: Vec<Type11>,
-trailer: Type12
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type11>,
+    trailer: Type12,
 }
 
 struct Type59 {
-pixels_per_unit_x: u32,
-pixels_per_unit_y: u32,
-unit_specifier: u8
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
 }
 
 struct Type67 {
-tag: (u8, u8, u8, u8),
-length: u32,
-data: Vec<u8>,
-pad: Type66
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type66,
 }
 
 struct Type88 {
-marker: Type28,
-length: u16,
-data: Type37
+    marker: Type28,
+    length: u16,
+    data: Type37,
 }
 
 struct Type35 {
-byte_order: Type32,
-magic: u16,
-offset: u32,
-ifd: Type34
+    byte_order: Type32,
+    magic: u16,
+    offset: u32,
+    ifd: Type34,
 }
 
-enum Type11 { graphic_block {
-graphic_control_extension: Type5,
-graphic_rendering_block: Type9
-}, special_purpose_block(Type10) }
+enum Type11 {
+    graphic_block {
+        graphic_control_extension: Type5,
+        graphic_rendering_block: Type9,
+    },
+    special_purpose_block(Type10),
+}
 
 struct Type26 {
-crc: u32,
-length: u32
+    crc: u32,
+    length: u32,
 }
 
 struct Type87 {
-marker: Type28,
-length: u16,
-data: Type31
+    marker: Type28,
+    length: u16,
+    data: Type31,
 }
 
 struct Type93 {
-marker: Type28,
-length: u16,
-data: Type41
+    marker: Type28,
+    length: u16,
+    data: Type41,
 }
 
 struct Type107 {
-separator: u8,
-label: u8,
-block_size: u8,
-text_grid_left_position: u16,
-text_grid_top_position: u16,
-text_grid_width: u16,
-text_grid_height: u16,
-character_cell_width: u8,
-character_cell_height: u8,
-text_foreground_color_index: u8,
-text_background_color_index: u8,
-plain_text_data: Vec<Type7>,
-terminator: u8
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type7>,
+    terminator: u8,
 }
 
-enum Type5 { some {
-separator: u8,
-label: u8,
-block_size: u8,
-flags: u8,
-delay_time: u16,
-transparent_color_index: u8,
-terminator: u8
-}, none() }
+enum Type5 {
+    some {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        flags: u8,
+        delay_time: u16,
+        transparent_color_index: u8,
+        terminator: u8,
+    },
+    none(),
+}
 
 struct Type89 {
-marker: Type28,
-length: u16,
-data: Type53
+    marker: Type28,
+    length: u16,
+    data: Type53,
 }
 
-enum Type10 { application_extension {
-separator: u8,
-label: u8,
-block_size: u8,
-identifier: Vec<u8>,
-authentication_code: Vec<u8>,
-application_data: Vec<Type7>,
-terminator: u8
-}, comment_extension {
-separator: u8,
-label: u8,
-comment_data: Vec<Type7>,
-terminator: u8
-} }
+enum Type10 {
+    application_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        identifier: Vec<u8>,
+        authentication_code: Vec<u8>,
+        application_data: Vec<Type7>,
+        terminator: u8,
+    },
+    comment_extension {
+        separator: u8,
+        label: u8,
+        comment_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
 
 struct Type25 {
-blocks: Vec<Type24>,
-codes: Vec<Type19>,
-inflate: Vec<u8>
+    blocks: Vec<Type24>,
+    codes: Vec<Type19>,
+    inflate: Vec<u8>,
 }
 
 struct Type33 {
-tag: u16,
-r#type: u16,
-length: u32,
-offset_or_data: u32
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
 }
 
 struct Type41 {
-class_table_id: u8,
-value: u8
+    class_table_id: u8,
+    value: u8,
 }
 
 struct Type2 {
-r: u8,
-g: u8,
-b: u8
+    r: u8,
+    g: u8,
+    b: u8,
 }
 
 struct Type45 {
-sample_precision: u8,
-num_lines: u16,
-num_samples_per_line: u16,
-num_image_components: u8,
-image_components: Vec<Type44>
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type44>,
 }
 
 struct Type96 {
-padding: u8,
-exif: Type35
+    padding: u8,
+    exif: Type35,
 }
 
 struct Type98 {
-version_major: u8,
-version_minor: u8,
-density_units: u8,
-density_x: u16,
-density_y: u16,
-thumbnail_width: u8,
-thumbnail_height: u8,
-thumbnail_pixels: Vec<Vec<Type2>>
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
 }
 
-enum Type20 { none(), some {
-length_extra_bits: u8,
-length: u16,
-distance_code: u8,
-distance_record: Type16
-} }
+enum Type20 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u8,
+        distance_record: Type16,
+    },
+}
 
-enum Type36 { other(Vec<u8>), xmp {
-xmp: Vec<u8>
-}, exif {
-padding: u8,
-exif: Type35
-} }
+enum Type36 {
+    other(Vec<u8>),
+    xmp { xmp: Vec<u8> },
+    exif { padding: u8, exif: Type35 },
+}
 
 struct Type72 {
-name: Type69,
-mode: Type70,
-uid: Type70,
-gid: Type70,
-size: u32,
-mtime: Type70,
-chksum: Type70,
-typeflag: u8,
-linkname: Type69,
-magic: (u8, u8, u8, u8, u8, u8),
-version: (u8, u8),
-uname: Type71,
-gname: Type71,
-devmajor: Type70,
-devminor: Type70,
-prefix: Type69,
-pad: Vec<u8>
+    name: Type69,
+    mode: Type70,
+    uid: Type70,
+    gid: Type70,
+    size: u32,
+    mtime: Type70,
+    chksum: Type70,
+    typeflag: u8,
+    linkname: Type69,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type71,
+    gname: Type71,
+    devmajor: Type70,
+    devminor: Type70,
+    prefix: Type69,
+    pad: Vec<u8>,
 }
 
 struct Type82 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type58,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type58,
+    crc: u32,
 }
 
 struct Type42 {
-restart_interval: u16
+    restart_interval: u16,
 }
 
-enum Type19 { literal(u8), reference {
-length: u16,
-distance: u16
-} }
+enum Type19 {
+    literal(u8),
+    reference { length: u16, distance: u16 },
+}
 
 struct Type44 {
-id: u8,
-sampling_factor: u8,
-quantization_table_id: u8
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
 }
 
 struct Type60 {
-year: u16,
-month: u8,
-day: u8,
-hour: u8,
-minute: u8,
-second: u8
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
 }
 
 struct Type6 {
-separator: u8,
-image_left_position: u16,
-image_top_position: u16,
-image_width: u16,
-image_height: u16,
-flags: u8
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
 }
 
-enum Type54 { some {
-marker: Type28,
-length: u16,
-data: Type53
-}, none() }
+enum Type54 {
+    some {
+        marker: Type28,
+        length: u16,
+        data: Type53,
+    },
+    none(),
+}
 
 struct Type31 {
-identifier: Type29,
-data: Type30
+    identifier: Type29,
+    data: Type30,
 }
 
 struct Type103 {
-separator: u8,
-label: u8,
-block_size: u8,
-identifier: Vec<u8>,
-authentication_code: Vec<u8>,
-application_data: Vec<Type7>,
-terminator: u8
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type7>,
+    terminator: u8,
 }
 
 struct Type0 {
-signature: (u8, u8, u8),
-version: Vec<u8>
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
 }
 
 struct Type55 {
-initial_segment: Type38,
-segments: Vec<Type43>,
-header: Type46,
-scan: Type52,
-dnl: Type54,
-scans: Vec<Type52>
+    initial_segment: Type38,
+    segments: Vec<Type43>,
+    header: Type46,
+    scan: Type52,
+    dnl: Type54,
+    scans: Vec<Type52>,
 }
 
-enum Type38 { app0 {
-marker: Type28,
-length: u16,
-data: Type31
-}, app1 {
-marker: Type28,
-length: u16,
-data: Type37
-} }
+enum Type38 {
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
+}
 
 struct Type51 {
-scan_data: Vec<Type50>,
-scan_data_stream: Vec<u8>
+    scan_data: Vec<Type50>,
+    scan_data_stream: Vec<u8>,
 }
 
-enum Type58 { color_type_3 {
-palette_index: u8
-}, color_type_6 {
-red: u16,
-green: u16,
-blue: u16
-}, color_type_2 {
-red: u16,
-green: u16,
-blue: u16
-}, color_type_4 {
-greyscale: u16
-}, color_type_0 {
-greyscale: u16
-} }
+enum Type58 {
+    color_type_3 { palette_index: u8 },
+    color_type_6 { red: u16, green: u16, blue: u16 },
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_4 { greyscale: u16 },
+    color_type_0 { greyscale: u16 },
+}
 
 struct Type13 {
-magic: (u8, u8),
-method: u8,
-file_flags: u8,
-timestamp: u32,
-compression_flags: u8,
-os_id: u8
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
 }
 
 struct Type49 {
-marker: Type28,
-length: u16,
-data: Type48
+    marker: Type28,
+    length: u16,
+    data: Type48,
 }
 
-enum Type66 { no(u8), yes() }
+enum Type66 {
+    no(u8),
+    yes(),
+}
 
 struct Type68 {
-tag: (u8, u8, u8, u8),
-chunks: Vec<Type67>
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type67>,
 }
 
 struct Type81 {
-contents: Vec<Type73>,
-__padding: Vec<u8>,
-__trailing: Vec<u8>
+    contents: Vec<Type73>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
 }
 
 struct Type101 {
-hlit: u8,
-hdist: u8,
-hclen: u8,
-code_length_alphabet_code_lengths: Vec<u8>,
-literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-literal_length_alphabet_code_lengths_value: Vec<u8>,
-distance_alphabet_code_lengths_value: Vec<u8>,
-codes: Vec<Type18>,
-codes_values: Vec<Type19>
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type18>,
+    codes_values: Vec<Type19>,
 }
 
 struct Type105 {
-separator: u8,
-label: u8,
-block_size: u8,
-flags: u8,
-delay_time: u16,
-transparent_color_index: u8,
-terminator: u8
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
 }
 
 struct Type12 {
-separator: u8
+    separator: u8,
 }
 
 struct Type106 {
-descriptor: Type6,
-local_color_table: Type3,
-data: Type8
+    descriptor: Type6,
+    local_color_table: Type3,
+    data: Type8,
 }
 
-enum Type9 { table_based_image {
-descriptor: Type6,
-local_color_table: Type3,
-data: Type8
-}, plain_text_extension {
-separator: u8,
-label: u8,
-block_size: u8,
-text_grid_left_position: u16,
-text_grid_top_position: u16,
-text_grid_width: u16,
-text_grid_height: u16,
-character_cell_width: u8,
-character_cell_height: u8,
-text_foreground_color_index: u8,
-text_background_color_index: u8,
-plain_text_data: Vec<Type7>,
-terminator: u8
-} }
+enum Type9 {
+    table_based_image {
+        descriptor: Type6,
+        local_color_table: Type3,
+        data: Type8,
+    },
+    plain_text_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        text_grid_left_position: u16,
+        text_grid_top_position: u16,
+        text_grid_width: u16,
+        text_grid_height: u16,
+        character_cell_width: u8,
+        character_cell_height: u8,
+        text_foreground_color_index: u8,
+        text_background_color_index: u8,
+        plain_text_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
 
 struct Type56 {
-width: u32,
-height: u32,
-bit_depth: u8,
-color_type: u8,
-compression_method: u8,
-filter_method: u8,
-interlace_method: u8
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
 }
 
-enum Type32 { le(u8, u8), be(u8, u8) }
+enum Type32 {
+    le(u8, u8),
+    be(u8, u8),
+}
 
 struct Type8 {
-lzw_min_code_size: u8,
-image_data: Vec<Type7>,
-terminator: u8
+    lzw_min_code_size: u8,
+    image_data: Vec<Type7>,
+    terminator: u8,
 }
 
 struct Type24 {
-r#final: u8,
-r#type: u8,
-data: Type23
+    r#final: u8,
+    r#type: u8,
+    data: Type23,
 }
 
-enum Type50 { mcu(u8), rst0 {
-ff: u8,
-marker: u8
-}, rst1 {
-ff: u8,
-marker: u8
-}, rst2 {
-ff: u8,
-marker: u8
-}, rst3 {
-ff: u8,
-marker: u8
-}, rst4 {
-ff: u8,
-marker: u8
-}, rst5 {
-ff: u8,
-marker: u8
-}, rst6 {
-ff: u8,
-marker: u8
-}, rst7 {
-ff: u8,
-marker: u8
-} }
+enum Type50 {
+    mcu(u8),
+    rst0 { ff: u8, marker: u8 },
+    rst1 { ff: u8, marker: u8 },
+    rst2 { ff: u8, marker: u8 },
+    rst3 { ff: u8, marker: u8 },
+    rst4 { ff: u8, marker: u8 },
+    rst5 { ff: u8, marker: u8 },
+    rst6 { ff: u8, marker: u8 },
+    rst7 { ff: u8, marker: u8 },
+}
 
 struct Type94 {
-marker: Type28,
-length: u16,
-data: Type42
+    marker: Type28,
+    length: u16,
+    data: Type42,
 }
 
 struct Type83 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type59,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type59,
+    crc: u32,
 }
 
 struct Type53 {
-num_lines: u16
+    num_lines: u16,
 }
 
 struct Type79 {
-signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-ihdr: Type57,
-chunks: Vec<Type63>,
-idat: Vec<Type64>,
-more_chunks: Vec<Type63>,
-iend: Type65
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type57,
+    chunks: Vec<Type63>,
+    idat: Vec<Type64>,
+    more_chunks: Vec<Type63>,
+    iend: Type65,
 }
 
 struct Type85 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type60,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type60,
+    crc: u32,
 }
 
 struct Type4 {
-descriptor: Type1,
-global_color_table: Type3
+    descriptor: Type1,
+    global_color_table: Type3,
 }
 
 struct Type15 {
-code: u16,
-extra: u8
+    code: u16,
+    extra: u8,
 }
 
-enum Type17 { none(), some {
-length_extra_bits: u8,
-length: u16,
-distance_code: u16,
-distance_record: Type16
-} }
+enum Type17 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u16,
+        distance_record: Type16,
+    },
+}
 
-enum Type22 { literal(u8) }
+enum Type22 {
+    literal(u8),
+}
 
 struct Type29 {
-string: Vec<u8>,
-null: u8
+    string: Vec<u8>,
+    null: u8,
 }
 
-enum Type3 { no(), yes(Vec<Type2>) }
+enum Type3 {
+    no(),
+    yes(Vec<Type2>),
+}
 
 struct Type37 {
-identifier: Type29,
-data: Type36
+    identifier: Type29,
+    data: Type36,
 }
 
 struct Type73 {
-header: Type72,
-file: Vec<u8>,
-__padding: ()
+    header: Type72,
+    file: Vec<u8>,
+    __padding: (),
 }
 
 struct Type102 {
-graphic_control_extension: Type5,
-graphic_rendering_block: Type9
+    graphic_control_extension: Type5,
+    graphic_rendering_block: Type9,
 }
 
 struct Type69 {
-string: Vec<u8>,
-__padding: Vec<u8>
+    string: Vec<u8>,
+    __padding: Vec<u8>,
 }
 
 struct Type104 {
-separator: u8,
-label: u8,
-comment_data: Vec<Type7>,
-terminator: u8
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type7>,
+    terminator: u8,
 }
 
 struct Type48 {
-num_image_components: u8,
-image_components: Vec<Type47>,
-start_spectral_selection: u8,
-end_spectral_selection: u8,
-approximation_bit_position: u8
+    num_image_components: u8,
+    image_components: Vec<Type47>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
 }
 
-enum Type62 { color_type_3(Vec<Type61>), color_type_2 {
-red: u16,
-green: u16,
-blue: u16
-}, color_type_0 {
-greyscale: u16
-} }
+enum Type62 {
+    color_type_3(Vec<Type61>),
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_0 { greyscale: u16 },
+}
 
 struct Type52 {
-segments: Vec<Type43>,
-sos: Type49,
-data: Type51
+    segments: Vec<Type43>,
+    sos: Type49,
+    data: Type51,
 }
 
-enum Type75 { gif {
-header: Type0,
-logical_screen: Type4,
-blocks: Vec<Type11>,
-trailer: Type12
-}, gzip(Vec<Type27>), jpeg {
-soi: Type28,
-frame: Type55,
-eoi: Type28
-}, png {
-signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-ihdr: Type57,
-chunks: Vec<Type63>,
-idat: Vec<Type64>,
-more_chunks: Vec<Type63>,
-iend: Type65
-}, riff {
-tag: (u8, u8, u8, u8),
-length: u32,
-data: Type68,
-pad: Type66
-}, tar {
-contents: Vec<Type73>,
-__padding: Vec<u8>,
-__trailing: Vec<u8>
-}, text(Type74) }
+enum Type75 {
+    gif {
+        header: Type0,
+        logical_screen: Type4,
+        blocks: Vec<Type11>,
+        trailer: Type12,
+    },
+    gzip(Vec<Type27>),
+    jpeg {
+        soi: Type28,
+        frame: Type55,
+        eoi: Type28,
+    },
+    png {
+        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+        ihdr: Type57,
+        chunks: Vec<Type63>,
+        idat: Vec<Type64>,
+        more_chunks: Vec<Type63>,
+        iend: Type65,
+    },
+    riff {
+        tag: (u8, u8, u8, u8),
+        length: u32,
+        data: Type68,
+        pad: Type66,
+    },
+    tar {
+        contents: Vec<Type73>,
+        __padding: Vec<u8>,
+        __trailing: Vec<u8>,
+    },
+    text(Type74),
+}
 
 struct Type91 {
-marker: Type28,
-length: u16,
-data: Type39
+    marker: Type28,
+    length: u16,
+    data: Type39,
 }
 
 struct Type70 {
-string: Vec<u8>,
-__nul_or_wsp: u8,
-__padding: Vec<u8>
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
 }
 
 struct Type61 {
-palette_index: u8
+    palette_index: u8,
 }
 
-enum Type46 { sof0 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof1 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof2 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof3 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof5 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof6 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof7 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof9 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof10 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof11 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof13 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof14 {
-marker: Type28,
-length: u16,
-data: Type45
-}, sof15 {
-marker: Type28,
-length: u16,
-data: Type45
-} }
+enum Type46 {
+    sof0 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof1 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof2 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof3 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof5 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof6 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof7 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof9 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof10 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof11 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof13 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof14 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof15 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+}
 
 struct Type71 {
-string: Vec<u8>,
-padding: Vec<u8>
+    string: Vec<u8>,
+    padding: Vec<u8>,
 }
 
 struct Type16 {
-distance_extra_bits: u16,
-distance: u16
+    distance_extra_bits: u16,
+    distance: u16,
 }
 
 struct Type40 {
-class_table_id: u8,
-num_codes: Vec<u8>,
-values: Vec<u8>
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
 }
 
 struct Type47 {
-component_selector: u8,
-entropy_coding_table_ids: u8
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
 struct Type65 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: (),
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
 }
 
 struct Type80 {
-tag: (u8, u8, u8, u8),
-length: u32,
-data: Type68,
-pad: Type66
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type68,
+    pad: Type66,
 }
 
 struct Type90 {
-marker: Type28,
-length: u16,
-data: Type45
+    marker: Type28,
+    length: u16,
+    data: Type45,
 }
 
 struct Type27 {
-header: Type13,
-fname: Type14,
-data: Type25,
-footer: Type26
+    header: Type13,
+    fname: Type14,
+    data: Type25,
+    footer: Type26,
 }
 
-enum Type74 { ascii(Vec<u8>), utf8(Vec<char>) }
+enum Type74 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
 
 struct Type95 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
+    marker: Type28,
+    length: u16,
+    data: Vec<u8>,
 }
 
 struct Type97 {
-xmp: Vec<u8>
+    xmp: Vec<u8>,
 }
 
 struct Type1 {
-screen_width: u16,
-screen_height: u16,
-flags: u8,
-bg_color_index: u8,
-pixel_aspect_ratio: u8
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
 }
 
-enum Type14 { no(), yes {
-string: Vec<u8>,
-null: u8
-} }
+enum Type14 {
+    no(),
+    yes { string: Vec<u8>, null: u8 },
+}
 
 struct Type76 {
-data: Type75,
-end: ()
+    data: Type75,
+    end: (),
 }
 
 struct Type64 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Vec<u8>,
-crc: u32
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<u8>,
+    crc: u32,
 }
 
 struct Type78 {
-soi: Type28,
-frame: Type55,
-eoi: Type28
+    soi: Type28,
+    frame: Type55,
+    eoi: Type28,
 }
 
-enum Type63 { bKGD {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type58,
-crc: u32
-}, pHYs {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type59,
-crc: u32
-}, PLTE {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Vec<Type2>,
-crc: u32
-}, tIME {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type60,
-crc: u32
-}, tRNS {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type62,
-crc: u32
-} }
+enum Type63 {
+    bKGD {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type58,
+        crc: u32,
+    },
+    pHYs {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type59,
+        crc: u32,
+    },
+    PLTE {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Vec<Type2>,
+        crc: u32,
+    },
+    tIME {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type60,
+        crc: u32,
+    },
+    tRNS {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type62,
+        crc: u32,
+    },
+}
 
 struct Type18 {
-code: u16,
-extra: Type17
+    code: u16,
+    extra: Type17,
 }
 
 struct Type34 {
-num_fields: u16,
-fields: Vec<Type33>,
-next_ifd_offset: u32,
-next_ifd: Vec<u8>
+    num_fields: u16,
+    fields: Vec<Type33>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
-return Some(Decoder1(scope, input)?);
+    return Some(Decoder1(scope, input)?);
 }
 
 fn Decoder1<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(6)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let end = if input.read_byte().is_none() {
-()
-} else {
-return None;
-};
-return Some(Type76 { data, end });
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let end = if input.read_byte().is_none() {
+        ()
+    } else {
+        return None;
+    };
+    return Some(Type76 { data, end });
 }
 
 fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type77> {
-let header = Decoder128(scope, input)?;
-let logical_screen = Decoder129(scope, input)?;
-let blocks = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let trailer = Decoder131(scope, input)?;
-return Some(Type77 { header, logical_screen, blocks, trailer });
+    let header = Decoder128(scope, input)?;
+    let logical_screen = Decoder129(scope, input)?;
+    let blocks = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let trailer = Decoder131(scope, input)?;
+    return Some(Type77 {
+        header,
+        logical_screen,
+        blocks,
+        trailer,
+    });
 }
 
 fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<Type27>> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder4<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type78> {
-let soi = Decoder45(scope, input)?;
-let frame = Decoder46(scope, input)?;
-let eoi = Decoder47(scope, input)?;
-return Some(Type78 { soi, frame, eoi });
+    let soi = Decoder45(scope, input)?;
+    let frame = Decoder46(scope, input)?;
+    let eoi = Decoder47(scope, input)?;
+    return Some(Type78 { soi, frame, eoi });
 }
 
 fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type79> {
-let signature = Decoder27(scope, input)?;
-let ihdr = Decoder28(scope, input)?;
-let chunks = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let idat = {
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let more_chunks = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let iend = Decoder31(scope, input)?;
-return Some(Type79 { signature, ihdr, chunks, idat, more_chunks, iend });
+    let signature = Decoder27(scope, input)?;
+    let ihdr = Decoder28(scope, input)?;
+    let chunks = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let idat = {
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let more_chunks = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let iend = Decoder31(scope, input)?;
+    return Some(Type79 {
+        signature,
+        ihdr,
+        chunks,
+        idat,
+        more_chunks,
+        iend,
+    });
 }
 
 fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder23(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let pad = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type80 { tag, length, data, pad });
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder23(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let pad = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type80 {
+        tag,
+        length,
+        data,
+        pad,
+    });
 }
 
 fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
-let contents = {
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let __padding = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let __trailing = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type81 { contents, __padding, __trailing });
+    let contents = {
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let __padding = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let __trailing = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type81 {
+        contents,
+        __padding,
+        __trailing,
+    });
 }
 
 fn Decoder8<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type74> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(6)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<char>> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder12<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder13<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type73> {
-let header = Decoder15(scope, input)?;
-let file = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let __padding = {
-while input.offset() % 512 != 0 {
-let _ = input.read_byte()?;
-}
-()
-};
-return Some(Type73 { header, file, __padding });
+    let header = Decoder15(scope, input)?;
+    let file = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let __padding = {
+        while input.offset() % 512 != 0 {
+            let _ = input.read_byte()?;
+        }
+        ()
+    };
+    return Some(Type73 {
+        header,
+        file,
+        __padding,
+    });
 }
 
 fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type72> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+        ]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let __padding = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type69 { string, __padding });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let __padding = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type69 { string, __padding });
 }
 
 fn Decoder18<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([71776119061217280, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([71776119061217280, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([4294967297, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([4294967297, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+        ]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let __padding = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type69 { string, __padding });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let __padding = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type69 { string, __padding });
 }
 
 fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type71> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let padding = {
-let tmp = r#"invoke_decoder @ Discriminant(11)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type71 { string, padding });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let padding = {
+        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type71 { string, padding });
 }
 
 fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type68> {
-let tag = Decoder25(scope, input)?;
-let chunks = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type68 { tag, chunks });
+    let tag = Decoder25(scope, input)?;
+    let chunks = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type68 { tag, chunks });
 }
 
 fn Decoder25<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let field0 = Decoder20(scope, input)?;
-let field1 = Decoder20(scope, input)?;
-let field2 = Decoder20(scope, input)?;
-let field3 = Decoder20(scope, input)?;
-return Some((field0, field1, field2, field3));
+    let field0 = Decoder20(scope, input)?;
+    let field1 = Decoder20(scope, input)?;
+    let field2 = Decoder20(scope, input)?;
+    let field3 = Decoder20(scope, input)?;
+    return Some((field0, field1, field2, field3));
 }
 
 fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type67> {
-let tag = Decoder25(scope, input)?;
-let length = Decoder23(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let pad = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type67 { tag, length, data, pad });
+    let tag = Decoder25(scope, input)?;
+    let length = Decoder23(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let pad = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type67 {
+        tag,
+        length,
+        data,
+        pad,
+    });
 }
 
-fn Decoder27<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
-let field0 = {
-let bs = ByteSet::from_bits([0, 0, 512, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field1 = {
-let bs = ByteSet::from_bits([0, 65536, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field2 = {
-let bs = ByteSet::from_bits([0, 16384, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field3 = {
-let bs = ByteSet::from_bits([0, 128, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field4 = {
-let bs = ByteSet::from_bits([8192, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field5 = {
-let bs = ByteSet::from_bits([1024, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field6 = {
-let bs = ByteSet::from_bits([67108864, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field7 = {
-let bs = ByteSet::from_bits([1024, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some((field0, field1, field2, field3, field4, field5, field6, field7));
+fn Decoder27<'input>(
+    scope: &mut Scope,
+    input: &mut ParseCtxt<'input>,
+) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
+    let field0 = {
+        let bs = ByteSet::from_bits([0, 0, 512, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field1 = {
+        let bs = ByteSet::from_bits([0, 65536, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field2 = {
+        let bs = ByteSet::from_bits([0, 16384, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field3 = {
+        let bs = ByteSet::from_bits([0, 128, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field4 = {
+        let bs = ByteSet::from_bits([8192, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field5 = {
+        let bs = ByteSet::from_bits([1024, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field6 = {
+        let bs = ByteSet::from_bits([67108864, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field7 = {
+        let bs = ByteSet::from_bits([1024, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some((
+        field0, field1, field2, field3, field4, field5, field6, field7,
+    ));
 }
 
 fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
-let length = Decoder32(scope, input)?;
-let tag = Decoder43(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type57 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = Decoder43(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type57 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder30<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
-let length = Decoder32(scope, input)?;
-let tag = Decoder35(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type64 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = Decoder35(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type64 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
-let length = Decoder32(scope, input)?;
-let tag = Decoder33(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type65 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = Decoder33(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type65 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let field0 = {
-let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field1 = {
-let bs = ByteSet::from_bits([0, 32, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field2 = {
-let bs = ByteSet::from_bits([0, 16384, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field3 = {
-let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some((field0, field1, field2, field3));
+    let field0 = {
+        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field1 = {
+        let bs = ByteSet::from_bits([0, 32, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field2 = {
+        let bs = ByteSet::from_bits([0, 16384, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field3 = {
+        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some((field0, field1, field2, field3));
 }
 
 fn Decoder34<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<()> {
-Some(())
+    Some(())
 }
 
 fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let field0 = {
-let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field1 = {
-let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field2 = {
-let bs = ByteSet::from_bits([0, 2, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field3 = {
-let bs = ByteSet::from_bits([0, 1048576, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some((field0, field1, field2, field3));
+    let field0 = {
+        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field1 = {
+        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field2 = {
+        let bs = ByteSet::from_bits([0, 2, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field3 = {
+        let bs = ByteSet::from_bits([0, 1048576, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some((field0, field1, field2, field3));
 }
 
 fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type82> {
-let length = Decoder32(scope, input)?;
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type82 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type82 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type83> {
-let length = Decoder32(scope, input)?;
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type83 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type83 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type84> {
-let length = Decoder32(scope, input)?;
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type84 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type84 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type85> {
-let length = Decoder32(scope, input)?;
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type85 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type85 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type86> {
-let length = Decoder32(scope, input)?;
-let tag = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let crc = Decoder32(scope, input)?;
-return Some(Type86 { length, tag, data, crc });
+    let length = Decoder32(scope, input)?;
+    let tag = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let crc = Decoder32(scope, input)?;
+    return Some(Type86 {
+        length,
+        tag,
+        data,
+        crc,
+    });
 }
 
 fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let field0 = {
-let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field1 = {
-let bs = ByteSet::from_bits([0, 256, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field2 = {
-let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let field3 = {
-let bs = ByteSet::from_bits([0, 262144, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some((field0, field1, field2, field3));
+    let field0 = {
+        let bs = ByteSet::from_bits([0, 512, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field1 = {
+        let bs = ByteSet::from_bits([0, 256, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field2 = {
+        let bs = ByteSet::from_bits([0, 16, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let field3 = {
+        let bs = ByteSet::from_bits([0, 262144, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some((field0, field1, field2, field3));
 }
 
 fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type56> {
-let width = Decoder32(scope, input)?;
-let height = Decoder32(scope, input)?;
-let bit_depth = Decoder16(scope, input)?;
-let color_type = Decoder16(scope, input)?;
-let compression_method = Decoder16(scope, input)?;
-let filter_method = Decoder16(scope, input)?;
-let interlace_method = Decoder16(scope, input)?;
-return Some(Type56 { width, height, bit_depth, color_type, compression_method, filter_method, interlace_method });
+    let width = Decoder32(scope, input)?;
+    let height = Decoder32(scope, input)?;
+    let bit_depth = Decoder16(scope, input)?;
+    let color_type = Decoder16(scope, input)?;
+    let compression_method = Decoder16(scope, input)?;
+    let filter_method = Decoder16(scope, input)?;
+    let interlace_method = Decoder16(scope, input)?;
+    return Some(Type56 {
+        width,
+        height,
+        bit_depth,
+        color_type,
+        compression_method,
+        filter_method,
+        interlace_method,
+    });
 }
 
 fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 16777216]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 16777216]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
-let initial_segment = {
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let segments = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let header = Decoder51(scope, input)?;
-let scan = Decoder52(scope, input)?;
-let dnl = {
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let scans = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type55 { initial_segment, segments, header, scan, dnl, scans });
+    let initial_segment = {
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let segments = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let header = Decoder51(scope, input)?;
+    let scan = Decoder52(scope, input)?;
+    let dnl = {
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let scans = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type55 {
+        initial_segment,
+        segments,
+        header,
+        scan,
+        dnl,
+        scans,
+    });
 }
 
 fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 33554432]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 33554432]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type87> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type87 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type87 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type88 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type88 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
-let segments = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let sos = Decoder55(scope, input)?;
-let data = Decoder69(scope, input)?;
-return Some(Type52 { segments, sos, data });
+    let segments = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let sos = Decoder55(scope, input)?;
+    let data = Decoder69(scope, input)?;
+    return Some(Type52 {
+        segments,
+        sos,
+        data,
+    });
 }
 
 fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type89> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type89 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type89 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
-let segments = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let sos = Decoder55(scope, input)?;
-let data = Decoder56(scope, input)?;
-return Some(Type52 { segments, sos, data });
+    let segments = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let sos = Decoder55(scope, input)?;
+    let data = Decoder56(scope, input)?;
+    return Some(Type52 {
+        segments,
+        sos,
+        data,
+    });
 }
 
 fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type49> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type49 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type49 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
-let scan_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let scan_data_stream = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type51 { scan_data, scan_data_stream });
+    let scan_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let scan_data_stream = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type51 {
+        scan_data,
+        scan_data_stream,
+    });
 }
 
 fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 65536]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 65536]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 131072]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 131072]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 262144]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 262144]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 524288]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 524288]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 1048576]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 1048576]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 2097152]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 2097152]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 4194304]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 4194304]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
-let ff = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let marker = {
-let bs = ByteSet::from_bits([0, 0, 0, 8388608]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type28 { ff, marker });
+    let ff = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let marker = {
+        let bs = ByteSet::from_bits([0, 0, 0, 8388608]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type28 { ff, marker });
 }
 
 fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type48> {
-let num_image_components = Decoder16(scope, input)?;
-let image_components = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let start_spectral_selection = Decoder16(scope, input)?;
-let end_spectral_selection = Decoder16(scope, input)?;
-let approximation_bit_position = Decoder16(scope, input)?;
-return Some(Type48 { num_image_components, image_components, start_spectral_selection, end_spectral_selection, approximation_bit_position });
+    let num_image_components = Decoder16(scope, input)?;
+    let image_components = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let start_spectral_selection = Decoder16(scope, input)?;
+    let end_spectral_selection = Decoder16(scope, input)?;
+    let approximation_bit_position = Decoder16(scope, input)?;
+    return Some(Type48 {
+        num_image_components,
+        image_components,
+        start_spectral_selection,
+        end_spectral_selection,
+        approximation_bit_position,
+    });
 }
 
 fn Decoder67<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
-let component_selector = Decoder16(scope, input)?;
-let entropy_coding_table_ids = Decoder16(scope, input)?;
-return Some(Type47 { component_selector, entropy_coding_table_ids });
+    let component_selector = Decoder16(scope, input)?;
+    let entropy_coding_table_ids = Decoder16(scope, input)?;
+    return Some(Type47 {
+        component_selector,
+        entropy_coding_table_ids,
+    });
 }
 
 fn Decoder68<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type53> {
-let num_lines = Decoder42(scope, input)?;
-return Some(Type53 { num_lines });
+    let num_lines = Decoder42(scope, input)?;
+    return Some(Type53 { num_lines });
 }
 
 fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
-let scan_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let scan_data_stream = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type51 { scan_data, scan_data_stream });
+    let scan_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let scan_data_stream = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type51 {
+        scan_data,
+        scan_data_stream,
+    });
 }
 
 fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder82<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type90 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type90 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type45> {
-let sample_precision = Decoder16(scope, input)?;
-let num_lines = Decoder42(scope, input)?;
-let num_samples_per_line = Decoder42(scope, input)?;
-let num_image_components = Decoder16(scope, input)?;
-let image_components = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type45 { sample_precision, num_lines, num_samples_per_line, num_image_components, image_components });
+    let sample_precision = Decoder16(scope, input)?;
+    let num_lines = Decoder42(scope, input)?;
+    let num_samples_per_line = Decoder42(scope, input)?;
+    let num_image_components = Decoder16(scope, input)?;
+    let image_components = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type45 {
+        sample_precision,
+        num_lines,
+        num_samples_per_line,
+        num_image_components,
+        image_components,
+    });
 }
 
 fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type44> {
-let id = Decoder16(scope, input)?;
-let sampling_factor = Decoder16(scope, input)?;
-let quantization_table_id = Decoder16(scope, input)?;
-return Some(Type44 { id, sampling_factor, quantization_table_id });
+    let id = Decoder16(scope, input)?;
+    let sampling_factor = Decoder16(scope, input)?;
+    let quantization_table_id = Decoder16(scope, input)?;
+    return Some(Type44 {
+        id,
+        sampling_factor,
+        quantization_table_id,
+    });
 }
 
 fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type91> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type91 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type91 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type92> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type92 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type92 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type93 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type93 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type94> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type94 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type94 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
-let marker = {
-let tmp = r#"invoke_decoder @ Discriminant(9)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let length = Decoder42(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(17)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type95 { marker, length, data });
+    let marker = {
+        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let length = Decoder42(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type95 {
+        marker,
+        length,
+        data,
+    });
 }
 
 fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
-let restart_interval = Decoder42(scope, input)?;
-return Some(Type42 { restart_interval });
+    let restart_interval = Decoder42(scope, input)?;
+    return Some(Type42 { restart_interval });
 }
 
 fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type41> {
-let class_table_id = Decoder16(scope, input)?;
-let value = Decoder16(scope, input)?;
-return Some(Type41 { class_table_id, value });
+    let class_table_id = Decoder16(scope, input)?;
+    let value = Decoder16(scope, input)?;
+    return Some(Type41 {
+        class_table_id,
+        value,
+    });
 }
 
 fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type40> {
-let class_table_id = Decoder16(scope, input)?;
-let num_codes = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let values = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type40 { class_table_id, num_codes, values });
+    let class_table_id = Decoder16(scope, input)?;
+    let num_codes = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let values = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type40 {
+        class_table_id,
+        num_codes,
+        values,
+    });
 }
 
 fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type39> {
-let precision_table_id = Decoder16(scope, input)?;
-let elements = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type39 { precision_table_id, elements });
+    let precision_table_id = Decoder16(scope, input)?;
+    let elements = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type39 {
+        precision_table_id,
+        elements,
+    });
 }
 
 fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type37> {
-let identifier = Decoder109(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type37 { identifier, data });
+    let identifier = Decoder109(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type37 { identifier, data });
 }
 
 fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let null = {
-let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type29 { string, null });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let null = {
+        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type29 { string, null });
 }
 
 fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
-let padding = {
-let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let exif = Decoder112(scope, input)?;
-return Some(Type96 { padding, exif });
+    let padding = {
+        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let exif = Decoder112(scope, input)?;
+    return Some(Type96 { padding, exif });
 }
 
 fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type97> {
-let xmp = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type97 { xmp });
+    let xmp = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type97 { xmp });
 }
 
 fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type35> {
-let byte_order = {
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let magic = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let offset = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let ifd = {
-let tmp = r#"invoke_decoder @ Discriminant(19)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type35 { byte_order, magic, offset, ifd });
+    let byte_order = {
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let magic = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let offset = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let ifd = {
+        let tmp = r#"invoke_decoder @ Discriminant(19)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type35 {
+        byte_order,
+        magic,
+        offset,
+        ifd,
+    });
 }
 
 fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type31> {
-let identifier = Decoder115(scope, input)?;
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type31 { identifier, data });
+    let identifier = Decoder115(scope, input)?;
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type31 { identifier, data });
 }
 
 fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let null = {
-let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type29 { string, null });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let null = {
+        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type29 { string, null });
 }
 
 fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type98> {
-let version_major = Decoder16(scope, input)?;
-let version_minor = Decoder16(scope, input)?;
-let density_units = Decoder16(scope, input)?;
-let density_x = Decoder42(scope, input)?;
-let density_y = Decoder42(scope, input)?;
-let thumbnail_width = Decoder16(scope, input)?;
-let thumbnail_height = Decoder16(scope, input)?;
-let thumbnail_pixels = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type98 { version_major, version_minor, density_units, density_x, density_y, thumbnail_width, thumbnail_height, thumbnail_pixels });
+    let version_major = Decoder16(scope, input)?;
+    let version_minor = Decoder16(scope, input)?;
+    let density_units = Decoder16(scope, input)?;
+    let density_x = Decoder42(scope, input)?;
+    let density_y = Decoder42(scope, input)?;
+    let thumbnail_width = Decoder16(scope, input)?;
+    let thumbnail_height = Decoder16(scope, input)?;
+    let thumbnail_pixels = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type98 {
+        version_major,
+        version_minor,
+        density_units,
+        density_x,
+        density_y,
+        thumbnail_width,
+        thumbnail_height,
+        thumbnail_pixels,
+    });
 }
 
 fn Decoder117<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
-let r = Decoder16(scope, input)?;
-let g = Decoder16(scope, input)?;
-let b = Decoder16(scope, input)?;
-return Some(Type2 { r, g, b });
+    let r = Decoder16(scope, input)?;
+    let g = Decoder16(scope, input)?;
+    let b = Decoder16(scope, input)?;
+    return Some(Type2 { r, g, b });
 }
 
 fn Decoder118<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
-let magic = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let method = Decoder16(scope, input)?;
-let file_flags = Decoder16(scope, input)?;
-let timestamp = Decoder23(scope, input)?;
-let compression_flags = Decoder16(scope, input)?;
-let os_id = Decoder16(scope, input)?;
-return Some(Type13 { magic, method, file_flags, timestamp, compression_flags, os_id });
+    let magic = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let method = Decoder16(scope, input)?;
+    let file_flags = Decoder16(scope, input)?;
+    let timestamp = Decoder23(scope, input)?;
+    let compression_flags = Decoder16(scope, input)?;
+    let os_id = Decoder16(scope, input)?;
+    return Some(Type13 {
+        magic,
+        method,
+        file_flags,
+        timestamp,
+        compression_flags,
+        os_id,
+    });
 }
 
 fn Decoder119<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
-return Some(Decoder127(scope, input)?);
+    return Some(Decoder127(scope, input)?);
 }
 
 fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type25> {
-let blocks = {
-let tmp = r#"invoke_decoder @ Discriminant(13)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let codes = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let inflate = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type25 { blocks, codes, inflate });
+    let blocks = {
+        let tmp = r#"invoke_decoder @ Discriminant(13)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let codes = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let inflate = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type25 {
+        blocks,
+        codes,
+        inflate,
+    });
 }
 
 fn Decoder121<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type26> {
-let crc = Decoder23(scope, input)?;
-let length = Decoder23(scope, input)?;
-return Some(Type26 { crc, length });
+    let crc = Decoder23(scope, input)?;
+    let length = Decoder23(scope, input)?;
+    return Some(Type26 { crc, length });
 }
 
 fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type24> {
-let r#final = Decoder123(scope, input)?;
-let r#type = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type24 { r#final, r#type, data });
+    let r#final = Decoder123(scope, input)?;
+    let r#type = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type24 {
+        r#final,
+        r#type,
+        data,
+    });
 }
 
 fn Decoder123<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+        ]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type99> {
-let align = {
-while input.offset() % 8 != 0 {
-let _ = input.read_byte()?;
-}
-()
-};
-let len = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let nlen = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let bytes = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let codes_values = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type99 { align, len, nlen, bytes, codes_values });
+    let align = {
+        while input.offset() % 8 != 0 {
+            let _ = input.read_byte()?;
+        }
+        ()
+    };
+    let len = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let nlen = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let bytes = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let codes_values = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type99 {
+        align,
+        len,
+        nlen,
+        bytes,
+        codes_values,
+    });
 }
 
 fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type100> {
-let codes = {
-let tmp = r#"invoke_decoder @ Discriminant(24)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let codes_values = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type100 { codes, codes_values });
+    let codes = {
+        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let codes_values = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type100 {
+        codes,
+        codes_values,
+    });
 }
 
 fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type101> {
-let hlit = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let hdist = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let hclen = {
-let tmp = r#"invoke_decoder @ Discriminant(20)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let code_length_alphabet_code_lengths = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let literal_length_distance_alphabet_code_lengths = {
-let tmp = r#"invoke_decoder @ Discriminant(24)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let literal_length_distance_alphabet_code_lengths_value = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let literal_length_alphabet_code_lengths_value = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let distance_alphabet_code_lengths_value = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let codes = {
-let tmp = r#"invoke_decoder @ Discriminant(24)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let codes_values = {
-let tmp = r#"invoke_decoder @ Discriminant(21)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type101 { hlit, hdist, hclen, code_length_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths_value, literal_length_alphabet_code_lengths_value, distance_alphabet_code_lengths_value, codes, codes_values });
+    let hlit = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let hdist = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let hclen = {
+        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let code_length_alphabet_code_lengths = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let literal_length_distance_alphabet_code_lengths = {
+        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let literal_length_distance_alphabet_code_lengths_value = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let literal_length_alphabet_code_lengths_value = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let distance_alphabet_code_lengths_value = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let codes = {
+        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let codes_values = {
+        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type101 {
+        hlit,
+        hdist,
+        hclen,
+        code_length_alphabet_code_lengths,
+        literal_length_distance_alphabet_code_lengths,
+        literal_length_distance_alphabet_code_lengths_value,
+        literal_length_alphabet_code_lengths_value,
+        distance_alphabet_code_lengths_value,
+        codes,
+        codes_values,
+    });
 }
 
 fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
-let string = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let null = {
-let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type29 { string, null });
+    let string = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let null = {
+        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type29 { string, null });
 }
 
 fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type0> {
-let signature = {
-let tmp = r#"invoke_decoder @ Discriminant(8)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let version = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type0 { signature, version });
+    let signature = {
+        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let version = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type0 { signature, version });
 }
 
 fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type4> {
-let descriptor = Decoder145(scope, input)?;
-let global_color_table = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type4 { descriptor, global_color_table });
+    let descriptor = Decoder145(scope, input)?;
+    let global_color_table = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type4 {
+        descriptor,
+        global_color_table,
+    });
 }
 
 fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type11> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
-let separator = {
-let bs = ByteSet::from_bits([576460752303423488, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-return Some(Type12 { separator });
+    let separator = {
+        let bs = ByteSet::from_bits([576460752303423488, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    return Some(Type12 { separator });
 }
 
 fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
-let graphic_control_extension = {
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let graphic_rendering_block = Decoder139(scope, input)?;
-return Some(Type102 { graphic_control_extension, graphic_rendering_block });
+    let graphic_control_extension = {
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let graphic_rendering_block = Decoder139(scope, input)?;
+    return Some(Type102 {
+        graphic_control_extension,
+        graphic_rendering_block,
+    });
 }
 
 fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
-let separator = {
-let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let label = {
-let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let block_size = {
-let bs = ByteSet::from_bits([2048, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let identifier = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let authentication_code = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let application_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let terminator = Decoder137(scope, input)?;
-return Some(Type103 { separator, label, block_size, identifier, authentication_code, application_data, terminator });
+    let separator = {
+        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let label = {
+        let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let block_size = {
+        let bs = ByteSet::from_bits([2048, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let identifier = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let authentication_code = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let application_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let terminator = Decoder137(scope, input)?;
+    return Some(Type103 {
+        separator,
+        label,
+        block_size,
+        identifier,
+        authentication_code,
+        application_data,
+        terminator,
+    });
 }
 
 fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
-let separator = {
-let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let label = {
-let bs = ByteSet::from_bits([0, 0, 0, 4611686018427387904]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let comment_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let terminator = Decoder137(scope, input)?;
-return Some(Type104 { separator, label, comment_data, terminator });
+    let separator = {
+        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let label = {
+        let bs = ByteSet::from_bits([0, 0, 0, 4611686018427387904]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let comment_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let terminator = Decoder137(scope, input)?;
+    return Some(Type104 {
+        separator,
+        label,
+        comment_data,
+        terminator,
+    });
 }
 
 fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
-let len_bytes = {
-let bs = ByteSet::from_bits([18446744073709551614, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let data = {
-let tmp = r#"invoke_decoder @ Discriminant(12)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-return Some(Type7 { len_bytes, data });
+    let len_bytes = {
+        let bs = ByteSet::from_bits([
+            18446744073709551614,
+            18446744073709551615,
+            18446744073709551615,
+            18446744073709551615,
+        ]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let data = {
+        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    return Some(Type7 { len_bytes, data });
 }
 
 fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-return Some({
-let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-});
+    return Some({
+        let bs = ByteSet::from_bits([1, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    });
 }
 
 fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type105> {
-let separator = {
-let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let label = {
-let bs = ByteSet::from_bits([0, 0, 0, 144115188075855872]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let block_size = {
-let bs = ByteSet::from_bits([16, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let flags = Decoder16(scope, input)?;
-let delay_time = Decoder113(scope, input)?;
-let transparent_color_index = Decoder16(scope, input)?;
-let terminator = Decoder137(scope, input)?;
-return Some(Type105 { separator, label, block_size, flags, delay_time, transparent_color_index, terminator });
+    let separator = {
+        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let label = {
+        let bs = ByteSet::from_bits([0, 0, 0, 144115188075855872]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let block_size = {
+        let bs = ByteSet::from_bits([16, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let flags = Decoder16(scope, input)?;
+    let delay_time = Decoder113(scope, input)?;
+    let transparent_color_index = Decoder16(scope, input)?;
+    let terminator = Decoder137(scope, input)?;
+    return Some(Type105 {
+        separator,
+        label,
+        block_size,
+        flags,
+        delay_time,
+        transparent_color_index,
+        terminator,
+    });
 }
 
 fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
-return Some({
-let tmp = r#"invoke_decoder @ Discriminant(7)"#;
-unimplemented!(r#"{}"#, tmp)
-});
+    return Some({
+        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        unimplemented!(r#"{}"#, tmp)
+    });
 }
 
 fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type106> {
-let descriptor = Decoder142(scope, input)?;
-let local_color_table = {
-let tmp = r#"invoke_decoder @ Discriminant(23)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let data = Decoder144(scope, input)?;
-return Some(Type106 { descriptor, local_color_table, data });
+    let descriptor = Decoder142(scope, input)?;
+    let local_color_table = {
+        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let data = Decoder144(scope, input)?;
+    return Some(Type106 {
+        descriptor,
+        local_color_table,
+        data,
+    });
 }
 
 fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
-let separator = {
-let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let label = {
-let bs = ByteSet::from_bits([2, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let block_size = {
-let bs = ByteSet::from_bits([4096, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let text_grid_left_position = Decoder113(scope, input)?;
-let text_grid_top_position = Decoder113(scope, input)?;
-let text_grid_width = Decoder113(scope, input)?;
-let text_grid_height = Decoder113(scope, input)?;
-let character_cell_width = Decoder16(scope, input)?;
-let character_cell_height = Decoder16(scope, input)?;
-let text_foreground_color_index = Decoder16(scope, input)?;
-let text_background_color_index = Decoder16(scope, input)?;
-let plain_text_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let terminator = Decoder137(scope, input)?;
-return Some(Type107 { separator, label, block_size, text_grid_left_position, text_grid_top_position, text_grid_width, text_grid_height, character_cell_width, character_cell_height, text_foreground_color_index, text_background_color_index, plain_text_data, terminator });
+    let separator = {
+        let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let label = {
+        let bs = ByteSet::from_bits([2, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let block_size = {
+        let bs = ByteSet::from_bits([4096, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let text_grid_left_position = Decoder113(scope, input)?;
+    let text_grid_top_position = Decoder113(scope, input)?;
+    let text_grid_width = Decoder113(scope, input)?;
+    let text_grid_height = Decoder113(scope, input)?;
+    let character_cell_width = Decoder16(scope, input)?;
+    let character_cell_height = Decoder16(scope, input)?;
+    let text_foreground_color_index = Decoder16(scope, input)?;
+    let text_background_color_index = Decoder16(scope, input)?;
+    let plain_text_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let terminator = Decoder137(scope, input)?;
+    return Some(Type107 {
+        separator,
+        label,
+        block_size,
+        text_grid_left_position,
+        text_grid_top_position,
+        text_grid_width,
+        text_grid_height,
+        character_cell_width,
+        character_cell_height,
+        text_foreground_color_index,
+        text_background_color_index,
+        plain_text_data,
+        terminator,
+    });
 }
 
 fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
-let separator = {
-let bs = ByteSet::from_bits([17592186044416, 0, 0, 0]);
-let b = input.read_byte()?;
-if bs.contains(b) {
-b
-} else {
-return None;
-}
-};
-let image_left_position = Decoder113(scope, input)?;
-let image_top_position = Decoder113(scope, input)?;
-let image_width = Decoder113(scope, input)?;
-let image_height = Decoder113(scope, input)?;
-let flags = Decoder16(scope, input)?;
-return Some(Type6 { separator, image_left_position, image_top_position, image_width, image_height, flags });
+    let separator = {
+        let bs = ByteSet::from_bits([17592186044416, 0, 0, 0]);
+        let b = input.read_byte()?;
+        if bs.contains(b) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let image_left_position = Decoder113(scope, input)?;
+    let image_top_position = Decoder113(scope, input)?;
+    let image_width = Decoder113(scope, input)?;
+    let image_height = Decoder113(scope, input)?;
+    let flags = Decoder16(scope, input)?;
+    return Some(Type6 {
+        separator,
+        image_left_position,
+        image_top_position,
+        image_width,
+        image_height,
+        flags,
+    });
 }
 
 fn Decoder143<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
-let r = Decoder16(scope, input)?;
-let g = Decoder16(scope, input)?;
-let b = Decoder16(scope, input)?;
-return Some(Type2 { r, g, b });
+    let r = Decoder16(scope, input)?;
+    let g = Decoder16(scope, input)?;
+    let b = Decoder16(scope, input)?;
+    return Some(Type2 { r, g, b });
 }
 
 fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
-let lzw_min_code_size = Decoder16(scope, input)?;
-let image_data = {
-let tmp = r#"invoke_decoder @ Discriminant(10)"#;
-unimplemented!(r#"{}"#, tmp)
-};
-let terminator = Decoder137(scope, input)?;
-return Some(Type8 { lzw_min_code_size, image_data, terminator });
+    let lzw_min_code_size = Decoder16(scope, input)?;
+    let image_data = {
+        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        unimplemented!(r#"{}"#, tmp)
+    };
+    let terminator = Decoder137(scope, input)?;
+    return Some(Type8 {
+        lzw_min_code_size,
+        image_data,
+        terminator,
+    });
 }
 
 fn Decoder145<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type1> {
-let screen_width = Decoder113(scope, input)?;
-let screen_height = Decoder113(scope, input)?;
-let flags = Decoder16(scope, input)?;
-let bg_color_index = Decoder16(scope, input)?;
-let pixel_aspect_ratio = Decoder16(scope, input)?;
-return Some(Type1 { screen_width, screen_height, flags, bg_color_index, pixel_aspect_ratio });
+    let screen_width = Decoder113(scope, input)?;
+    let screen_height = Decoder113(scope, input)?;
+    let flags = Decoder16(scope, input)?;
+    let bg_color_index = Decoder16(scope, input)?;
+    let pixel_aspect_ratio = Decoder16(scope, input)?;
+    return Some(Type1 {
+        screen_width,
+        screen_height,
+        flags,
+        bg_color_index,
+        pixel_aspect_ratio,
+    });
 }
-
 
 #[test]
 fn test_decoder_27() {

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,85 +1,26 @@
 use doodle::prelude::*;
 
-enum Type94 {
-    color_type_3(Vec<Type84>),
-    color_type_2(Type85),
-    color_type_0(Type86),
+struct Type31 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u8,
+    distance_record: Type24,
 }
 
-struct Type72 {
-    num_image_components: u8,
-    image_components: Vec<Type71>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
+enum Type44 {
+    other(Vec<u8>),
+    jfif(Type43),
 }
 
-struct Type50 {
-    num_fields: u16,
-    fields: Vec<Type49>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-struct Type52 {
-    padding: u8,
-    exif: Type51,
-}
-
-struct Type67 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
+struct Type109 {
+    contents: Vec<Type108>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
 }
 
 struct Type34 {
     codes: Vec<Type33>,
     codes_values: Vec<Type29>,
-}
-
-struct Type102 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type101>,
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
-struct Type57 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-enum Type79 {
-    some(Type78),
-    none,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type36 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type35>,
-}
-
-struct Type64 {
-    marker: Type42,
-    length: u16,
-    data: Type63,
-}
-
-struct Type75 {
-    scan_data: Vec<Type74>,
-    scan_data_stream: Vec<u8>,
 }
 
 enum Type74 {
@@ -94,194 +35,67 @@ enum Type74 {
     rst7(Type42),
 }
 
-struct Type86 {
-    greyscale: u16,
+enum Type87 {
+    color_type_3(Type84),
+    color_type_6(Type85),
+    color_type_2(Type85),
+    color_type_4(Type86),
+    color_type_0(Type86),
 }
 
-struct Type107 {
-    name: Type104,
-    mode: Type105,
-    uid: Type105,
-    gid: Type105,
-    size: u32,
-    mtime: Type105,
-    chksum: Type105,
-    typeflag: u8,
-    linkname: Type104,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type106,
-    gname: Type106,
-    devmajor: Type105,
-    devminor: Type105,
-    prefix: Type104,
-    pad: Vec<u8>,
-}
-
-enum Type22 {
-    no,
-    yes(Type21),
-}
-
-struct Type21 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-enum Type12 {
-    table_based_image(Type10),
-    plain_text_extension(Type11),
-}
-
-enum Type16 {
-    application_extension(Type14),
-    comment_extension(Type15),
-}
-
-struct Type30 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type27>,
-    codes_values: Vec<Type29>,
-}
-
-struct Type38 {
-    r#final: u8,
-    r#type: u8,
-    data: Type37,
-}
-
-struct Type8 {
-    len_bytes: u8,
-    data: Vec<u8>,
-}
-
-struct Type51 {
-    byte_order: Type48,
-    magic: u16,
-    offset: u32,
-    ifd: Type50,
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-enum Type56 {
-    app0(Type46),
-    app1(Type55),
-}
-
-struct Type65 {
+struct Type64 {
     marker: Type42,
     length: u16,
-    data: Vec<u8>,
+    data: Type63,
 }
 
-struct Type19 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type17>,
-    trailer: Type18,
+struct Type20 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
 }
 
-enum Type26 {
+struct Type50 {
+    num_fields: u16,
+    fields: Vec<Type49>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
+}
+
+struct Type52 {
+    padding: u8,
+    exif: Type51,
+}
+
+enum Type70 {
+    sof0(Type69),
+    sof1(Type69),
+    sof2(Type69),
+    sof3(Type69),
+    sof5(Type69),
+    sof6(Type69),
+    sof7(Type69),
+    sof9(Type69),
+    sof10(Type69),
+    sof11(Type69),
+    sof13(Type69),
+    sof14(Type69),
+    sof15(Type69),
+}
+
+enum Type79 {
+    some(Type78),
     none,
-    some(Type25),
 }
 
-enum Type48 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type99 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type83,
-    chunks: Vec<Type96>,
-    idat: Vec<Type97>,
-    more_chunks: Vec<Type96>,
-    iend: Type98,
-}
-
-enum Type37 {
-    dynamic_huffman(Type30),
-    fixed_huffman(Type34),
-    uncompressed(Type36),
-}
-
-struct Type58 {
-    marker: Type42,
-    length: u16,
-    data: Type57,
-}
-
-struct Type62 {
-    marker: Type42,
-    length: u16,
-    data: Type61,
-}
-
-enum Type3 {
-    no,
-    yes(Vec<Type2>),
-}
-
-struct Type104 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-struct Type13 {
-    graphic_control_extension: Type6,
-    graphic_rendering_block: Type12,
-}
-
-struct Type27 {
-    code: u16,
-    extra: Type26,
-}
-
-struct Type83 {
+struct Type93 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Type82,
+    data: Type92,
     crc: u32,
-}
-
-enum Type29 {
-    literal(u8),
-    reference(Type28),
-}
-
-struct Type78 {
-    marker: Type42,
-    length: u16,
-    data: Type77,
-}
-
-struct Type39 {
-    blocks: Vec<Type38>,
-    codes: Vec<Type29>,
-    inflate: Vec<u8>,
-}
-
-struct Type25 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u16,
-    distance_record: Type24,
-}
-
-struct Type77 {
-    num_lines: u16,
 }
 
 struct Type101 {
@@ -291,44 +105,49 @@ struct Type101 {
     pad: Type100,
 }
 
-struct Type95 {
+struct Type62 {
+    marker: Type42,
+    length: u16,
+    data: Type61,
+}
+
+struct Type8 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+struct Type9 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type8>,
+    terminator: u8,
+}
+
+enum Type12 {
+    table_based_image(Type10),
+    plain_text_extension(Type11),
+}
+
+struct Type77 {
+    num_lines: u16,
+}
+
+struct Type88 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Type94,
+    data: Type87,
     crc: u32,
 }
 
-struct Type41 {
-    header: Type20,
-    fname: Type22,
-    data: Type39,
-    footer: Type40,
+struct Type59 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
 }
 
-enum Type44 {
-    other(Vec<u8>),
-    jfif(Type43),
-}
-
-struct Type10 {
-    descriptor: Type7,
-    local_color_table: Type3,
-    data: Type9,
-}
-
-struct Type55 {
+struct Type65 {
     marker: Type42,
     length: u16,
-    data: Type54,
-}
-
-struct Type80 {
-    initial_segment: Type56,
-    segments: Vec<Type66>,
-    header: Type70,
-    scan: Type76,
-    dnl: Type79,
-    scans: Vec<Type76>,
+    data: Vec<u8>,
 }
 
 struct Type82 {
@@ -341,39 +160,14 @@ struct Type82 {
     interlace_method: u8,
 }
 
-struct Type109 {
-    contents: Vec<Type108>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
+struct Type102 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type101>,
 }
 
-struct Type5 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type18 {
-    separator: u8,
-}
-
-struct Type28 {
-    length: u16,
-    distance: u16,
-}
-
-enum Type110 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-struct Type33 {
-    code: u16,
-    extra: Type32,
+enum Type32 {
+    none,
+    some(Type31),
 }
 
 struct Type60 {
@@ -382,49 +176,37 @@ struct Type60 {
     data: Type59,
 }
 
-struct Type49 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type69 {
-    marker: Type42,
-    length: u16,
-    data: Type68,
-}
-
-struct Type23 {
+struct Type33 {
     code: u16,
-    extra: u8,
+    extra: Type32,
 }
 
-struct Type89 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
+struct Type10 {
+    descriptor: Type7,
+    local_color_table: Type3,
+    data: Type9,
 }
 
-enum Type35 {
-    literal(u8),
+struct Type13 {
+    graphic_control_extension: Type6,
+    graphic_rendering_block: Type12,
 }
 
-enum Type17 {
-    graphic_block(Type13),
-    special_purpose_block(Type16),
+enum Type26 {
+    none,
+    some(Type25),
 }
 
-struct Type93 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type92,
-    crc: u32,
+struct Type81 {
+    soi: Type42,
+    frame: Type80,
+    eoi: Type42,
 }
 
-struct Type106 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
+struct Type76 {
+    segments: Vec<Type66>,
+    sos: Type73,
+    data: Type75,
 }
 
 struct Type112 {
@@ -432,88 +214,18 @@ struct Type112 {
     end: (),
 }
 
-struct Type54 {
-    identifier: Type21,
-    data: Type53,
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
 }
 
-struct Type46 {
-    marker: Type42,
-    length: u16,
-    data: Type45,
-}
-
-struct Type31 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u8,
-    distance_record: Type24,
-}
-
-struct Type15 {
+struct Type18 {
     separator: u8,
-    label: u8,
-    comment_data: Vec<Type8>,
-    terminator: u8,
 }
 
-struct Type71 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
-}
-
-struct Type103 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type102,
-    pad: Type100,
-}
-
-struct Type43 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
-struct Type88 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type87,
-    crc: u32,
-}
-
-struct Type47 {
-    xmp: Vec<u8>,
-}
-
-enum Type96 {
-    bKGD(Type88),
-    pHYs(Type90),
-    PLTE(Type91),
-    tIME(Type93),
-    tRNS(Type95),
-}
-
-struct Type108 {
-    header: Type107,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type45 {
-    identifier: Type21,
-    data: Type44,
-}
-
-struct Type9 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type8>,
-    terminator: u8,
+struct Type57 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
 }
 
 enum Type66 {
@@ -540,104 +252,35 @@ enum Type66 {
     com(Type65),
 }
 
-struct Type59 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
+struct Type43 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
 }
 
-struct Type91 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
+enum Type3 {
+    no,
+    yes(Vec<Type2>),
 }
 
-struct Type85 {
-    red: u16,
-    green: u16,
-    blue: u16,
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
 }
 
-struct Type42 {
-    ff: u8,
-    marker: u8,
+enum Type17 {
+    graphic_block(Type13),
+    special_purpose_block(Type16),
 }
 
-struct Type14 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type8>,
-    terminator: u8,
-}
-
-enum Type70 {
-    sof0(Type69),
-    sof1(Type69),
-    sof2(Type69),
-    sof3(Type69),
-    sof5(Type69),
-    sof6(Type69),
-    sof7(Type69),
-    sof9(Type69),
-    sof10(Type69),
-    sof11(Type69),
-    sof13(Type69),
-    sof14(Type69),
-    sof15(Type69),
-}
-
-struct Type84 {
-    palette_index: u8,
-}
-
-struct Type7 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type63 {
-    restart_interval: u16,
-}
-
-struct Type73 {
-    marker: Type42,
-    length: u16,
-    data: Type72,
-}
-
-struct Type90 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type89,
-    crc: u32,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type61 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type98 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: (),
-    crc: u32,
+struct Type86 {
+    greyscale: u16,
 }
 
 enum Type111 {
@@ -650,15 +293,51 @@ enum Type111 {
     text(Type110),
 }
 
-struct Type76 {
-    segments: Vec<Type66>,
-    sos: Type73,
-    data: Type75,
+struct Type108 {
+    header: Type107,
+    file: Vec<u8>,
+    __padding: (),
 }
 
-enum Type100 {
-    no(u8),
-    yes,
+struct Type67 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+struct Type72 {
+    num_image_components: u8,
+    image_components: Vec<Type71>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type41 {
+    header: Type20,
+    fname: Type22,
+    data: Type39,
+    footer: Type40,
+}
+
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+struct Type105 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
+}
+
+struct Type73 {
+    marker: Type42,
+    length: u16,
+    data: Type72,
 }
 
 struct Type97 {
@@ -668,9 +347,22 @@ struct Type97 {
     crc: u32,
 }
 
-struct Type24 {
-    distance_extra_bits: u16,
-    distance: u16,
+struct Type84 {
+    palette_index: u8,
+}
+
+struct Type38 {
+    r#final: u8,
+    r#type: u8,
+    data: Type37,
+}
+
+struct Type68 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type67>,
 }
 
 struct Type11 {
@@ -689,29 +381,322 @@ struct Type11 {
     terminator: u8,
 }
 
+struct Type5 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+struct Type63 {
+    restart_interval: u16,
+}
+
+struct Type98 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
+}
+
+struct Type15 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type95 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type94,
+    crc: u32,
+}
+
+enum Type37 {
+    dynamic_huffman(Type30),
+    fixed_huffman(Type34),
+    uncompressed(Type36),
+}
+
+struct Type104 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type49 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
+struct Type24 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type21 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+struct Type103 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type102,
+    pad: Type100,
+}
+
+struct Type30 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type27>,
+    codes_values: Vec<Type29>,
+}
+
+struct Type27 {
+    code: u16,
+    extra: Type26,
+}
+
+struct Type99 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type83,
+    chunks: Vec<Type96>,
+    idat: Vec<Type97>,
+    more_chunks: Vec<Type96>,
+    iend: Type98,
+}
+
+enum Type96 {
+    bKGD(Type88),
+    pHYs(Type90),
+    PLTE(Type91),
+    tIME(Type93),
+    tRNS(Type95),
+}
+
+struct Type45 {
+    identifier: Type21,
+    data: Type44,
+}
+
+struct Type106 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+struct Type78 {
+    marker: Type42,
+    length: u16,
+    data: Type77,
+}
+
+struct Type89 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+enum Type53 {
+    other(Vec<u8>),
+    xmp(Type47),
+    exif(Type52),
+}
+
+enum Type29 {
+    literal(u8),
+    reference(Type28),
+}
+
+struct Type36 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type35>,
+}
+
+struct Type51 {
+    byte_order: Type48,
+    magic: u16,
+    offset: u32,
+    ifd: Type50,
+}
+
+enum Type94 {
+    color_type_3(Vec<Type84>),
+    color_type_2(Type85),
+    color_type_0(Type86),
+}
+
+enum Type100 {
+    no(u8),
+    yes,
+}
+
+struct Type90 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type89,
+    crc: u32,
+}
+
+enum Type16 {
+    application_extension(Type14),
+    comment_extension(Type15),
+}
+
+enum Type56 {
+    app0(Type46),
+    app1(Type55),
+}
+
+struct Type46 {
+    marker: Type42,
+    length: u16,
+    data: Type45,
+}
+
+struct Type80 {
+    initial_segment: Type56,
+    segments: Vec<Type66>,
+    header: Type70,
+    scan: Type76,
+    dnl: Type79,
+    scans: Vec<Type76>,
+}
+
+struct Type7 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type25 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u16,
+    distance_record: Type24,
+}
+
+struct Type91 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type58 {
+    marker: Type42,
+    length: u16,
+    data: Type57,
+}
+
+struct Type47 {
+    xmp: Vec<u8>,
+}
+
+enum Type110 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+enum Type48 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
 enum Type6 {
     some(Type5),
     none,
 }
 
-enum Type32 {
-    none,
-    some(Type31),
+struct Type23 {
+    code: u16,
+    extra: u8,
 }
 
-struct Type81 {
-    soi: Type42,
-    frame: Type80,
-    eoi: Type42,
+struct Type54 {
+    identifier: Type21,
+    data: Type53,
 }
 
-struct Type20 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
+enum Type35 {
+    literal(u8),
+}
+
+struct Type40 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type61 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type14 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type19 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type17>,
+    trailer: Type18,
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type82,
+    crc: u32,
+}
+
+struct Type28 {
+    length: u16,
+    distance: u16,
+}
+
+struct Type69 {
+    marker: Type42,
+    length: u16,
+    data: Type68,
+}
+
+struct Type42 {
+    ff: u8,
+    marker: u8,
+}
+
+struct Type75 {
+    scan_data: Vec<Type74>,
+    scan_data_stream: Vec<u8>,
 }
 
 struct Type92 {
@@ -723,37 +708,52 @@ struct Type92 {
     second: u8,
 }
 
-struct Type40 {
-    crc: u32,
-    length: u32,
+struct Type39 {
+    blocks: Vec<Type38>,
+    codes: Vec<Type29>,
+    inflate: Vec<u8>,
 }
 
-enum Type53 {
-    other(Vec<u8>),
-    xmp(Type47),
-    exif(Type52),
+struct Type55 {
+    marker: Type42,
+    length: u16,
+    data: Type54,
 }
 
-struct Type68 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type67>,
+struct Type107 {
+    name: Type104,
+    mode: Type105,
+    uid: Type105,
+    gid: Type105,
+    size: u32,
+    mtime: Type105,
+    chksum: Type105,
+    typeflag: u8,
+    linkname: Type104,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type106,
+    gname: Type106,
+    devmajor: Type105,
+    devminor: Type105,
+    prefix: Type104,
+    pad: Vec<u8>,
 }
 
-struct Type105 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
+struct Type71 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
-enum Type87 {
-    color_type_3(Type84),
-    color_type_6(Type85),
-    color_type_2(Type85),
-    color_type_4(Type86),
-    color_type_0(Type86),
+struct Type85 {
+    red: u16,
+    green: u16,
+    blue: u16,
+}
+
+enum Type22 {
+    no,
+    yes(Type21),
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
@@ -796,7 +796,7 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let trailer = { (Decoder131(scope, input))? };
     (Some(Type19 {
@@ -849,7 +849,7 @@ fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
             (accum.push(next_elem));
         }
     }
-    (Some((Some(accum))))
+    (Some(accum))
 }
 
 fn Decoder4<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
@@ -869,6 +869,8 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
+                    73 => 1,
+
                     98 => 0,
 
                     112 => 0,
@@ -876,8 +878,6 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     80 => 0,
 
                     116 => 0,
-
-                    73 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -887,7 +887,7 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let idat = {
         let mut accum = (Vec::new());
@@ -921,7 +921,7 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 (accum.push(next_elem));
             }
         }
-        (Some(accum))
+        accum
     };
     let more_chunks = {
         let mut accum = (Vec::new());
@@ -948,7 +948,7 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let iend = { (Decoder31(scope, input))? };
     (Some(Type99 {
@@ -1047,7 +1047,7 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 (accum.push(next_elem));
             }
         }
-        (Some(accum))
+        accum
     };
     let __padding = {
         let mut accum = (Vec::new());
@@ -1061,7 +1061,7 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 }
             }));
         }
-        (Some(accum))
+        accum
     };
     let __trailing = {
         let mut accum = (Vec::new());
@@ -1089,7 +1089,7 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type109 {
         contents,
@@ -1123,7 +1123,7 @@ fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
             (accum.push(next_elem));
         }
     }
-    (Some((Some(accum))))
+    (Some(accum))
 }
 
 fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<char>> {
@@ -1168,7 +1168,7 @@ fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             break;
         }
     }
-    (Some((Some(accum))))
+    (Some(accum))
 }
 
 fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
@@ -1177,6 +1177,16 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             let lookahead = (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
+                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
+
+                224 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
+
+                237 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
+
                 tmp if ((ByteSet::from_bits([
                     18446744073709551615,
                     18446744073709551615,
@@ -1193,16 +1203,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
 
                 244 => 3,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
-
-                224 => 2,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
-
-                237 => 2,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
             }
         };
         match tree_index {
@@ -1251,7 +1251,11 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         match b {
                             224 => 0,
 
-                            237 => 2,
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
+                                .contains(tmp)) =>
+                            {
+                                1
+                            }
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
                                 .contains(tmp)) =>
@@ -1259,11 +1263,7 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                                 3
                             }
 
-                            tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
-                                .contains(tmp)) =>
-                            {
-                                1
-                            }
+                            237 => 2,
                         }
                     };
                     match tree_index {
@@ -1374,8 +1374,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
-                            244 => 2,
-
                             240 => 0,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
@@ -1383,6 +1381,8 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             {
                                 1
                             }
+
+                            244 => 2,
                         }
                     };
                     match tree_index {
@@ -1506,7 +1506,7 @@ fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         for _ in 0..header.size {
             (accum.push((Decoder16(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     let __padding = {
         while (input.offset() % 512 != 0) {
@@ -1538,9 +1538,9 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 0,
-
                     tmp if (tmp != 0) => 1,
+
+                    0 => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -1557,7 +1557,7 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 (accum.push(next_elem));
             }
         }
-        (Some(accum))
+        accum
     };
     let __padding = {
         let mut accum = (Vec::new());
@@ -1585,7 +1585,7 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type104 { string, __padding }))
 }
@@ -1644,7 +1644,7 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let __padding = {
         let mut accum = (Vec::new());
@@ -1672,7 +1672,7 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type104 { string, __padding }))
 }
@@ -1685,9 +1685,9 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -1704,7 +1704,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let padding = {
         let mut accum = (Vec::new());
@@ -1732,7 +1732,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 (accum.push(next_elem));
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type106 { string, padding }))
 }
@@ -1764,7 +1764,7 @@ fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type102 { tag, chunks }))
 }
@@ -1900,20 +1900,20 @@ fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let lookahead = (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            116 => {
-                let b = (lookahead.read_byte())?;
-                match b {
-                    82 => 4,
-
-                    73 => 3,
-                }
-            }
-
-            98 => 0,
+            112 => 1,
 
             80 => 2,
 
-            112 => 1,
+            98 => 0,
+
+            116 => {
+                let b = (lookahead.read_byte())?;
+                match b {
+                    73 => 3,
+
+                    82 => 4,
+                }
+            }
         }
     };
     (Some(match tree_index {
@@ -2071,7 +2071,7 @@ fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             break;
         }
     }
-    (Some((Some(accum))))
+    (Some(accum))
 }
 
 fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
@@ -2401,9 +2401,9 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             if (b == 255) {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    224 => 0,
-
                     225 => 1,
+
+                    224 => 0,
                 }
             } else {
                 return None;
@@ -2509,7 +2509,7 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let header = { (Decoder51(scope, input))? };
     let scan = { (Decoder52(scope, input))? };
@@ -2650,7 +2650,7 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type80 {
         initial_segment,
@@ -2747,47 +2747,47 @@ fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                254 => 20,
-
-                236 => 16,
-
-                204 => 2,
-
-                234 => 14,
-
-                237 => 17,
-
                 232 => 12,
-
-                230 => 10,
-
-                235 => 15,
-
-                228 => 8,
-
-                227 => 7,
-
-                196 => 1,
-
-                224 => 4,
-
-                238 => 18,
-
-                239 => 19,
 
                 233 => 13,
 
-                219 => 0,
-
-                231 => 11,
+                204 => 2,
 
                 226 => 6,
 
-                225 => 5,
+                254 => 20,
+
+                237 => 17,
+
+                239 => 19,
+
+                196 => 1,
+
+                229 => 9,
+
+                231 => 11,
+
+                230 => 10,
+
+                238 => 18,
 
                 221 => 3,
 
-                229 => 9,
+                219 => 0,
+
+                227 => 7,
+
+                228 => 8,
+
+                224 => 4,
+
+                225 => 5,
+
+                234 => 14,
+
+                235 => 15,
+
+                236 => 16,
             }
         } else {
             return None;
@@ -2908,9 +2908,17 @@ fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                199 => 6,
+                205 => 10,
 
                 198 => 5,
+
+                201 => 7,
+
+                207 => 12,
+
+                193 => 1,
+
+                195 => 3,
 
                 194 => 2,
 
@@ -2918,19 +2926,11 @@ fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
                 206 => 11,
 
-                207 => 12,
-
                 202 => 8,
-
-                201 => 7,
-
-                193 => 1,
 
                 203 => 9,
 
-                195 => 3,
-
-                205 => 10,
+                199 => 6,
 
                 192 => 0,
             }
@@ -3071,7 +3071,7 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let sos = { (Decoder55(scope, input))? };
     let data = { (Decoder69(scope, input))? };
@@ -3176,7 +3176,7 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let sos = { (Decoder55(scope, input))? };
     let data = { (Decoder56(scope, input))? };
@@ -3224,8 +3224,6 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 255) => 0,
-
                     255 => {
                         let b = (lookahead.read_byte())?;
                         match b {
@@ -3294,6 +3292,8 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             254 => 1,
                         }
                     }
+
+                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -3302,30 +3302,30 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
-                            tmp if (tmp != 255) => 0,
-
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    0 => 0,
-
-                                    213 => 6,
-
-                                    210 => 3,
-
-                                    212 => 5,
+                                    211 => 4,
 
                                     208 => 1,
 
-                                    215 => 8,
-
-                                    211 => 4,
+                                    213 => 6,
 
                                     209 => 2,
 
                                     214 => 7,
+
+                                    215 => 8,
+
+                                    0 => 0,
+
+                                    210 => 3,
+
+                                    212 => 5,
                                 }
                             }
+
+                            tmp if (tmp != 255) => 0,
                         }
                     };
                     match tree_index {
@@ -3380,7 +3380,7 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let scan_data_stream = {
         (((scan_data.into_iter()).flat_map(
@@ -3642,7 +3642,7 @@ fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         for _ in 0..num_image_components {
             (accum.push((Decoder67(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     let start_spectral_selection = { (Decoder16(scope, input))? };
     let end_spectral_selection = { (Decoder16(scope, input))? };
@@ -3678,6 +3678,8 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
+                    tmp if (tmp != 255) => 0,
+
                     255 => {
                         let b = (lookahead.read_byte())?;
                         match b {
@@ -3748,8 +3750,6 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             254 => 1,
                         }
                     }
-
-                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -3761,23 +3761,23 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    214 => 7,
-
                                     211 => 4,
 
+                                    214 => 7,
+
+                                    209 => 2,
+
+                                    0 => 0,
+
                                     213 => 6,
+
+                                    210 => 3,
 
                                     215 => 8,
 
                                     208 => 1,
 
-                                    210 => 3,
-
-                                    0 => 0,
-
                                     212 => 5,
-
-                                    209 => 2,
                                 }
                             }
 
@@ -3836,7 +3836,7 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let scan_data_stream = {
         (((scan_data.into_iter()).flat_map(
@@ -4273,7 +4273,7 @@ fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         for _ in 0..num_image_components {
             (accum.push((Decoder84(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     (Some(Type68 {
         sample_precision,
@@ -4867,7 +4867,7 @@ fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         for _ in 0..16 {
             (accum.push((Decoder16(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     let values = {
         let mut accum = (Vec::new());
@@ -4883,7 +4883,7 @@ fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type59 {
         class_table_id,
@@ -4908,7 +4908,7 @@ fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type57 {
         precision_table_id,
@@ -4946,7 +4946,7 @@ fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                             break;
                         }
                     }
-                    (Some(accum))
+                    accum
                 };
                 (Type53::other(inner))
             }
@@ -4963,9 +4963,9 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -4982,7 +4982,7 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let null = {
         let b = (input.read_byte())?;
@@ -5023,7 +5023,7 @@ fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     (Some(Type47 { xmp }))
 }
@@ -5034,9 +5034,9 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             let lookahead = (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
-                73 => 0,
-
                 77 => 1,
+
+                73 => 0,
             }
         };
         match tree_index {
@@ -5137,7 +5137,7 @@ fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                             break;
                         }
                     }
-                    (Some(accum))
+                    accum
                 };
                 (Type44::other(inner))
             }
@@ -5154,9 +5154,9 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -5173,7 +5173,7 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let null = {
         let b = (input.read_byte())?;
@@ -5202,10 +5202,10 @@ fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 for _ in 0..thumbnail_width {
                     (accum.push((Decoder117(scope, input))?));
                 }
-                (Some(accum))
+                accum
             }));
         }
-        (Some(accum))
+        accum
     };
     (Some(Type43 {
         version_major,
@@ -5277,7 +5277,7 @@ fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 (accum.push(elem));
             }
         }
-        (Some(accum))
+        accum
     };
     let codes = {
         (((blocks.into_iter()).flat_map(
@@ -5471,7 +5471,7 @@ fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 })(inner))
             }));
         }
-        (Some(accum))
+        accum
     };
     let codes_values =
         { (((bytes.into_iter()).flat_map((|x| [(literal(x))].to_vec()))).collect()) };
@@ -5900,7 +5900,7 @@ fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 ((|bits| bits.2 << 2 | bits.1 << 1 | bits.0)(inner))
             }));
         }
-        (Some(accum))
+        accum
     };
     let literal_length_distance_alphabet_code_lengths =
         { (unimplemented!(r#"translate @ Decoder::Dynamic"#)) };
@@ -6359,7 +6359,7 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let null = {
         let b = (input.read_byte())?;
@@ -6405,7 +6405,7 @@ fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         for _ in 0..3 {
             (accum.push((Decoder20(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     (Some(Type0 { signature, version }))
 }
@@ -6420,7 +6420,7 @@ fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                     for _ in 0..(2 << (descriptor.flags & 7)) {
                         (accum.push((Decoder143(scope, input))?));
                     }
-                    (Some(accum))
+                    accum
                 };
                 (Type3::yes(inner))
             }
@@ -6445,13 +6445,13 @@ fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             33 => {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    255 => 1,
-
-                    254 => 1,
-
                     249 => 0,
 
                     1 => 0,
+
+                    255 => 1,
+
+                    254 => 1,
                 }
             }
 
@@ -6489,6 +6489,8 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             let lookahead = (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
+                44 => 1,
+
                 33 => {
                     let b = (lookahead.read_byte())?;
                     match b {
@@ -6497,8 +6499,6 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                         1 => 1,
                     }
                 }
-
-                44 => 1,
             }
         };
         match tree_index {
@@ -6578,14 +6578,14 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         for _ in 0..8 {
             (accum.push((Decoder16(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     let authentication_code = {
         let mut accum = (Vec::new());
         for _ in 0..3 {
             (accum.push((Decoder16(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     let application_data = {
         let mut accum = (Vec::new());
@@ -6594,9 +6594,9 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -6606,7 +6606,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let terminator = { (Decoder137(scope, input))? };
     (Some(Type14 {
@@ -6644,9 +6644,9 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -6656,7 +6656,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let terminator = { (Decoder137(scope, input))? };
     (Some(Type15 {
@@ -6681,7 +6681,7 @@ fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         for _ in 0..len_bytes {
             (accum.push((Decoder16(scope, input))?));
         }
-        (Some(accum))
+        accum
     };
     (Some(Type8 { len_bytes, data }))
 }
@@ -6768,7 +6768,7 @@ fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                     for _ in 0..(2 << (descriptor.flags & 7)) {
                         (accum.push((Decoder143(scope, input))?));
                     }
-                    (Some(accum))
+                    accum
                 };
                 (Type3::yes(inner))
             }
@@ -6827,9 +6827,9 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -6839,7 +6839,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let terminator = { (Decoder137(scope, input))? };
     (Some(Type11 {
@@ -6911,7 +6911,7 @@ fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 break;
             }
         }
-        (Some(accum))
+        accum
     };
     let terminator = { (Decoder137(scope, input))? };
     (Some(Type9 {

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -832,8 +832,8 @@ fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                         }
 
                         false => {
-                            let inner = ();
-                            (Type22::no(inner))
+                            let _ = ();
+                            Type22::no
                         }
                     }
                 };
@@ -1002,8 +1002,8 @@ fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     let pad = {
         match (length % 2 == 0) {
             true => {
-                let inner = ();
-                (Type100::yes(inner))
+                let _ = ();
+                Type100::yes
             }
 
             false => {
@@ -1780,8 +1780,8 @@ fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let pad = {
         match (length % 2 == 0) {
             true => {
-                let inner = ();
-                (Type100::yes(inner))
+                let _ = ();
+                Type100::yes
             }
 
             false => {
@@ -2575,8 +2575,8 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             }
 
             1 => {
-                let inner = ();
-                (Type79::none(inner))
+                let _ = ();
+                Type79::none
             }
         }
     };
@@ -6246,8 +6246,8 @@ fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             }
 
             false => {
-                let inner = ();
-                (Type3::no(inner))
+                let _ = ();
+                Type3::no
             }
         }
     };
@@ -6328,8 +6328,8 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             }
 
             1 => {
-                let inner = ();
-                (Type10::none(inner))
+                let _ = ();
+                Type10::none
             }
         }
     };
@@ -6594,8 +6594,8 @@ fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             }
 
             false => {
-                let inner = ();
-                (Type3::no(inner))
+                let _ = ();
+                Type3::no
             }
         }
     };

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1741,7 +1741,7 @@ fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let field3 = { (Decoder16(scope, input))? };
         (field0, field1, field2, field3)
     };
-    (Some(((|x| u32::from_le_bytes(x))(inner))))
+    (Some(((|x| u32le(x))(inner))))
 }
 
 fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
@@ -1974,7 +1974,7 @@ fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let field3 = { (Decoder16(scope, input))? };
         (field0, field1, field2, field3)
     };
-    (Some(((|x| u32::from_be_bytes(x))(inner))))
+    (Some(((|x| u32be(x))(inner))))
 }
 
 fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
@@ -2311,7 +2311,7 @@ fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let field1 = { (Decoder16(scope, input))? };
         (field0, field1)
     };
-    (Some(((|x| u16::from_be_bytes(x))(inner))))
+    (Some(((|x| u16be(x))(inner))))
 }
 
 fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
@@ -5070,7 +5070,7 @@ fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let field1 = { (Decoder16(scope, input))? };
         (field0, field1)
     };
-    (Some(((|x| u16::from_le_bytes(x))(inner))))
+    (Some(((|x| u16le(x))(inner))))
 }
 
 fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type54> {

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -30,6 +30,33 @@ struct Type4 {
 }
 
 struct Type5 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+struct Type6 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type5>,
+    terminator: u8,
+}
+
+struct Type7 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type5>,
+    terminator: u8,
+}
+
+enum Type8 {
+    comment_extension(Type6),
+    application_extension(Type7),
+}
+
+struct Type9 {
     separator: u8,
     label: u8,
     block_size: u8,
@@ -39,35 +66,9 @@ struct Type5 {
     terminator: u8,
 }
 
-enum Type6 {
-    some(Type5),
+enum Type10 {
     none,
-}
-
-struct Type7 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type8 {
-    len_bytes: u8,
-    data: Vec<u8>,
-}
-
-struct Type9 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type10 {
-    descriptor: Type7,
-    local_color_table: Type3,
-    data: Type9,
+    some(Type9),
 }
 
 struct Type11 {
@@ -82,45 +83,44 @@ struct Type11 {
     character_cell_height: u8,
     text_foreground_color_index: u8,
     text_background_color_index: u8,
-    plain_text_data: Vec<Type8>,
+    plain_text_data: Vec<Type5>,
     terminator: u8,
 }
 
-enum Type12 {
-    table_based_image(Type10),
-    plain_text_extension(Type11),
+struct Type12 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
 }
 
 struct Type13 {
-    graphic_control_extension: Type6,
-    graphic_rendering_block: Type12,
+    lzw_min_code_size: u8,
+    image_data: Vec<Type5>,
+    terminator: u8,
 }
 
 struct Type14 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type8>,
-    terminator: u8,
+    descriptor: Type12,
+    local_color_table: Type3,
+    data: Type13,
 }
 
-struct Type15 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type8>,
-    terminator: u8,
+enum Type15 {
+    plain_text_extension(Type11),
+    table_based_image(Type14),
 }
 
-enum Type16 {
-    application_extension(Type14),
-    comment_extension(Type15),
+struct Type16 {
+    graphic_control_extension: Type10,
+    graphic_rendering_block: Type15,
 }
 
 enum Type17 {
-    graphic_block(Type13),
-    special_purpose_block(Type16),
+    special_purpose_block(Type8),
+    graphic_block(Type16),
 }
 
 struct Type18 {
@@ -273,6 +273,58 @@ struct Type42 {
 }
 
 struct Type43 {
+    xmp: Vec<u8>,
+}
+
+enum Type44 {
+    be(u8, u8),
+    le(u8, u8),
+}
+
+struct Type45 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
+struct Type46 {
+    num_fields: u16,
+    fields: Vec<Type45>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
+}
+
+struct Type47 {
+    byte_order: Type44,
+    magic: u16,
+    offset: u32,
+    ifd: Type46,
+}
+
+struct Type48 {
+    padding: u8,
+    exif: Type47,
+}
+
+enum Type49 {
+    other(Vec<u8>),
+    xmp(Type43),
+    exif(Type48),
+}
+
+struct Type50 {
+    identifier: Type21,
+    data: Type49,
+}
+
+struct Type51 {
+    marker: Type42,
+    length: u16,
+    data: Type50,
+}
+
+struct Type52 {
     version_major: u8,
     version_minor: u8,
     density_units: u8,
@@ -283,61 +335,9 @@ struct Type43 {
     thumbnail_pixels: Vec<Vec<Type2>>,
 }
 
-enum Type44 {
-    other(Vec<u8>),
-    jfif(Type43),
-}
-
-struct Type45 {
-    identifier: Type21,
-    data: Type44,
-}
-
-struct Type46 {
-    marker: Type42,
-    length: u16,
-    data: Type45,
-}
-
-struct Type47 {
-    xmp: Vec<u8>,
-}
-
-enum Type48 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type49 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type50 {
-    num_fields: u16,
-    fields: Vec<Type49>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-struct Type51 {
-    byte_order: Type48,
-    magic: u16,
-    offset: u32,
-    ifd: Type50,
-}
-
-struct Type52 {
-    padding: u8,
-    exif: Type51,
-}
-
 enum Type53 {
     other(Vec<u8>),
-    xmp(Type47),
-    exif(Type52),
+    jfif(Type52),
 }
 
 struct Type54 {
@@ -352,82 +352,82 @@ struct Type55 {
 }
 
 enum Type56 {
-    app0(Type46),
-    app1(Type55),
+    app1(Type51),
+    app0(Type55),
 }
 
 struct Type57 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-struct Type58 {
-    marker: Type42,
-    length: u16,
-    data: Type57,
-}
-
-struct Type59 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-struct Type60 {
-    marker: Type42,
-    length: u16,
-    data: Type59,
-}
-
-struct Type61 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type62 {
-    marker: Type42,
-    length: u16,
-    data: Type61,
-}
-
-struct Type63 {
-    restart_interval: u16,
-}
-
-struct Type64 {
-    marker: Type42,
-    length: u16,
-    data: Type63,
-}
-
-struct Type65 {
     marker: Type42,
     length: u16,
     data: Vec<u8>,
 }
 
+struct Type58 {
+    restart_interval: u16,
+}
+
+struct Type59 {
+    marker: Type42,
+    length: u16,
+    data: Type58,
+}
+
+struct Type60 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type61 {
+    marker: Type42,
+    length: u16,
+    data: Type60,
+}
+
+struct Type62 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+struct Type63 {
+    marker: Type42,
+    length: u16,
+    data: Type62,
+}
+
+struct Type64 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+struct Type65 {
+    marker: Type42,
+    length: u16,
+    data: Type64,
+}
+
 enum Type66 {
-    dqt(Type58),
-    dht(Type60),
-    dac(Type62),
-    dri(Type64),
-    app0(Type46),
-    app1(Type55),
-    app2(Type65),
-    app3(Type65),
-    app4(Type65),
-    app5(Type65),
-    app6(Type65),
-    app7(Type65),
-    app8(Type65),
-    app9(Type65),
-    app10(Type65),
-    app11(Type65),
-    app12(Type65),
-    app13(Type65),
-    app14(Type65),
-    app15(Type65),
-    com(Type65),
+    com(Type57),
+    app15(Type57),
+    app14(Type57),
+    app13(Type57),
+    app12(Type57),
+    app11(Type57),
+    app10(Type57),
+    app9(Type57),
+    app8(Type57),
+    app7(Type57),
+    app6(Type57),
+    app5(Type57),
+    app4(Type57),
+    app3(Type57),
+    app2(Type57),
+    app1(Type51),
+    app0(Type55),
+    dri(Type59),
+    dac(Type61),
+    dht(Type63),
+    dqt(Type65),
 }
 
 struct Type67 {
@@ -451,19 +451,19 @@ struct Type69 {
 }
 
 enum Type70 {
-    sof0(Type69),
-    sof1(Type69),
-    sof2(Type69),
-    sof3(Type69),
-    sof5(Type69),
-    sof6(Type69),
-    sof7(Type69),
-    sof9(Type69),
-    sof10(Type69),
-    sof11(Type69),
-    sof13(Type69),
-    sof14(Type69),
     sof15(Type69),
+    sof14(Type69),
+    sof13(Type69),
+    sof11(Type69),
+    sof10(Type69),
+    sof9(Type69),
+    sof7(Type69),
+    sof6(Type69),
+    sof5(Type69),
+    sof3(Type69),
+    sof2(Type69),
+    sof1(Type69),
+    sof0(Type69),
 }
 
 struct Type71 {
@@ -486,15 +486,15 @@ struct Type73 {
 }
 
 enum Type74 {
-    mcu(u8),
-    rst0(Type42),
-    rst1(Type42),
-    rst2(Type42),
-    rst3(Type42),
-    rst4(Type42),
-    rst5(Type42),
-    rst6(Type42),
     rst7(Type42),
+    rst6(Type42),
+    rst5(Type42),
+    rst4(Type42),
+    rst3(Type42),
+    rst2(Type42),
+    rst1(Type42),
+    rst0(Type42),
+    mcu(u8),
 }
 
 struct Type75 {
@@ -519,8 +519,8 @@ struct Type78 {
 }
 
 enum Type79 {
-    some(Type78),
     none,
+    some(Type78),
 }
 
 struct Type80 {
@@ -570,10 +570,8 @@ struct Type86 {
 }
 
 enum Type87 {
-    color_type_3(Type84),
-    color_type_6(Type85),
+    color_type_3(Vec<Type84>),
     color_type_2(Type85),
-    color_type_4(Type86),
     color_type_0(Type86),
 }
 
@@ -585,9 +583,12 @@ struct Type88 {
 }
 
 struct Type89 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
 }
 
 struct Type90 {
@@ -605,12 +606,9 @@ struct Type91 {
 }
 
 struct Type92 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
 }
 
 struct Type93 {
@@ -621,8 +619,10 @@ struct Type93 {
 }
 
 enum Type94 {
-    color_type_3(Vec<Type84>),
+    color_type_3(Type84),
+    color_type_6(Type85),
     color_type_2(Type85),
+    color_type_4(Type86),
     color_type_0(Type86),
 }
 
@@ -634,11 +634,11 @@ struct Type95 {
 }
 
 enum Type96 {
-    bKGD(Type88),
-    pHYs(Type90),
+    tRNS(Type88),
+    tIME(Type90),
     PLTE(Type91),
-    tIME(Type93),
-    tRNS(Type95),
+    pHYs(Type93),
+    bKGD(Type95),
 }
 
 struct Type97 {
@@ -1188,6 +1188,8 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     0
                 }
 
+                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
+
                 224 => 2,
 
                 tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
@@ -1201,8 +1203,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
 
                 244 => 3,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
             }
         };
         match tree_index {
@@ -1237,9 +1237,7 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     (field0, field1)
                 };
                 ((|bytes| match bytes {
-                    (x1, x0) => {
-                        ((x1 as u32) << 6 | (x0 as u32));
-                    }
+                    (x1, x0) => ((x1 as u32) << 6 | (x0 as u32)),
                 })(inner))
             }
 
@@ -1249,20 +1247,20 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
-                            tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
-                                .contains(tmp)) =>
-                            {
-                                3
-                            }
-
-                            237 => 2,
-
                             224 => 0,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
                                 .contains(tmp)) =>
                             {
                                 1
+                            }
+
+                            237 => 2,
+
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
+                                .contains(tmp)) =>
+                            {
+                                3
                             }
                         }
                     };
@@ -1362,9 +1360,7 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     }
                 };
                 ((|bytes| match bytes {
-                    (x2, x1, x0) => {
-                        ((x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32));
-                    }
+                    (x2, x1, x0) => ((x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32)),
                 })(inner))
             }
 
@@ -1374,8 +1370,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
-                            244 => 2,
-
                             240 => 0,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
@@ -1383,6 +1377,8 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             {
                                 1
                             }
+
+                            244 => 2,
                         }
                     };
                     match tree_index {
@@ -1467,7 +1463,7 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 };
                 ((|bytes| match bytes {
                     (x3, x2, x1, x0) => {
-                        ((x3 as u32) << 18 | (x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32));
+                        ((x3 as u32) << 18 | (x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32))
                     }
                 })(inner))
             }
@@ -1538,9 +1534,9 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 1,
-
                     0 => 0,
+
+                    tmp if (tmp != 0) => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1685,9 +1681,9 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1900,11 +1896,11 @@ fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            80 => 2,
+            98 => 0,
 
             112 => 1,
 
-            98 => 0,
+            80 => 2,
 
             116 => {
                 let b = (lookahead.read_byte())?;
@@ -2074,7 +2070,7 @@ fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     (Some(accum))
 }
 
-fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
+fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let length = { (Decoder32(scope, input))? };
     let tag = {
         let field0 = {
@@ -2113,7 +2109,7 @@ fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let crc = { (Decoder32(scope, input))? };
-    (Some(Type88 {
+    (Some(Type95 {
         length,
         tag,
         data,
@@ -2121,7 +2117,7 @@ fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     }))
 }
 
-fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
     let length = { (Decoder32(scope, input))? };
     let tag = {
         let field0 = {
@@ -2160,7 +2156,7 @@ fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let crc = { (Decoder32(scope, input))? };
-    (Some(Type90 {
+    (Some(Type93 {
         length,
         tag,
         data,
@@ -2215,7 +2211,7 @@ fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     }))
 }
 
-fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
+fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let length = { (Decoder32(scope, input))? };
     let tag = {
         let field0 = {
@@ -2254,7 +2250,7 @@ fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let crc = { (Decoder32(scope, input))? };
-    (Some(Type93 {
+    (Some(Type90 {
         length,
         tag,
         data,
@@ -2262,7 +2258,7 @@ fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     }))
 }
 
-fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
     let length = { (Decoder32(scope, input))? };
     let tag = {
         let field0 = {
@@ -2301,7 +2297,7 @@ fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let crc = { (Decoder32(scope, input))? };
-    (Some(Type95 {
+    (Some(Type88 {
         length,
         tag,
         data,
@@ -2520,6 +2516,8 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             if (b == 255) {
                 let b = (lookahead.read_byte())?;
                 match b {
+                    220 => 0,
+
                     217 => 1,
 
                     218 => 1,
@@ -2565,8 +2563,6 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     239 => 1,
 
                     254 => 1,
-
-                    220 => 0,
                 }
             } else {
                 return None;
@@ -2682,7 +2678,7 @@ fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     (Some(Type42 { ff, marker }))
 }
 
-fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
+fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -2704,14 +2700,14 @@ fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type46 {
+    (Some(Type55 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
+fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -2733,7 +2729,7 @@ fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type55 {
+    (Some(Type51 {
         marker,
         length,
         data,
@@ -2747,47 +2743,47 @@ fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                227 => 7,
-
-                224 => 4,
-
-                239 => 19,
-
-                228 => 8,
+                219 => 0,
 
                 196 => 1,
 
-                236 => 16,
-
-                235 => 15,
-
                 204 => 2,
-
-                234 => 14,
-
-                225 => 5,
-
-                233 => 13,
 
                 221 => 3,
 
-                231 => 11,
+                224 => 4,
 
-                238 => 18,
-
-                229 => 9,
-
-                219 => 0,
-
-                230 => 10,
+                225 => 5,
 
                 226 => 6,
 
-                254 => 20,
+                227 => 7,
+
+                228 => 8,
+
+                229 => 9,
+
+                230 => 10,
+
+                231 => 11,
+
+                232 => 12,
+
+                233 => 13,
+
+                234 => 14,
+
+                235 => 15,
+
+                236 => 16,
 
                 237 => 17,
 
-                232 => 12,
+                238 => 18,
+
+                239 => 19,
+
+                254 => 20,
             }
         } else {
             return None;
@@ -2908,31 +2904,31 @@ fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                198 => 5,
+                192 => 0,
 
                 193 => 1,
 
-                202 => 8,
-
-                205 => 10,
-
-                197 => 4,
-
-                192 => 0,
-
-                201 => 7,
-
-                207 => 12,
-
-                203 => 9,
+                194 => 2,
 
                 195 => 3,
 
-                194 => 2,
+                197 => 4,
+
+                198 => 5,
+
+                199 => 6,
+
+                201 => 7,
+
+                202 => 8,
+
+                203 => 9,
+
+                205 => 10,
 
                 206 => 11,
 
-                199 => 6,
+                207 => 12,
             }
         } else {
             return None;
@@ -3016,8 +3012,6 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        218 => 1,
-
                         219 => 0,
 
                         196 => 0,
@@ -3059,6 +3053,8 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
+
+                        218 => 1,
                     }
                 } else {
                     return None;
@@ -3121,8 +3117,6 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        218 => 1,
-
                         219 => 0,
 
                         196 => 0,
@@ -3164,6 +3158,8 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
+
+                        218 => 1,
                     }
                 } else {
                     return None;
@@ -3302,30 +3298,30 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
+                            tmp if (tmp != 255) => 0,
+
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    215 => 8,
-
-                                    214 => 7,
-
-                                    211 => 4,
-
-                                    210 => 3,
-
                                     0 => 0,
 
-                                    213 => 6,
-
-                                    212 => 5,
+                                    208 => 1,
 
                                     209 => 2,
 
-                                    208 => 1,
+                                    210 => 3,
+
+                                    211 => 4,
+
+                                    212 => 5,
+
+                                    213 => 6,
+
+                                    214 => 7,
+
+                                    215 => 8,
                                 }
                             }
-
-                            tmp if (tmp != 255) => 0,
                         }
                     };
                     match tree_index {
@@ -3385,41 +3381,23 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let scan_data_stream = {
         (((scan_data.into_iter()).flat_map(
             (|x| match x {
-                mcu(v) => {
-                    ([v].to_vec());
-                }
+                mcu(v) => ([v].to_vec()),
 
-                rst0(_) => {
-                    ([].to_vec());
-                }
+                rst0(_) => ([].to_vec()),
 
-                rst1(_) => {
-                    ([].to_vec());
-                }
+                rst1(_) => ([].to_vec()),
 
-                rst2(_) => {
-                    ([].to_vec());
-                }
+                rst2(_) => ([].to_vec()),
 
-                rst3(_) => {
-                    ([].to_vec());
-                }
+                rst3(_) => ([].to_vec()),
 
-                rst4(_) => {
-                    ([].to_vec());
-                }
+                rst4(_) => ([].to_vec()),
 
-                rst5(_) => {
-                    ([].to_vec());
-                }
+                rst5(_) => ([].to_vec()),
 
-                rst6(_) => {
-                    ([].to_vec());
-                }
+                rst6(_) => ([].to_vec()),
 
-                rst7(_) => {
-                    ([].to_vec());
-                }
+                rst7(_) => ([].to_vec()),
             }),
         ))
         .collect())
@@ -3435,9 +3413,9 @@ fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            255 => 1,
-
             tmp if (tmp != 255) => 0,
+
+            255 => 1,
         }
     };
     (Some(match tree_index {
@@ -3678,6 +3656,8 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
+                    tmp if (tmp != 255) => 0,
+
                     255 => {
                         let b = (lookahead.read_byte())?;
                         match b {
@@ -3748,8 +3728,6 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             254 => 1,
                         }
                     }
-
-                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -3758,30 +3736,30 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
+                            tmp if (tmp != 255) => 0,
+
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    215 => 8,
+                                    0 => 0,
+
+                                    208 => 1,
+
+                                    209 => 2,
+
+                                    210 => 3,
+
+                                    211 => 4,
+
+                                    212 => 5,
 
                                     213 => 6,
 
                                     214 => 7,
 
-                                    208 => 1,
-
-                                    210 => 3,
-
-                                    209 => 2,
-
-                                    0 => 0,
-
-                                    212 => 5,
-
-                                    211 => 4,
+                                    215 => 8,
                                 }
                             }
-
-                            tmp if (tmp != 255) => 0,
                         }
                     };
                     match tree_index {
@@ -3841,41 +3819,23 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let scan_data_stream = {
         (((scan_data.into_iter()).flat_map(
             (|x| match x {
-                mcu(v) => {
-                    ([v].to_vec());
-                }
+                mcu(v) => ([v].to_vec()),
 
-                rst0(_) => {
-                    ([].to_vec());
-                }
+                rst0(_) => ([].to_vec()),
 
-                rst1(_) => {
-                    ([].to_vec());
-                }
+                rst1(_) => ([].to_vec()),
 
-                rst2(_) => {
-                    ([].to_vec());
-                }
+                rst2(_) => ([].to_vec()),
 
-                rst3(_) => {
-                    ([].to_vec());
-                }
+                rst3(_) => ([].to_vec()),
 
-                rst4(_) => {
-                    ([].to_vec());
-                }
+                rst4(_) => ([].to_vec()),
 
-                rst5(_) => {
-                    ([].to_vec());
-                }
+                rst5(_) => ([].to_vec()),
 
-                rst6(_) => {
-                    ([].to_vec());
-                }
+                rst6(_) => ([].to_vec()),
 
-                rst7(_) => {
-                    ([].to_vec());
-                }
+                rst7(_) => ([].to_vec()),
             }),
         ))
         .collect())
@@ -4295,7 +4255,7 @@ fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     }))
 }
 
-fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type58> {
+fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4317,14 +4277,14 @@ fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type58 {
+    (Some(Type65 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type60> {
+fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4346,14 +4306,14 @@ fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type60 {
+    (Some(Type63 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type62> {
+fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type61> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4375,14 +4335,14 @@ fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type62 {
+    (Some(Type61 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
+fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type59> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4404,14 +4364,14 @@ fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type64 {
+    (Some(Type59 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4433,14 +4393,14 @@ fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4462,14 +4422,14 @@ fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4491,14 +4451,14 @@ fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4520,14 +4480,14 @@ fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4549,14 +4509,14 @@ fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4578,14 +4538,14 @@ fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4607,14 +4567,14 @@ fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4636,14 +4596,14 @@ fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4665,14 +4625,14 @@ fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4694,14 +4654,14 @@ fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4723,14 +4683,14 @@ fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4752,14 +4712,14 @@ fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4781,14 +4741,14 @@ fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4810,14 +4770,14 @@ fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
     let marker = {
         let ff = {
             let b = (input.read_byte())?;
@@ -4839,28 +4799,28 @@ fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     };
     let length = { (Decoder42(scope, input))? };
     let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
-    (Some(Type65 {
+    (Some(Type57 {
         marker,
         length,
         data,
     }))
 }
 
-fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
+fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type58> {
     let restart_interval = { (Decoder42(scope, input))? };
-    (Some(Type63 { restart_interval }))
+    (Some(Type58 { restart_interval }))
 }
 
-fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type61> {
+fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type60> {
     let class_table_id = { (Decoder16(scope, input))? };
     let value = { (Decoder16(scope, input))? };
-    (Some(Type61 {
+    (Some(Type60 {
         class_table_id,
         value,
     }))
 }
 
-fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type59> {
+fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type62> {
     let class_table_id = { (Decoder16(scope, input))? };
     let num_codes = {
         let mut accum = (Vec::new());
@@ -4885,14 +4845,14 @@ fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
         accum
     };
-    (Some(Type59 {
+    (Some(Type62 {
         class_table_id,
         num_codes,
         values,
     }))
 }
 
-fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
+fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
     let precision_table_id = { (Decoder16(scope, input))? };
     let elements = {
         let mut accum = (Vec::new());
@@ -4910,25 +4870,216 @@ fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
         accum
     };
-    (Some(Type57 {
+    (Some(Type64 {
         precision_table_id,
         elements,
     }))
 }
 
-fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type54> {
+fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type50> {
     let identifier = { (Decoder109(scope, input))? };
     let data = {
         match identifier.string {
             [69, 120, 105, 102] => {
                 let inner = (Decoder110(scope, input))?;
-                (Type53::exif(inner))
+                (Type49::exif(inner))
             }
 
             [104, 116, 116, 112, 58, 47, 47, 110, 115, 46, 97, 100, 111, 98, 101, 46, 99, 111, 109, 47, 120, 97, 112, 47, 49, 46, 48, 47] =>
             {
                 let inner = (Decoder111(scope, input))?;
-                (Type53::xmp(inner))
+                (Type49::xmp(inner))
+            }
+
+            _ => {
+                let inner = {
+                    let mut accum = (Vec::new());
+                    while true {
+                        let matching_ix = {
+                            let lookahead = &mut (input.clone());
+                            0
+                        };
+                        if (matching_ix == 0) {
+                            let next_elem = (Decoder16(scope, input))?;
+                            (accum.push(next_elem));
+                        } else {
+                            break;
+                        }
+                    }
+                    accum
+                };
+                (Type49::other(inner))
+            }
+        }
+    };
+    (Some(Type50 { identifier, data }))
+}
+
+fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
+    let string = {
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = &mut (input.clone());
+                let b = (lookahead.read_byte())?;
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        accum
+    };
+    let null = {
+        let b = (input.read_byte())?;
+        if (b == 0) {
+            b
+        } else {
+            return None;
+        }
+    };
+    (Some(Type21 { string, null }))
+}
+
+fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type48> {
+    let padding = {
+        let b = (input.read_byte())?;
+        if (b == 0) {
+            b
+        } else {
+            return None;
+        }
+    };
+    let exif = { (Decoder112(scope, input))? };
+    (Some(Type48 { padding, exif }))
+}
+
+fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
+    let xmp = {
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = &mut (input.clone());
+                0
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder16(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        accum
+    };
+    (Some(Type43 { xmp }))
+}
+
+fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
+    let byte_order = {
+        let tree_index = {
+            let lookahead = &mut (input.clone());
+            let b = (lookahead.read_byte())?;
+            match b {
+                73 => 0,
+
+                77 => 1,
+            }
+        };
+        match tree_index {
+            0 => {
+                let field0 = {
+                    let b = (input.read_byte())?;
+                    if (b == 73) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                let field1 = {
+                    let b = (input.read_byte())?;
+                    if (b == 73) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type44::le(field0, field1))
+            }
+
+            1 => {
+                let field0 = {
+                    let b = (input.read_byte())?;
+                    if (b == 77) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                let field1 = {
+                    let b = (input.read_byte())?;
+                    if (b == 77) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type44::be(field0, field1))
+            }
+        }
+    };
+    let magic = {
+        match byte_order {
+            le(_) => (Decoder113(scope, input))?,
+
+            be(_) => (Decoder42(scope, input))?,
+        }
+    };
+    let offset = {
+        match byte_order {
+            le(_) => (Decoder23(scope, input))?,
+
+            be(_) => (Decoder32(scope, input))?,
+        }
+    };
+    let ifd = { (unimplemented!(r#"translate @ Decoder::WithRelativeOffset"#)) };
+    (Some(Type47 {
+        byte_order,
+        magic,
+        offset,
+        ifd,
+    }))
+}
+
+fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
+    let inner = {
+        let field0 = { (Decoder16(scope, input))? };
+        let field1 = { (Decoder16(scope, input))? };
+        (field0, field1)
+    };
+    (Some(((|x| u16::from_le_bytes(x))(inner))))
+}
+
+fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type54> {
+    let identifier = { (Decoder115(scope, input))? };
+    let data = {
+        match identifier.string {
+            [74, 70, 73, 70] => {
+                let inner = (Decoder116(scope, input))?;
+                (Type53::jfif(inner))
             }
 
             _ => {
@@ -4955,197 +5106,6 @@ fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(Type54 { identifier, data }))
 }
 
-fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
-    let string = {
-        let mut accum = (Vec::new());
-        while true {
-            let matching_ix = {
-                let lookahead = &mut (input.clone());
-                let b = (lookahead.read_byte())?;
-                match b {
-                    0 => 1,
-
-                    tmp if (tmp != 0) => 0,
-                }
-            };
-            if (matching_ix == 0) {
-                let next_elem = {
-                    let b = (input.read_byte())?;
-                    if (b != 0) {
-                        b
-                    } else {
-                        return None;
-                    }
-                };
-                (accum.push(next_elem));
-            } else {
-                break;
-            }
-        }
-        accum
-    };
-    let null = {
-        let b = (input.read_byte())?;
-        if (b == 0) {
-            b
-        } else {
-            return None;
-        }
-    };
-    (Some(Type21 { string, null }))
-}
-
-fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
-    let padding = {
-        let b = (input.read_byte())?;
-        if (b == 0) {
-            b
-        } else {
-            return None;
-        }
-    };
-    let exif = { (Decoder112(scope, input))? };
-    (Some(Type52 { padding, exif }))
-}
-
-fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
-    let xmp = {
-        let mut accum = (Vec::new());
-        while true {
-            let matching_ix = {
-                let lookahead = &mut (input.clone());
-                0
-            };
-            if (matching_ix == 0) {
-                let next_elem = (Decoder16(scope, input))?;
-                (accum.push(next_elem));
-            } else {
-                break;
-            }
-        }
-        accum
-    };
-    (Some(Type47 { xmp }))
-}
-
-fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
-    let byte_order = {
-        let tree_index = {
-            let lookahead = &mut (input.clone());
-            let b = (lookahead.read_byte())?;
-            match b {
-                77 => 1,
-
-                73 => 0,
-            }
-        };
-        match tree_index {
-            0 => {
-                let field0 = {
-                    let b = (input.read_byte())?;
-                    if (b == 73) {
-                        b
-                    } else {
-                        return None;
-                    }
-                };
-                let field1 = {
-                    let b = (input.read_byte())?;
-                    if (b == 73) {
-                        b
-                    } else {
-                        return None;
-                    }
-                };
-                (Type48::le(field0, field1))
-            }
-
-            1 => {
-                let field0 = {
-                    let b = (input.read_byte())?;
-                    if (b == 77) {
-                        b
-                    } else {
-                        return None;
-                    }
-                };
-                let field1 = {
-                    let b = (input.read_byte())?;
-                    if (b == 77) {
-                        b
-                    } else {
-                        return None;
-                    }
-                };
-                (Type48::be(field0, field1))
-            }
-        }
-    };
-    let magic = {
-        match byte_order {
-            le(_) => (Decoder113(scope, input))?,
-
-            be(_) => (Decoder42(scope, input))?,
-        }
-    };
-    let offset = {
-        match byte_order {
-            le(_) => (Decoder23(scope, input))?,
-
-            be(_) => (Decoder32(scope, input))?,
-        }
-    };
-    let ifd = { (unimplemented!(r#"translate @ Decoder::WithRelativeOffset"#)) };
-    (Some(Type51 {
-        byte_order,
-        magic,
-        offset,
-        ifd,
-    }))
-}
-
-fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
-    let inner = {
-        let field0 = { (Decoder16(scope, input))? };
-        let field1 = { (Decoder16(scope, input))? };
-        (field0, field1)
-    };
-    (Some(((|x| u16::from_le_bytes(x))(inner))))
-}
-
-fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type45> {
-    let identifier = { (Decoder115(scope, input))? };
-    let data = {
-        match identifier.string {
-            [74, 70, 73, 70] => {
-                let inner = (Decoder116(scope, input))?;
-                (Type44::jfif(inner))
-            }
-
-            _ => {
-                let inner = {
-                    let mut accum = (Vec::new());
-                    while true {
-                        let matching_ix = {
-                            let lookahead = &mut (input.clone());
-                            0
-                        };
-                        if (matching_ix == 0) {
-                            let next_elem = (Decoder16(scope, input))?;
-                            (accum.push(next_elem));
-                        } else {
-                            break;
-                        }
-                    }
-                    accum
-                };
-                (Type44::other(inner))
-            }
-        }
-    };
-    (Some(Type45 { identifier, data }))
-}
-
 fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
     let string = {
         let mut accum = (Vec::new());
@@ -5154,9 +5114,9 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -5186,7 +5146,7 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(Type21 { string, null }))
 }
 
-fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
+fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
     let version_major = { (Decoder16(scope, input))? };
     let version_minor = { (Decoder16(scope, input))? };
     let density_units = { (Decoder16(scope, input))? };
@@ -5207,7 +5167,7 @@ fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
         accum
     };
-    (Some(Type43 {
+    (Some(Type52 {
         version_major,
         version_minor,
         density_units,
@@ -5282,17 +5242,11 @@ fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let codes = {
         (((blocks.into_iter()).flat_map(
             (|x| match x.data {
-                uncompressed(y) => {
-                    y.codes_values;
-                }
+                uncompressed(y) => y.codes_values,
 
-                fixed_huffman(y) => {
-                    y.codes_values;
-                }
+                fixed_huffman(y) => y.codes_values,
 
-                dynamic_huffman(y) => {
-                    y.codes_values;
-                }
+                dynamic_huffman(y) => y.codes_values,
             }),
         ))
         .collect())
@@ -5489,361 +5443,299 @@ fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let codes_values = {
         (((codes.into_iter()).flat_map(
             (|x| match x.code {
-                256 => {
-                    ([].to_vec());
-                }
+                256 => ([].to_vec()),
 
-                257 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                257 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                258 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                258 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                259 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                259 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                260 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                260 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                261 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                261 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                262 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                262 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                263 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                263 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                264 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                264 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                265 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                265 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                266 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                266 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                267 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                267 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                268 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                268 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                269 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                269 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                270 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                270 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                271 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                271 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                272 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                272 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                273 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                273 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                274 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                274 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                275 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                275 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                276 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                276 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                277 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                277 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                278 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                278 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                279 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                279 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                280 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                280 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                281 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                281 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                282 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                282 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                283 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                283 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                284 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                284 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                285 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                285 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                _ => {
-                    ([(literal((x.code as u8)))].to_vec());
-                }
+                _ => ([(literal((x.code as u8)))].to_vec()),
             }),
         ))
         .collect())
@@ -5908,37 +5800,27 @@ fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         (((literal_length_distance_alphabet_code_lengths.into_iter()).fold(
             (none(())),
             (|x| match (x.1.code as u8) {
-                16 => {
-                    (
-                        x.0,
-                        (Vec::from_iter(
-                            ((std::iter::repeat(match x.0 {
-                                some(y) => {
-                                    y;
-                                }
-                            }))
-                            .take((x.1.extra + 3))),
-                        )),
-                    );
-                }
+                16 => (
+                    x.0,
+                    (Vec::from_iter(
+                        ((std::iter::repeat(match x.0 {
+                            some(y) => y,
+                        }))
+                        .take((x.1.extra + 3))),
+                    )),
+                ),
 
-                17 => {
-                    (
-                        x.0,
-                        (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 3))))),
-                    );
-                }
+                17 => (
+                    x.0,
+                    (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 3))))),
+                ),
 
-                18 => {
-                    (
-                        x.0,
-                        (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 11))))),
-                    );
-                }
+                18 => (
+                    x.0,
+                    (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 11))))),
+                ),
 
-                v => {
-                    ((some(v)), ([v].to_vec()));
-                }
+                v => ((some(v)), ([v].to_vec())),
             }),
         ))
         .collect())
@@ -5959,361 +5841,299 @@ fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let codes_values = {
         (((codes.into_iter()).flat_map(
             (|x| match x.code {
-                256 => {
-                    ([].to_vec());
-                }
+                256 => ([].to_vec()),
 
-                257 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                257 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                258 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                258 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                259 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                259 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                260 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                260 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                261 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                261 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                262 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                262 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                263 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                263 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                264 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                264 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                265 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                265 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                266 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                266 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                267 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                267 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                268 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                268 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                269 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                269 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                270 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                270 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                271 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                271 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                272 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                272 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                273 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                273 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                274 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                274 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                275 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                275 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                276 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                276 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                277 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                277 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                278 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                278 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                279 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                279 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                280 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                280 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                281 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                281 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                282 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                282 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                283 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                283 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                284 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                284 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                285 => {
-                    match x.extra {
-                        some(rec) => {
-                            ([reference {
-                                length: rec.length,
-                                distance: rec.distance_record.distance,
-                            }]
-                            .to_vec());
-                        }
-                    };
-                }
+                285 => match x.extra {
+                    some(rec) => {
+                        ([reference {
+                            length: rec.length,
+                            distance: rec.distance_record.distance,
+                        }]
+                        .to_vec())
+                    }
+                },
 
-                _ => {
-                    ([(literal((x.code as u8)))].to_vec());
-                }
+                _ => ([(literal((x.code as u8)))].to_vec()),
             }),
         ))
         .collect())
@@ -6445,13 +6265,13 @@ fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             33 => {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    255 => 1,
-
-                    254 => 1,
-
                     249 => 0,
 
                     1 => 0,
+
+                    255 => 1,
+
+                    254 => 1,
                 }
             }
 
@@ -6483,7 +6303,7 @@ fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(Type18 { separator }))
 }
 
-fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
+fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type16> {
     let graphic_control_extension = {
         let tree_index = {
             let lookahead = &mut (input.clone());
@@ -6504,32 +6324,32 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         match tree_index {
             0 => {
                 let inner = (Decoder138(scope, input))?;
-                (Type6::some(inner))
+                (Type10::some(inner))
             }
 
             1 => {
                 let inner = ();
-                (Type6::none(inner))
+                (Type10::none(inner))
             }
         }
     };
     let graphic_rendering_block = { (Decoder139(scope, input))? };
-    (Some(Type13 {
+    (Some(Type16 {
         graphic_control_extension,
         graphic_rendering_block,
     }))
 }
 
-fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type16> {
+fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
     let tree_index = {
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         if (b == 33) {
             let b = (lookahead.read_byte())?;
             match b {
-                254 => 1,
-
                 255 => 0,
+
+                254 => 1,
             }
         } else {
             return None;
@@ -6538,17 +6358,17 @@ fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(match tree_index {
         0 => {
             let inner = (Decoder134(scope, input))?;
-            (Type16::application_extension(inner))
+            (Type8::application_extension(inner))
         }
 
         1 => {
             let inner = (Decoder135(scope, input))?;
-            (Type16::comment_extension(inner))
+            (Type8::comment_extension(inner))
         }
     }))
 }
 
-fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type14> {
+fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
     let separator = {
         let b = (input.read_byte())?;
         if (b == 33) {
@@ -6609,7 +6429,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         accum
     };
     let terminator = { (Decoder137(scope, input))? };
-    (Some(Type14 {
+    (Some(Type7 {
         separator,
         label,
         block_size,
@@ -6620,7 +6440,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     }))
 }
 
-fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type15> {
+fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
     let separator = {
         let b = (input.read_byte())?;
         if (b == 33) {
@@ -6644,9 +6464,9 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -6659,7 +6479,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         accum
     };
     let terminator = { (Decoder137(scope, input))? };
-    (Some(Type15 {
+    (Some(Type6 {
         separator,
         label,
         comment_data,
@@ -6667,7 +6487,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     }))
 }
 
-fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
+fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type5> {
     let len_bytes = {
         let b = (input.read_byte())?;
         if (b != 0) {
@@ -6683,7 +6503,7 @@ fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
         accum
     };
-    (Some(Type8 { len_bytes, data }))
+    (Some(Type5 { len_bytes, data }))
 }
 
 fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
@@ -6695,7 +6515,7 @@ fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     }))
 }
 
-fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type5> {
+fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
     let separator = {
         let b = (input.read_byte())?;
         if (b == 33) {
@@ -6724,7 +6544,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let delay_time = { (Decoder113(scope, input))? };
     let transparent_color_index = { (Decoder16(scope, input))? };
     let terminator = { (Decoder137(scope, input))? };
-    (Some(Type5 {
+    (Some(Type9 {
         separator,
         label,
         block_size,
@@ -6735,7 +6555,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     }))
 }
 
-fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
+fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type15> {
     let tree_index = {
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
@@ -6748,17 +6568,17 @@ fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(match tree_index {
         0 => {
             let inner = (Decoder140(scope, input))?;
-            (Type12::table_based_image(inner))
+            (Type15::table_based_image(inner))
         }
 
         1 => {
             let inner = (Decoder141(scope, input))?;
-            (Type12::plain_text_extension(inner))
+            (Type15::plain_text_extension(inner))
         }
     }))
 }
 
-fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
+fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type14> {
     let descriptor = { (Decoder142(scope, input))? };
     let local_color_table = {
         match (descriptor.flags & 128 != 0) {
@@ -6780,7 +6600,7 @@ fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let data = { (Decoder144(scope, input))? };
-    (Some(Type10 {
+    (Some(Type14 {
         descriptor,
         local_color_table,
         data,
@@ -6859,7 +6679,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     }))
 }
 
-fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
+fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
     let separator = {
         let b = (input.read_byte())?;
         if (b == 44) {
@@ -6873,7 +6693,7 @@ fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let image_width = { (Decoder113(scope, input))? };
     let image_height = { (Decoder113(scope, input))? };
     let flags = { (Decoder16(scope, input))? };
-    (Some(Type7 {
+    (Some(Type12 {
         separator,
         image_left_position,
         image_top_position,
@@ -6890,7 +6710,7 @@ fn Decoder143<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     (Some(Type2 { r, g, b }))
 }
 
-fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
+fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
     let lzw_min_code_size = { (Decoder16(scope, input))? };
     let image_data = {
         let mut accum = (Vec::new());
@@ -6914,7 +6734,7 @@ fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         accum
     };
     let terminator = { (Decoder137(scope, input))? };
-    (Some(Type9 {
+    (Some(Type13 {
         lzw_min_code_size,
         image_data,
         terminator,

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,78 +1,9 @@
 use doodle::prelude::*;
 
-struct Type21 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-enum Type6 {
-    some(Type5),
-    none,
-}
-
-enum Type32 {
-    none,
-    some(Type31),
-}
-
-enum Type87 {
-    color_type_3(Type84),
-    color_type_6(Type85),
-    color_type_2(Type85),
-    color_type_4(Type86),
-    color_type_0(Type86),
-}
-
-struct Type91 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
-}
-
-struct Type28 {
-    length: u16,
-    distance: u16,
-}
-
-struct Type69 {
-    marker: Type42,
-    length: u16,
-    data: Type68,
-}
-
-struct Type77 {
-    num_lines: u16,
-}
-
 enum Type94 {
     color_type_3(Vec<Type84>),
     color_type_2(Type85),
     color_type_0(Type86),
-}
-
-struct Type39 {
-    blocks: Vec<Type38>,
-    codes: Vec<Type29>,
-    inflate: Vec<u8>,
-}
-
-struct Type41 {
-    header: Type20,
-    fname: Type22,
-    data: Type39,
-    footer: Type40,
-}
-
-enum Type48 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type58 {
-    marker: Type42,
-    length: u16,
-    data: Type57,
 }
 
 struct Type72 {
@@ -83,56 +14,67 @@ struct Type72 {
     approximation_bit_position: u8,
 }
 
-struct Type51 {
-    byte_order: Type48,
-    magic: u16,
-    offset: u32,
-    ifd: Type50,
+struct Type50 {
+    num_fields: u16,
+    fields: Vec<Type49>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
 }
 
-struct Type40 {
-    crc: u32,
-    length: u32,
+struct Type52 {
+    padding: u8,
+    exif: Type51,
 }
 
-struct Type49 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
+struct Type67 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
 }
 
-struct Type101 {
+struct Type34 {
+    codes: Vec<Type33>,
+    codes_values: Vec<Type29>,
+}
+
+struct Type102 {
     tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type100,
+    chunks: Vec<Type101>,
 }
 
-enum Type37 {
-    dynamic_huffman(Type30),
-    fixed_huffman(Type34),
-    uncompressed(Type36),
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
 }
 
-enum Type100 {
-    no(u8),
-    yes,
+struct Type57 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
 }
 
-enum Type111 {
-    gif(Type19),
-    gzip(Vec<Type41>),
-    jpeg(Type81),
-    png(Type99),
-    riff(Type103),
-    tar(Type109),
-    text(Type110),
+enum Type79 {
+    some(Type78),
+    none,
 }
 
-enum Type12 {
-    table_based_image(Type10),
-    plain_text_extension(Type11),
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type36 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type35>,
+}
+
+struct Type64 {
+    marker: Type42,
+    length: u16,
+    data: Type63,
 }
 
 struct Type75 {
@@ -152,58 +94,8 @@ enum Type74 {
     rst7(Type42),
 }
 
-struct Type38 {
-    r#final: u8,
-    r#type: u8,
-    data: Type37,
-}
-
-struct Type60 {
-    marker: Type42,
-    length: u16,
-    data: Type59,
-}
-
-struct Type27 {
-    code: u16,
-    extra: Type26,
-}
-
-enum Type26 {
-    none,
-    some(Type25),
-}
-
-struct Type31 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u8,
-    distance_record: Type24,
-}
-
-enum Type56 {
-    app0(Type46),
-    app1(Type55),
-}
-
-struct Type65 {
-    marker: Type42,
-    length: u16,
-    data: Vec<u8>,
-}
-
-enum Type44 {
-    other(Vec<u8>),
-    jfif(Type43),
-}
-
-struct Type99 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type83,
-    chunks: Vec<Type96>,
-    idat: Vec<Type97>,
-    more_chunks: Vec<Type96>,
-    iend: Type98,
+struct Type86 {
+    greyscale: u16,
 }
 
 struct Type107 {
@@ -226,99 +118,24 @@ struct Type107 {
     pad: Vec<u8>,
 }
 
-enum Type3 {
+enum Type22 {
     no,
-    yes(Vec<Type2>),
+    yes(Type21),
 }
 
-struct Type54 {
-    identifier: Type21,
-    data: Type53,
+struct Type21 {
+    string: Vec<u8>,
+    null: u8,
 }
 
-struct Type55 {
-    marker: Type42,
-    length: u16,
-    data: Type54,
-}
-
-struct Type88 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type87,
-    crc: u32,
-}
-
-struct Type62 {
-    marker: Type42,
-    length: u16,
-    data: Type61,
-}
-
-struct Type92 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type24 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-enum Type70 {
-    sof0(Type69),
-    sof1(Type69),
-    sof2(Type69),
-    sof3(Type69),
-    sof5(Type69),
-    sof6(Type69),
-    sof7(Type69),
-    sof9(Type69),
-    sof10(Type69),
-    sof11(Type69),
-    sof13(Type69),
-    sof14(Type69),
-    sof15(Type69),
+enum Type12 {
+    table_based_image(Type10),
+    plain_text_extension(Type11),
 }
 
 enum Type16 {
     application_extension(Type14),
     comment_extension(Type15),
-}
-
-struct Type23 {
-    code: u16,
-    extra: u8,
-}
-
-enum Type110 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-struct Type11 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type13 {
-    graphic_control_extension: Type6,
-    graphic_rendering_block: Type12,
 }
 
 struct Type30 {
@@ -332,6 +149,371 @@ struct Type30 {
     distance_alphabet_code_lengths_value: Vec<u8>,
     codes: Vec<Type27>,
     codes_values: Vec<Type29>,
+}
+
+struct Type38 {
+    r#final: u8,
+    r#type: u8,
+    data: Type37,
+}
+
+struct Type8 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+struct Type51 {
+    byte_order: Type48,
+    magic: u16,
+    offset: u32,
+    ifd: Type50,
+}
+
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+enum Type56 {
+    app0(Type46),
+    app1(Type55),
+}
+
+struct Type65 {
+    marker: Type42,
+    length: u16,
+    data: Vec<u8>,
+}
+
+struct Type19 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type17>,
+    trailer: Type18,
+}
+
+enum Type26 {
+    none,
+    some(Type25),
+}
+
+enum Type48 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+struct Type99 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type83,
+    chunks: Vec<Type96>,
+    idat: Vec<Type97>,
+    more_chunks: Vec<Type96>,
+    iend: Type98,
+}
+
+enum Type37 {
+    dynamic_huffman(Type30),
+    fixed_huffman(Type34),
+    uncompressed(Type36),
+}
+
+struct Type58 {
+    marker: Type42,
+    length: u16,
+    data: Type57,
+}
+
+struct Type62 {
+    marker: Type42,
+    length: u16,
+    data: Type61,
+}
+
+enum Type3 {
+    no,
+    yes(Vec<Type2>),
+}
+
+struct Type104 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type13 {
+    graphic_control_extension: Type6,
+    graphic_rendering_block: Type12,
+}
+
+struct Type27 {
+    code: u16,
+    extra: Type26,
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type82,
+    crc: u32,
+}
+
+enum Type29 {
+    literal(u8),
+    reference(Type28),
+}
+
+struct Type78 {
+    marker: Type42,
+    length: u16,
+    data: Type77,
+}
+
+struct Type39 {
+    blocks: Vec<Type38>,
+    codes: Vec<Type29>,
+    inflate: Vec<u8>,
+}
+
+struct Type25 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u16,
+    distance_record: Type24,
+}
+
+struct Type77 {
+    num_lines: u16,
+}
+
+struct Type101 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type100,
+}
+
+struct Type95 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type94,
+    crc: u32,
+}
+
+struct Type41 {
+    header: Type20,
+    fname: Type22,
+    data: Type39,
+    footer: Type40,
+}
+
+enum Type44 {
+    other(Vec<u8>),
+    jfif(Type43),
+}
+
+struct Type10 {
+    descriptor: Type7,
+    local_color_table: Type3,
+    data: Type9,
+}
+
+struct Type55 {
+    marker: Type42,
+    length: u16,
+    data: Type54,
+}
+
+struct Type80 {
+    initial_segment: Type56,
+    segments: Vec<Type66>,
+    header: Type70,
+    scan: Type76,
+    dnl: Type79,
+    scans: Vec<Type76>,
+}
+
+struct Type82 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type109 {
+    contents: Vec<Type108>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
+}
+
+struct Type5 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+struct Type18 {
+    separator: u8,
+}
+
+struct Type28 {
+    length: u16,
+    distance: u16,
+}
+
+enum Type110 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+struct Type33 {
+    code: u16,
+    extra: Type32,
+}
+
+struct Type60 {
+    marker: Type42,
+    length: u16,
+    data: Type59,
+}
+
+struct Type49 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
+struct Type69 {
+    marker: Type42,
+    length: u16,
+    data: Type68,
+}
+
+struct Type23 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type89 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+enum Type35 {
+    literal(u8),
+}
+
+enum Type17 {
+    graphic_block(Type13),
+    special_purpose_block(Type16),
+}
+
+struct Type93 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type92,
+    crc: u32,
+}
+
+struct Type106 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+struct Type112 {
+    data: Type111,
+    end: (),
+}
+
+struct Type54 {
+    identifier: Type21,
+    data: Type53,
+}
+
+struct Type46 {
+    marker: Type42,
+    length: u16,
+    data: Type45,
+}
+
+struct Type31 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u8,
+    distance_record: Type24,
+}
+
+struct Type15 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type71 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
+}
+
+struct Type103 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type102,
+    pad: Type100,
+}
+
+struct Type43 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+struct Type88 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type87,
+    crc: u32,
+}
+
+struct Type47 {
+    xmp: Vec<u8>,
+}
+
+enum Type96 {
+    bKGD(Type88),
+    pHYs(Type90),
+    PLTE(Type91),
+    tIME(Type93),
+    tRNS(Type95),
+}
+
+struct Type108 {
+    header: Type107,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type45 {
+    identifier: Type21,
+    data: Type44,
+}
+
+struct Type9 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type8>,
+    terminator: u8,
 }
 
 enum Type66 {
@@ -358,81 +540,16 @@ enum Type66 {
     com(Type65),
 }
 
-struct Type71 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
+struct Type59 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
 }
 
-struct Type80 {
-    initial_segment: Type56,
-    segments: Vec<Type66>,
-    header: Type70,
-    scan: Type76,
-    dnl: Type79,
-    scans: Vec<Type76>,
-}
-
-struct Type64 {
-    marker: Type42,
-    length: u16,
-    data: Type63,
-}
-
-struct Type112 {
-    data: Type111,
-    end: (),
-}
-
-struct Type82 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type95 {
+struct Type91 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Type94,
-    crc: u32,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type34 {
-    codes: Vec<Type33>,
-    codes_values: Vec<Type29>,
-}
-
-struct Type102 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type101>,
-}
-
-struct Type9 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type93 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type92,
+    data: Vec<Type2>,
     crc: u32,
 }
 
@@ -442,166 +559,9 @@ struct Type85 {
     blue: u16,
 }
 
-struct Type109 {
-    contents: Vec<Type108>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-struct Type63 {
-    restart_interval: u16,
-}
-
-struct Type52 {
-    padding: u8,
-    exif: Type51,
-}
-
-struct Type76 {
-    segments: Vec<Type66>,
-    sos: Type73,
-    data: Type75,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type57 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-enum Type53 {
-    other(Vec<u8>),
-    xmp(Type47),
-    exif(Type52),
-}
-
-struct Type47 {
-    xmp: Vec<u8>,
-}
-
-struct Type89 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-enum Type96 {
-    bKGD(Type88),
-    pHYs(Type90),
-    PLTE(Type91),
-    tIME(Type93),
-    tRNS(Type95),
-}
-
-enum Type17 {
-    graphic_block(Type13),
-    special_purpose_block(Type16),
-}
-
-struct Type108 {
-    header: Type107,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type81 {
-    soi: Type42,
-    frame: Type80,
-    eoi: Type42,
-}
-
-struct Type15 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type46 {
-    marker: Type42,
-    length: u16,
-    data: Type45,
-}
-
-struct Type90 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type89,
-    crc: u32,
-}
-
-struct Type84 {
-    palette_index: u8,
-}
-
-struct Type20 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type103 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type102,
-    pad: Type100,
-}
-
-struct Type10 {
-    descriptor: Type7,
-    local_color_table: Type3,
-    data: Type9,
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type82,
-    crc: u32,
-}
-
-struct Type61 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type106 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-struct Type68 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type67>,
-}
-
-enum Type22 {
-    no,
-    yes(Type21),
-}
-
-struct Type19 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type17>,
-    trailer: Type18,
-}
-
-struct Type25 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u16,
-    distance_record: Type24,
+struct Type42 {
+    ff: u8,
+    marker: u8,
 }
 
 struct Type14 {
@@ -614,31 +574,24 @@ struct Type14 {
     terminator: u8,
 }
 
-struct Type33 {
-    code: u16,
-    extra: Type32,
+enum Type70 {
+    sof0(Type69),
+    sof1(Type69),
+    sof2(Type69),
+    sof3(Type69),
+    sof5(Type69),
+    sof6(Type69),
+    sof7(Type69),
+    sof9(Type69),
+    sof10(Type69),
+    sof11(Type69),
+    sof13(Type69),
+    sof14(Type69),
+    sof15(Type69),
 }
 
-enum Type35 {
-    literal(u8),
-}
-
-struct Type50 {
-    num_fields: u16,
-    fields: Vec<Type49>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-enum Type79 {
-    some(Type78),
-    none,
-}
-
-struct Type73 {
-    marker: Type42,
-    length: u16,
-    data: Type72,
+struct Type84 {
+    palette_index: u8,
 }
 
 struct Type7 {
@@ -650,39 +603,34 @@ struct Type7 {
     flags: u8,
 }
 
-struct Type36 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type35>,
+struct Type63 {
+    restart_interval: u16,
 }
 
-struct Type43 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
+struct Type73 {
+    marker: Type42,
+    length: u16,
+    data: Type72,
 }
 
-struct Type45 {
-    identifier: Type21,
-    data: Type44,
+struct Type90 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type89,
+    crc: u32,
 }
 
-struct Type59 {
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+struct Type61 {
     class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-struct Type104 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
+    value: u8,
 }
 
 struct Type98 {
@@ -692,46 +640,25 @@ struct Type98 {
     crc: u32,
 }
 
-struct Type78 {
-    marker: Type42,
-    length: u16,
-    data: Type77,
+enum Type111 {
+    gif(Type19),
+    gzip(Vec<Type41>),
+    jpeg(Type81),
+    png(Type99),
+    riff(Type103),
+    tar(Type109),
+    text(Type110),
 }
 
-struct Type86 {
-    greyscale: u16,
+struct Type76 {
+    segments: Vec<Type66>,
+    sos: Type73,
+    data: Type75,
 }
 
-struct Type8 {
-    len_bytes: u8,
-    data: Vec<u8>,
-}
-
-struct Type67 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-struct Type5 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-enum Type29 {
-    literal(u8),
-    reference(Type28),
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
+enum Type100 {
+    no(u8),
+    yes,
 }
 
 struct Type97 {
@@ -741,19 +668,92 @@ struct Type97 {
     crc: u32,
 }
 
-struct Type42 {
-    ff: u8,
-    marker: u8,
+struct Type24 {
+    distance_extra_bits: u16,
+    distance: u16,
 }
 
-struct Type18 {
+struct Type11 {
     separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type8>,
+    terminator: u8,
+}
+
+enum Type6 {
+    some(Type5),
+    none,
+}
+
+enum Type32 {
+    none,
+    some(Type31),
+}
+
+struct Type81 {
+    soi: Type42,
+    frame: Type80,
+    eoi: Type42,
+}
+
+struct Type20 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type92 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type40 {
+    crc: u32,
+    length: u32,
+}
+
+enum Type53 {
+    other(Vec<u8>),
+    xmp(Type47),
+    exif(Type52),
+}
+
+struct Type68 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type67>,
 }
 
 struct Type105 {
     string: Vec<u8>,
     __nul_or_wsp: u8,
     __padding: Vec<u8>,
+}
+
+enum Type87 {
+    color_type_3(Type84),
+    color_type_6(Type85),
+    color_type_2(Type85),
+    color_type_4(Type86),
+    color_type_0(Type86),
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
@@ -780,13 +780,13 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    59 => 1,
-
                     33 => 0,
 
                     44 => 0,
+
+                    59 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -812,7 +812,7 @@ fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     while true {
         let matching_ix = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             if (b == 31) {
                 1
             } else {
@@ -867,10 +867,8 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    73 => 1,
-
                     98 => 0,
 
                     112 => 0,
@@ -878,6 +876,8 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     80 => 0,
 
                     116 => 0,
+
+                    73 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -894,14 +894,14 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     73 => {
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
-                            69 => 0,
-
                             68 => 1,
+
+                            69 => 0,
                         }
                     }
 
@@ -928,8 +928,10 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
+                    73 => 1,
+
                     98 => 0,
 
                     112 => 0,
@@ -937,8 +939,6 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     80 => 0,
 
                     116 => 0,
-
-                    73 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1033,11 +1033,11 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 1,
-
                     0 => 0,
+
+                    tmp if (tmp != 0) => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1068,7 +1068,7 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
                 } else {
@@ -1107,7 +1107,7 @@ fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     while true {
         let matching_ix = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             if ((ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]))
                 .contains(b))
             {
@@ -1131,7 +1131,7 @@ fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     while true {
         let matching_ix = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
                 tmp if ((ByteSet::from_bits([
                     18446744073709551615,
@@ -1175,7 +1175,7 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let inner = {
         let tree_index = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
                 tmp if ((ByteSet::from_bits([
                     18446744073709551615,
@@ -1188,6 +1188,12 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     0
                 }
 
+                240 => 3,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
+
+                244 => 3,
+
                 tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
 
                 224 => 2,
@@ -1197,12 +1203,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 237 => 2,
 
                 tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
-
-                240 => 3,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
-
-                244 => 3,
             }
         };
         match tree_index {
@@ -1247,17 +1247,17 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let inner = {
                     let tree_index = {
                         let lookahead = (input.clone());
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
+                            224 => 0,
+
+                            237 => 2,
+
                             tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
                                 .contains(tmp)) =>
                             {
                                 3
                             }
-
-                            224 => 0,
-
-                            237 => 2,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
                                 .contains(tmp)) =>
@@ -1372,17 +1372,17 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let inner = {
                     let tree_index = {
                         let lookahead = (input.clone());
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
+                            244 => 2,
+
+                            240 => 0,
+
                             tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
                                 .contains(tmp)) =>
                             {
                                 1
                             }
-
-                            244 => 2,
-
-                            240 => 0,
                         }
                     };
                     match tree_index {
@@ -1536,11 +1536,11 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 1,
-
                     0 => 0,
+
+                    tmp if (tmp != 0) => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1564,7 +1564,7 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
                 } else {
@@ -1623,11 +1623,11 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1651,7 +1651,7 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
                 } else {
@@ -1683,7 +1683,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
 
@@ -1711,7 +1711,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     1
                 } else {
@@ -1898,20 +1898,20 @@ fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         match b {
+            116 => {
+                let b = (lookahead.read_byte())?;
+                match b {
+                    82 => 4,
+
+                    73 => 3,
+                }
+            }
+
             98 => 0,
 
             80 => 2,
-
-            116 => {
-                let b = (lookahead.read_byte());
-                match b {
-                    73 => 3,
-
-                    82 => 4,
-                }
-            }
 
             112 => 1,
         }
@@ -2397,13 +2397,13 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let initial_segment = {
         let tree_index = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             if (b == 255) {
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    225 => 1,
-
                     224 => 0,
+
+                    225 => 1,
                 }
             } else {
                 return None;
@@ -2426,10 +2426,36 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 255) {
-                    let b = (lookahead.read_byte());
+                    let b = (lookahead.read_byte())?;
                     match b {
+                        192 => 1,
+
+                        193 => 1,
+
+                        194 => 1,
+
+                        195 => 1,
+
+                        197 => 1,
+
+                        198 => 1,
+
+                        199 => 1,
+
+                        201 => 1,
+
+                        202 => 1,
+
+                        203 => 1,
+
+                        205 => 1,
+
+                        206 => 1,
+
+                        207 => 1,
+
                         219 => 0,
 
                         196 => 0,
@@ -2471,32 +2497,6 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
-
-                        192 => 1,
-
-                        193 => 1,
-
-                        194 => 1,
-
-                        195 => 1,
-
-                        197 => 1,
-
-                        198 => 1,
-
-                        199 => 1,
-
-                        201 => 1,
-
-                        202 => 1,
-
-                        203 => 1,
-
-                        205 => 1,
-
-                        206 => 1,
-
-                        207 => 1,
                     }
                 } else {
                     return None;
@@ -2516,9 +2516,9 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let dnl = {
         let tree_index = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             if (b == 255) {
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     220 => 0,
 
@@ -2589,12 +2589,10 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 255) {
-                    let b = (lookahead.read_byte());
+                    let b = (lookahead.read_byte())?;
                     match b {
-                        217 => 1,
-
                         218 => 0,
 
                         219 => 0,
@@ -2638,6 +2636,8 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
+
+                        217 => 1,
                     }
                 } else {
                     return None;
@@ -2743,51 +2743,51 @@ fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type66> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         if (b == 255) {
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
-                233 => 13,
-
-                196 => 1,
-
-                235 => 15,
-
                 254 => 20,
-
-                221 => 3,
-
-                219 => 0,
-
-                237 => 17,
-
-                231 => 11,
-
-                230 => 10,
-
-                234 => 14,
-
-                238 => 18,
 
                 236 => 16,
 
-                224 => 4,
+                204 => 2,
 
-                239 => 19,
+                234 => 14,
+
+                237 => 17,
 
                 232 => 12,
 
-                225 => 5,
+                230 => 10,
+
+                235 => 15,
+
+                228 => 8,
 
                 227 => 7,
 
-                204 => 2,
+                196 => 1,
 
-                229 => 9,
+                224 => 4,
+
+                238 => 18,
+
+                239 => 19,
+
+                233 => 13,
+
+                219 => 0,
+
+                231 => 11,
 
                 226 => 6,
 
-                228 => 8,
+                225 => 5,
+
+                221 => 3,
+
+                229 => 9,
             }
         } else {
             return None;
@@ -2904,35 +2904,35 @@ fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type70> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         if (b == 255) {
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
-                197 => 4,
-
-                203 => 9,
-
                 199 => 6,
 
-                193 => 1,
+                198 => 5,
 
-                202 => 8,
+                194 => 2,
+
+                197 => 4,
 
                 206 => 11,
 
                 207 => 12,
 
+                202 => 8,
+
                 201 => 7,
 
-                205 => 10,
+                193 => 1,
 
-                194 => 2,
+                203 => 9,
 
                 195 => 3,
 
-                192 => 0,
+                205 => 10,
 
-                198 => 5,
+                192 => 0,
             }
         } else {
             return None;
@@ -3012,9 +3012,9 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 255) {
-                    let b = (lookahead.read_byte());
+                    let b = (lookahead.read_byte())?;
                     match b {
                         219 => 0,
 
@@ -3117,9 +3117,9 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 if (b == 255) {
-                    let b = (lookahead.read_byte());
+                    let b = (lookahead.read_byte())?;
                     match b {
                         218 => 1,
 
@@ -3222,11 +3222,31 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
+                    tmp if (tmp != 255) => 0,
+
                     255 => {
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
+                            0 => 0,
+
+                            208 => 0,
+
+                            209 => 0,
+
+                            210 => 0,
+
+                            211 => 0,
+
+                            212 => 0,
+
+                            213 => 0,
+
+                            214 => 0,
+
+                            215 => 0,
+
                             217 => 1,
 
                             218 => 1,
@@ -3272,60 +3292,40 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             239 => 1,
 
                             254 => 1,
-
-                            0 => 0,
-
-                            208 => 0,
-
-                            209 => 0,
-
-                            210 => 0,
-
-                            211 => 0,
-
-                            212 => 0,
-
-                            213 => 0,
-
-                            214 => 0,
-
-                            215 => 0,
                         }
                     }
-
-                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
                 let next_elem = {
                     let tree_index = {
                         let lookahead = (input.clone());
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
+                            tmp if (tmp != 255) => 0,
+
                             255 => {
-                                let b = (lookahead.read_byte());
+                                let b = (lookahead.read_byte())?;
                                 match b {
-                                    214 => 7,
-
-                                    210 => 3,
-
-                                    211 => 4,
-
-                                    215 => 8,
-
-                                    212 => 5,
-
-                                    209 => 2,
+                                    0 => 0,
 
                                     213 => 6,
 
-                                    0 => 0,
+                                    210 => 3,
+
+                                    212 => 5,
 
                                     208 => 1,
+
+                                    215 => 8,
+
+                                    211 => 4,
+
+                                    209 => 2,
+
+                                    214 => 7,
                                 }
                             }
-
-                            tmp if (tmp != 255) => 0,
                         }
                     };
                     match tree_index {
@@ -3433,7 +3433,7 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         match b {
             255 => 1,
 
@@ -3676,10 +3676,10 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     255 => {
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
                             0 => 0,
 
@@ -3756,28 +3756,28 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let next_elem = {
                     let tree_index = {
                         let lookahead = (input.clone());
-                        let b = (lookahead.read_byte());
+                        let b = (lookahead.read_byte())?;
                         match b {
                             255 => {
-                                let b = (lookahead.read_byte());
+                                let b = (lookahead.read_byte())?;
                                 match b {
                                     214 => 7,
-
-                                    212 => 5,
-
-                                    210 => 3,
-
-                                    208 => 1,
-
-                                    215 => 8,
-
-                                    209 => 2,
-
-                                    0 => 0,
 
                                     211 => 4,
 
                                     213 => 6,
+
+                                    215 => 8,
+
+                                    208 => 1,
+
+                                    210 => 3,
+
+                                    0 => 0,
+
+                                    212 => 5,
+
+                                    209 => 2,
                                 }
                             }
 
@@ -4961,11 +4961,11 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -5032,7 +5032,7 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let byte_order = {
         let tree_index = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
                 73 => 0,
 
@@ -5152,7 +5152,7 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
 
@@ -6338,7 +6338,7 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
 
@@ -6440,18 +6440,18 @@ fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type17> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         match b {
             33 => {
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    249 => 0,
-
-                    1 => 0,
-
                     255 => 1,
 
                     254 => 1,
+
+                    249 => 0,
+
+                    1 => 0,
                 }
             }
 
@@ -6487,18 +6487,18 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let graphic_control_extension = {
         let tree_index = {
             let lookahead = (input.clone());
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
-                44 => 1,
-
                 33 => {
-                    let b = (lookahead.read_byte());
+                    let b = (lookahead.read_byte())?;
                     match b {
                         249 => 0,
 
                         1 => 1,
                     }
                 }
+
+                44 => 1,
             }
         };
         match tree_index {
@@ -6523,9 +6523,9 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type16> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         if (b == 33) {
-            let b = (lookahead.read_byte());
+            let b = (lookahead.read_byte())?;
             match b {
                 255 => 0,
 
@@ -6592,7 +6592,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
 
@@ -6642,7 +6642,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
 
@@ -6738,7 +6738,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
     let tree_index = {
         let lookahead = (input.clone());
-        let b = (lookahead.read_byte());
+        let b = (lookahead.read_byte())?;
         match b {
             44 => 0,
 
@@ -6825,7 +6825,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
 
@@ -6897,11 +6897,11 @@ fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         while true {
             let matching_ix = {
                 let lookahead = (input.clone());
-                let b = (lookahead.read_byte());
+                let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,91 +1,68 @@
 use doodle::prelude::*;
 
-struct Type86 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type62,
-    crc: u32,
+enum Type36 {
+    other(Vec<u8>),
+    xmp { xmp: Vec<u8> },
+    exif { padding: u8, exif: Type35 },
 }
 
-enum Type23 {
-    dynamic_huffman {
-        hlit: u8,
-        hdist: u8,
-        hclen: u8,
-        code_length_alphabet_code_lengths: Vec<u8>,
-        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-        literal_length_alphabet_code_lengths_value: Vec<u8>,
-        distance_alphabet_code_lengths_value: Vec<u8>,
-        codes: Vec<Type18>,
-        codes_values: Vec<Type19>,
-    },
-    fixed_huffman {
-        codes: Vec<Type21>,
-        codes_values: Vec<Type19>,
-    },
-    uncompressed {
-        align: (),
-        len: u16,
-        nlen: u16,
-        bytes: Vec<u8>,
-        codes_values: Vec<Type22>,
-    },
+struct Type41 {
+    class_table_id: u8,
+    value: u8,
 }
 
-struct Type92 {
+struct Type94 {
     marker: Type28,
     length: u16,
-    data: Type40,
+    data: Type42,
 }
 
-struct Type84 {
+struct Type82 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
+    data: Type58,
     crc: u32,
 }
 
-enum Type30 {
-    other(Vec<u8>),
-    jfif {
-        version_major: u8,
-        version_minor: u8,
-        density_units: u8,
-        density_x: u16,
-        density_y: u16,
-        thumbnail_width: u8,
-        thumbnail_height: u8,
-        thumbnail_pixels: Vec<Vec<Type2>>,
-    },
+struct Type64 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<u8>,
+    crc: u32,
 }
 
-struct Type99 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type22>,
-}
-
-struct Type39 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-struct Type100 {
-    codes: Vec<Type21>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type21 {
-    code: u16,
-    extra: Type20,
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
 }
 
 struct Type7 {
     len_bytes: u8,
     data: Vec<u8>,
+}
+
+struct Type68 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type67>,
+}
+
+enum Type32 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+enum Type74 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+struct Type88 {
+    marker: Type28,
+    length: u16,
+    data: Type37,
 }
 
 enum Type43 {
@@ -196,177 +173,6 @@ enum Type43 {
     },
 }
 
-struct Type28 {
-    ff: u8,
-    marker: u8,
-}
-
-struct Type57 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type56,
-    crc: u32,
-}
-
-struct Type77 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type11>,
-    trailer: Type12,
-}
-
-struct Type59 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-struct Type67 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type66,
-}
-
-struct Type88 {
-    marker: Type28,
-    length: u16,
-    data: Type37,
-}
-
-struct Type35 {
-    byte_order: Type32,
-    magic: u16,
-    offset: u32,
-    ifd: Type34,
-}
-
-enum Type11 {
-    graphic_block {
-        graphic_control_extension: Type5,
-        graphic_rendering_block: Type9,
-    },
-    special_purpose_block(Type10),
-}
-
-struct Type26 {
-    crc: u32,
-    length: u32,
-}
-
-struct Type87 {
-    marker: Type28,
-    length: u16,
-    data: Type31,
-}
-
-struct Type93 {
-    marker: Type28,
-    length: u16,
-    data: Type41,
-}
-
-struct Type107 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type7>,
-    terminator: u8,
-}
-
-enum Type5 {
-    some {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        flags: u8,
-        delay_time: u16,
-        transparent_color_index: u8,
-        terminator: u8,
-    },
-    none(),
-}
-
-struct Type89 {
-    marker: Type28,
-    length: u16,
-    data: Type53,
-}
-
-enum Type10 {
-    application_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        identifier: Vec<u8>,
-        authentication_code: Vec<u8>,
-        application_data: Vec<Type7>,
-        terminator: u8,
-    },
-    comment_extension {
-        separator: u8,
-        label: u8,
-        comment_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type25 {
-    blocks: Vec<Type24>,
-    codes: Vec<Type19>,
-    inflate: Vec<u8>,
-}
-
-struct Type33 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type41 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
-struct Type45 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type44>,
-}
-
-struct Type96 {
-    padding: u8,
-    exif: Type35,
-}
-
-struct Type98 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
 enum Type20 {
     none(),
     some {
@@ -377,317 +183,28 @@ enum Type20 {
     },
 }
 
-enum Type36 {
-    other(Vec<u8>),
-    xmp { xmp: Vec<u8> },
-    exif { padding: u8, exif: Type35 },
+struct Type61 {
+    palette_index: u8,
 }
 
-struct Type72 {
-    name: Type69,
-    mode: Type70,
-    uid: Type70,
-    gid: Type70,
-    size: u32,
-    mtime: Type70,
-    chksum: Type70,
-    typeflag: u8,
-    linkname: Type69,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type71,
-    gname: Type71,
-    devmajor: Type70,
-    devminor: Type70,
-    prefix: Type69,
-    pad: Vec<u8>,
+struct Type25 {
+    blocks: Vec<Type24>,
+    codes: Vec<Type19>,
+    inflate: Vec<u8>,
 }
 
-struct Type82 {
+struct Type27 {
+    header: Type13,
+    fname: Type14,
+    data: Type25,
+    footer: Type26,
+}
+
+struct Type33 {
+    tag: u16,
+    r#type: u16,
     length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type58,
-    crc: u32,
-}
-
-struct Type42 {
-    restart_interval: u16,
-}
-
-enum Type19 {
-    literal(u8),
-    reference { length: u16, distance: u16 },
-}
-
-struct Type44 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-struct Type60 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type6 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-enum Type54 {
-    some {
-        marker: Type28,
-        length: u16,
-        data: Type53,
-    },
-    none(),
-}
-
-struct Type31 {
-    identifier: Type29,
-    data: Type30,
-}
-
-struct Type103 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type55 {
-    initial_segment: Type38,
-    segments: Vec<Type43>,
-    header: Type46,
-    scan: Type52,
-    dnl: Type54,
-    scans: Vec<Type52>,
-}
-
-enum Type38 {
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-}
-
-struct Type51 {
-    scan_data: Vec<Type50>,
-    scan_data_stream: Vec<u8>,
-}
-
-enum Type58 {
-    color_type_3 { palette_index: u8 },
-    color_type_6 { red: u16, green: u16, blue: u16 },
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_4 { greyscale: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-struct Type13 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type49 {
-    marker: Type28,
-    length: u16,
-    data: Type48,
-}
-
-enum Type66 {
-    no(u8),
-    yes(),
-}
-
-struct Type68 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type67>,
-}
-
-struct Type81 {
-    contents: Vec<Type73>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-struct Type101 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type18>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type105 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type12 {
-    separator: u8,
-}
-
-struct Type106 {
-    descriptor: Type6,
-    local_color_table: Type3,
-    data: Type8,
-}
-
-enum Type9 {
-    table_based_image {
-        descriptor: Type6,
-        local_color_table: Type3,
-        data: Type8,
-    },
-    plain_text_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        text_grid_left_position: u16,
-        text_grid_top_position: u16,
-        text_grid_width: u16,
-        text_grid_height: u16,
-        character_cell_width: u8,
-        character_cell_height: u8,
-        text_foreground_color_index: u8,
-        text_background_color_index: u8,
-        plain_text_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type56 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-enum Type32 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type8 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type24 {
-    r#final: u8,
-    r#type: u8,
-    data: Type23,
-}
-
-enum Type50 {
-    mcu(u8),
-    rst0 { ff: u8, marker: u8 },
-    rst1 { ff: u8, marker: u8 },
-    rst2 { ff: u8, marker: u8 },
-    rst3 { ff: u8, marker: u8 },
-    rst4 { ff: u8, marker: u8 },
-    rst5 { ff: u8, marker: u8 },
-    rst6 { ff: u8, marker: u8 },
-    rst7 { ff: u8, marker: u8 },
-}
-
-struct Type94 {
-    marker: Type28,
-    length: u16,
-    data: Type42,
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type59,
-    crc: u32,
-}
-
-struct Type53 {
-    num_lines: u16,
-}
-
-struct Type79 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type57,
-    chunks: Vec<Type63>,
-    idat: Vec<Type64>,
-    more_chunks: Vec<Type63>,
-    iend: Type65,
-}
-
-struct Type85 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type60,
-    crc: u32,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type15 {
-    code: u16,
-    extra: u8,
-}
-
-enum Type17 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u16,
-        distance_record: Type16,
-    },
-}
-
-enum Type22 {
-    literal(u8),
+    offset_or_data: u32,
 }
 
 struct Type29 {
@@ -695,108 +212,11 @@ struct Type29 {
     null: u8,
 }
 
-enum Type3 {
-    no(),
-    yes(Vec<Type2>),
-}
-
-struct Type37 {
-    identifier: Type29,
-    data: Type36,
-}
-
-struct Type73 {
-    header: Type72,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type102 {
-    graphic_control_extension: Type5,
-    graphic_rendering_block: Type9,
-}
-
-struct Type69 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-struct Type104 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type48 {
-    num_image_components: u8,
-    image_components: Vec<Type47>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-enum Type62 {
-    color_type_3(Vec<Type61>),
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-struct Type52 {
-    segments: Vec<Type43>,
-    sos: Type49,
-    data: Type51,
-}
-
-enum Type75 {
-    gif {
-        header: Type0,
-        logical_screen: Type4,
-        blocks: Vec<Type11>,
-        trailer: Type12,
-    },
-    gzip(Vec<Type27>),
-    jpeg {
-        soi: Type28,
-        frame: Type55,
-        eoi: Type28,
-    },
-    png {
-        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-        ihdr: Type57,
-        chunks: Vec<Type63>,
-        idat: Vec<Type64>,
-        more_chunks: Vec<Type63>,
-        iend: Type65,
-    },
-    riff {
-        tag: (u8, u8, u8, u8),
-        length: u32,
-        data: Type68,
-        pad: Type66,
-    },
-    tar {
-        contents: Vec<Type73>,
-        __padding: Vec<u8>,
-        __trailing: Vec<u8>,
-    },
-    text(Type74),
-}
-
-struct Type91 {
-    marker: Type28,
-    length: u16,
-    data: Type39,
-}
-
-struct Type70 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-struct Type61 {
-    palette_index: u8,
+struct Type34 {
+    num_fields: u16,
+    fields: Vec<Type33>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
 }
 
 enum Type46 {
@@ -867,25 +287,262 @@ enum Type46 {
     },
 }
 
-struct Type71 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
+struct Type80 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type68,
+    pad: Type66,
 }
 
-struct Type16 {
-    distance_extra_bits: u16,
-    distance: u16,
+struct Type84 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
 }
 
-struct Type40 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
+struct Type85 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type60,
+    crc: u32,
 }
 
-struct Type47 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
+struct Type81 {
+    contents: Vec<Type73>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
+}
+
+struct Type90 {
+    marker: Type28,
+    length: u16,
+    data: Type45,
+}
+
+struct Type100 {
+    codes: Vec<Type21>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type79 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type57,
+    chunks: Vec<Type63>,
+    idat: Vec<Type64>,
+    more_chunks: Vec<Type63>,
+    iend: Type65,
+}
+
+struct Type103 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type78 {
+    soi: Type28,
+    frame: Type55,
+    eoi: Type28,
+}
+
+struct Type92 {
+    marker: Type28,
+    length: u16,
+    data: Type40,
+}
+
+struct Type45 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type44>,
+}
+
+enum Type3 {
+    no(),
+    yes(Vec<Type2>),
+}
+
+struct Type24 {
+    r#final: u8,
+    r#type: u8,
+    data: Type23,
+}
+
+struct Type8 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type55 {
+    initial_segment: Type38,
+    segments: Vec<Type43>,
+    header: Type46,
+    scan: Type52,
+    dnl: Type54,
+    scans: Vec<Type52>,
+}
+
+struct Type15 {
+    code: u16,
+    extra: u8,
+}
+
+enum Type58 {
+    color_type_3 { palette_index: u8 },
+    color_type_6 { red: u16, green: u16, blue: u16 },
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_4 { greyscale: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type59 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+struct Type48 {
+    num_image_components: u8,
+    image_components: Vec<Type47>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type51 {
+    scan_data: Vec<Type50>,
+    scan_data_stream: Vec<u8>,
+}
+
+struct Type35 {
+    byte_order: Type32,
+    magic: u16,
+    offset: u32,
+    ifd: Type34,
+}
+
+enum Type19 {
+    literal(u8),
+    reference { length: u16, distance: u16 },
+}
+
+struct Type12 {
+    separator: u8,
+}
+
+struct Type72 {
+    name: Type69,
+    mode: Type70,
+    uid: Type70,
+    gid: Type70,
+    size: u32,
+    mtime: Type70,
+    chksum: Type70,
+    typeflag: u8,
+    linkname: Type69,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type71,
+    gname: Type71,
+    devmajor: Type70,
+    devminor: Type70,
+    prefix: Type69,
+    pad: Vec<u8>,
+}
+
+struct Type95 {
+    marker: Type28,
+    length: u16,
+    data: Vec<u8>,
+}
+
+enum Type5 {
+    some {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        flags: u8,
+        delay_time: u16,
+        transparent_color_index: u8,
+        terminator: u8,
+    },
+    none(),
+}
+
+struct Type67 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type66,
+}
+
+enum Type54 {
+    some {
+        marker: Type28,
+        length: u16,
+        data: Type53,
+    },
+    none(),
+}
+
+struct Type42 {
+    restart_interval: u16,
+}
+
+struct Type73 {
+    header: Type72,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type93 {
+    marker: Type28,
+    length: u16,
+    data: Type41,
+}
+
+struct Type104 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type49 {
+    marker: Type28,
+    length: u16,
+    data: Type48,
+}
+
+struct Type31 {
+    identifier: Type29,
+    data: Type30,
+}
+
+enum Type38 {
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
 }
 
 struct Type65 {
@@ -895,70 +552,60 @@ struct Type65 {
     crc: u32,
 }
 
-struct Type80 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type68,
-    pad: Type66,
+struct Type70 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
 }
 
-struct Type90 {
-    marker: Type28,
-    length: u16,
-    data: Type45,
+enum Type17 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u16,
+        distance_record: Type16,
+    },
 }
 
-struct Type27 {
-    header: Type13,
-    fname: Type14,
-    data: Type25,
-    footer: Type26,
-}
-
-enum Type74 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-struct Type95 {
-    marker: Type28,
-    length: u16,
-    data: Vec<u8>,
-}
-
-struct Type97 {
-    xmp: Vec<u8>,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-enum Type14 {
-    no(),
-    yes { string: Vec<u8>, null: u8 },
-}
-
-struct Type76 {
-    data: Type75,
-    end: (),
-}
-
-struct Type64 {
+struct Type86 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
+    data: Type62,
     crc: u32,
 }
 
-struct Type78 {
-    soi: Type28,
-    frame: Type55,
-    eoi: Type28,
+struct Type60 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type96 {
+    padding: u8,
+    exif: Type35,
+}
+
+struct Type99 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type22>,
+}
+
+struct Type106 {
+    descriptor: Type6,
+    local_color_table: Type3,
+    data: Type8,
+}
+
+struct Type39 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
 }
 
 enum Type63 {
@@ -994,16 +641,369 @@ enum Type63 {
     },
 }
 
+enum Type10 {
+    application_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        identifier: Vec<u8>,
+        authentication_code: Vec<u8>,
+        application_data: Vec<Type7>,
+        terminator: u8,
+    },
+    comment_extension {
+        separator: u8,
+        label: u8,
+        comment_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+enum Type14 {
+    no(),
+    yes { string: Vec<u8>, null: u8 },
+}
+
 struct Type18 {
     code: u16,
     extra: Type17,
 }
 
-struct Type34 {
-    num_fields: u16,
-    fields: Vec<Type33>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
+struct Type57 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type56,
+    crc: u32,
+}
+
+struct Type13 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type76 {
+    data: Type75,
+    end: (),
+}
+
+struct Type28 {
+    ff: u8,
+    marker: u8,
+}
+
+enum Type75 {
+    gif {
+        header: Type0,
+        logical_screen: Type4,
+        blocks: Vec<Type11>,
+        trailer: Type12,
+    },
+    gzip(Vec<Type27>),
+    jpeg {
+        soi: Type28,
+        frame: Type55,
+        eoi: Type28,
+    },
+    png {
+        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+        ihdr: Type57,
+        chunks: Vec<Type63>,
+        idat: Vec<Type64>,
+        more_chunks: Vec<Type63>,
+        iend: Type65,
+    },
+    riff {
+        tag: (u8, u8, u8, u8),
+        length: u32,
+        data: Type68,
+        pad: Type66,
+    },
+    tar {
+        contents: Vec<Type73>,
+        __padding: Vec<u8>,
+        __trailing: Vec<u8>,
+    },
+    text(Type74),
+}
+
+struct Type69 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type77 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type11>,
+    trailer: Type12,
+}
+
+struct Type87 {
+    marker: Type28,
+    length: u16,
+    data: Type31,
+}
+
+struct Type91 {
+    marker: Type28,
+    length: u16,
+    data: Type39,
+}
+
+struct Type97 {
+    xmp: Vec<u8>,
+}
+
+struct Type21 {
+    code: u16,
+    extra: Type20,
+}
+
+enum Type9 {
+    table_based_image {
+        descriptor: Type6,
+        local_color_table: Type3,
+        data: Type8,
+    },
+    plain_text_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        text_grid_left_position: u16,
+        text_grid_top_position: u16,
+        text_grid_width: u16,
+        text_grid_height: u16,
+        character_cell_width: u8,
+        character_cell_height: u8,
+        text_foreground_color_index: u8,
+        text_background_color_index: u8,
+        plain_text_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+struct Type53 {
+    num_lines: u16,
+}
+
+struct Type52 {
+    segments: Vec<Type43>,
+    sos: Type49,
+    data: Type51,
+}
+
+struct Type47 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
+}
+
+enum Type62 {
+    color_type_3(Vec<Type61>),
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type71 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+struct Type98 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+struct Type26 {
+    crc: u32,
+    length: u32,
+}
+
+enum Type22 {
+    literal(u8),
+}
+
+struct Type40 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+enum Type30 {
+    other(Vec<u8>),
+    jfif {
+        version_major: u8,
+        version_minor: u8,
+        density_units: u8,
+        density_x: u16,
+        density_y: u16,
+        thumbnail_width: u8,
+        thumbnail_height: u8,
+        thumbnail_pixels: Vec<Vec<Type2>>,
+    },
+}
+
+struct Type6 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type44 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+enum Type23 {
+    dynamic_huffman {
+        hlit: u8,
+        hdist: u8,
+        hclen: u8,
+        code_length_alphabet_code_lengths: Vec<u8>,
+        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+        literal_length_alphabet_code_lengths_value: Vec<u8>,
+        distance_alphabet_code_lengths_value: Vec<u8>,
+        codes: Vec<Type18>,
+        codes_values: Vec<Type19>,
+    },
+    fixed_huffman {
+        codes: Vec<Type21>,
+        codes_values: Vec<Type19>,
+    },
+    uncompressed {
+        align: (),
+        len: u16,
+        nlen: u16,
+        bytes: Vec<u8>,
+        codes_values: Vec<Type22>,
+    },
+}
+
+struct Type16 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+enum Type50 {
+    mcu(u8),
+    rst0 { ff: u8, marker: u8 },
+    rst1 { ff: u8, marker: u8 },
+    rst2 { ff: u8, marker: u8 },
+    rst3 { ff: u8, marker: u8 },
+    rst4 { ff: u8, marker: u8 },
+    rst5 { ff: u8, marker: u8 },
+    rst6 { ff: u8, marker: u8 },
+    rst7 { ff: u8, marker: u8 },
+}
+
+enum Type66 {
+    no(u8),
+    yes(),
+}
+
+struct Type56 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type89 {
+    marker: Type28,
+    length: u16,
+    data: Type53,
+}
+
+struct Type37 {
+    identifier: Type29,
+    data: Type36,
+}
+
+struct Type101 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type18>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type102 {
+    graphic_control_extension: Type5,
+    graphic_rendering_block: Type9,
+}
+
+struct Type105 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+struct Type107 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type7>,
+    terminator: u8,
+}
+
+enum Type11 {
+    graphic_block {
+        graphic_control_extension: Type5,
+        graphic_rendering_block: Type9,
+    },
+    special_purpose_block(Type10),
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type59,
+    crc: u32,
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
@@ -1012,7 +1012,7 @@ fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
 
 fn Decoder1<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+        let tmp = r#"invoke_decoder @ Parallel"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let end = if input.read_byte().is_none() {
@@ -1027,7 +1027,7 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     let header = Decoder128(scope, input)?;
     let logical_screen = Decoder129(scope, input)?;
     let blocks = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let trailer = Decoder131(scope, input)?;
@@ -1041,7 +1041,7 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
 
 fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<Type27>> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1057,15 +1057,15 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     let signature = Decoder27(scope, input)?;
     let ihdr = Decoder28(scope, input)?;
     let chunks = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let idat = {
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let more_chunks = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let iend = Decoder31(scope, input)?;
@@ -1081,16 +1081,16 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
 
 fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder23(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let pad = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type80 {
@@ -1103,15 +1103,15 @@ fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
 
 fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
     let contents = {
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let __trailing = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type81 {
@@ -1123,35 +1123,35 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
 
 fn Decoder8<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type74> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+        let tmp = r#"invoke_decoder @ Parallel"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<char>> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder12<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1171,7 +1171,7 @@ fn Decoder13<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type73> {
     let header = Decoder15(scope, input)?;
     let file = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let __padding = {
@@ -1189,7 +1189,7 @@ fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type72> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1213,11 +1213,11 @@ fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type69 { string, __padding });
@@ -1266,11 +1266,11 @@ fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type69 { string, __padding });
@@ -1278,11 +1278,11 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type71> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let padding = {
-        let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+        let tmp = r#"invoke_decoder @ Until"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type71 { string, padding });
@@ -1290,7 +1290,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1298,7 +1298,7 @@ fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type68> {
     let tag = Decoder25(scope, input)?;
     let chunks = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type68 { tag, chunks });
@@ -1316,11 +1316,11 @@ fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let tag = Decoder25(scope, input)?;
     let length = Decoder23(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let pad = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type67 {
@@ -1416,7 +1416,7 @@ fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let length = Decoder32(scope, input)?;
     let tag = Decoder43(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1430,7 +1430,7 @@ fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1439,7 +1439,7 @@ fn Decoder30<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let length = Decoder32(scope, input)?;
     let tag = Decoder35(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1455,7 +1455,7 @@ fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let length = Decoder32(scope, input)?;
     let tag = Decoder33(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1469,7 +1469,7 @@ fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1560,7 +1560,7 @@ fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1568,11 +1568,11 @@ fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type82> {
     let length = Decoder32(scope, input)?;
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1587,11 +1587,11 @@ fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type83> {
     let length = Decoder32(scope, input)?;
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1606,11 +1606,11 @@ fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type84> {
     let length = Decoder32(scope, input)?;
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1625,11 +1625,11 @@ fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type85> {
     let length = Decoder32(scope, input)?;
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1644,11 +1644,11 @@ fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type86> {
     let length = Decoder32(scope, input)?;
     let tag = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let crc = Decoder32(scope, input)?;
@@ -1662,7 +1662,7 @@ fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -1750,21 +1750,21 @@ fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
     let initial_segment = {
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let segments = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let header = Decoder51(scope, input)?;
     let scan = Decoder52(scope, input)?;
     let dnl = {
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let scans = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type55 {
@@ -1801,12 +1801,12 @@ fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type87> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type87 {
@@ -1818,12 +1818,12 @@ fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type88 {
@@ -1835,21 +1835,21 @@ fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
 
 fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
     let segments = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let sos = Decoder55(scope, input)?;
@@ -1863,12 +1863,12 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type89> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type89 {
@@ -1880,7 +1880,7 @@ fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
     let segments = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let sos = Decoder55(scope, input)?;
@@ -1894,12 +1894,12 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type49> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type49 {
@@ -1911,11 +1911,11 @@ fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
     let scan_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let scan_data_stream = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type51 {
@@ -1926,7 +1926,7 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -2110,7 +2110,7 @@ fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type48> {
     let num_image_components = Decoder16(scope, input)?;
     let image_components = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let start_spectral_selection = Decoder16(scope, input)?;
@@ -2141,11 +2141,11 @@ fn Decoder68<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
     let scan_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let scan_data_stream = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type51 {
@@ -2156,12 +2156,12 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2173,12 +2173,12 @@ fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2190,12 +2190,12 @@ fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2207,12 +2207,12 @@ fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2224,12 +2224,12 @@ fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2241,12 +2241,12 @@ fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2258,12 +2258,12 @@ fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2275,12 +2275,12 @@ fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2292,12 +2292,12 @@ fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2309,12 +2309,12 @@ fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2326,12 +2326,12 @@ fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2343,12 +2343,12 @@ fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2360,12 +2360,12 @@ fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder82<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type90 {
@@ -2381,7 +2381,7 @@ fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let num_samples_per_line = Decoder42(scope, input)?;
     let num_image_components = Decoder16(scope, input)?;
     let image_components = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type45 {
@@ -2406,12 +2406,12 @@ fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type91> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type91 {
@@ -2423,12 +2423,12 @@ fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type92> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type92 {
@@ -2440,12 +2440,12 @@ fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type93 {
@@ -2457,12 +2457,12 @@ fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type94> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type94 {
@@ -2474,12 +2474,12 @@ fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2491,12 +2491,12 @@ fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2508,12 +2508,12 @@ fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2525,12 +2525,12 @@ fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2542,12 +2542,12 @@ fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2559,12 +2559,12 @@ fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2576,12 +2576,12 @@ fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2593,12 +2593,12 @@ fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2610,12 +2610,12 @@ fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2627,12 +2627,12 @@ fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2644,12 +2644,12 @@ fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2661,12 +2661,12 @@ fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2678,12 +2678,12 @@ fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2695,12 +2695,12 @@ fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2712,12 +2712,12 @@ fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+        let tmp = r#"invoke_decoder @ Record"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let length = Decoder42(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+        let tmp = r#"invoke_decoder @ Slice"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type95 {
@@ -2744,11 +2744,11 @@ fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type40> {
     let class_table_id = Decoder16(scope, input)?;
     let num_codes = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let values = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type40 {
@@ -2761,7 +2761,7 @@ fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type39> {
     let precision_table_id = Decoder16(scope, input)?;
     let elements = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type39 {
@@ -2773,7 +2773,7 @@ fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type37> {
     let identifier = Decoder109(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type37 { identifier, data });
@@ -2781,7 +2781,7 @@ fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
@@ -2812,7 +2812,7 @@ fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type97> {
     let xmp = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type97 { xmp });
@@ -2820,19 +2820,19 @@ fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type35> {
     let byte_order = {
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let magic = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let offset = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let ifd = {
-        let tmp = r#"invoke_decoder @ Discriminant(19)"#;
+        let tmp = r#"invoke_decoder @ WithRelativeOffset"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type35 {
@@ -2845,7 +2845,7 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -2853,7 +2853,7 @@ fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type31> {
     let identifier = Decoder115(scope, input)?;
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type31 { identifier, data });
@@ -2861,7 +2861,7 @@ fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
@@ -2885,7 +2885,7 @@ fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let thumbnail_width = Decoder16(scope, input)?;
     let thumbnail_height = Decoder16(scope, input)?;
     let thumbnail_pixels = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type98 {
@@ -2909,7 +2909,7 @@ fn Decoder117<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder118<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
     let magic = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let method = Decoder16(scope, input)?;
@@ -2933,15 +2933,15 @@ fn Decoder119<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type25> {
     let blocks = {
-        let tmp = r#"invoke_decoder @ Discriminant(13)"#;
+        let tmp = r#"invoke_decoder @ RepeatUntilLast"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let codes = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let inflate = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type25 {
@@ -2960,11 +2960,11 @@ fn Decoder121<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type24> {
     let r#final = Decoder123(scope, input)?;
     let r#type = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type24 {
@@ -2999,19 +2999,19 @@ fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         ()
     };
     let len = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let nlen = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let bytes = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let codes_values = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type99 {
@@ -3025,11 +3025,11 @@ fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type100> {
     let codes = {
-        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        let tmp = r#"invoke_decoder @ Dynamic"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let codes_values = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type100 {
@@ -3040,43 +3040,43 @@ fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type101> {
     let hlit = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let hdist = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let hclen = {
-        let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+        let tmp = r#"invoke_decoder @ Map"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let code_length_alphabet_code_lengths = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let literal_length_distance_alphabet_code_lengths = {
-        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        let tmp = r#"invoke_decoder @ Dynamic"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let literal_length_distance_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let literal_length_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let distance_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let codes = {
-        let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+        let tmp = r#"invoke_decoder @ Dynamic"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let codes_values = {
-        let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+        let tmp = r#"invoke_decoder @ Compute"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type101 {
@@ -3095,7 +3095,7 @@ fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
     let string = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
@@ -3112,11 +3112,11 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type0> {
     let signature = {
-        let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+        let tmp = r#"invoke_decoder @ Tuple"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let version = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type0 { signature, version });
@@ -3125,7 +3125,7 @@ fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type4> {
     let descriptor = Decoder145(scope, input)?;
     let global_color_table = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type4 {
@@ -3136,7 +3136,7 @@ fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type11> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -3156,7 +3156,7 @@ fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
     let graphic_control_extension = {
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let graphic_rendering_block = Decoder139(scope, input)?;
@@ -3168,7 +3168,7 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -3202,15 +3202,15 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let identifier = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let authentication_code = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let application_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let terminator = Decoder137(scope, input)?;
@@ -3245,7 +3245,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let comment_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let terminator = Decoder137(scope, input)?;
@@ -3273,7 +3273,7 @@ fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         }
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+        let tmp = r#"invoke_decoder @ RepeatCount"#;
         unimplemented!(r#"{}"#, tmp)
     };
     return Some(Type7 { len_bytes, data });
@@ -3336,7 +3336,7 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
     return Some({
-        let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+        let tmp = r#"invoke_decoder @ Branch"#;
         unimplemented!(r#"{}"#, tmp)
     });
 }
@@ -3344,7 +3344,7 @@ fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type106> {
     let descriptor = Decoder142(scope, input)?;
     let local_color_table = {
-        let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+        let tmp = r#"invoke_decoder @ Match"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let data = Decoder144(scope, input)?;
@@ -3392,7 +3392,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
     let text_foreground_color_index = Decoder16(scope, input)?;
     let text_background_color_index = Decoder16(scope, input)?;
     let plain_text_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let terminator = Decoder137(scope, input)?;
@@ -3448,7 +3448,7 @@ fn Decoder143<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
     let lzw_min_code_size = Decoder16(scope, input)?;
     let image_data = {
-        let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+        let tmp = r#"invoke_decoder @ While"#;
         unimplemented!(r#"{}"#, tmp)
     };
     let terminator = Decoder137(scope, input)?;

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,74 +1,10 @@
 use doodle::prelude::*;
 
-struct Type100 {
-codes: Vec<Type21>,
-codes_values: Vec<Type19>
-}
-
-struct Type103 {
-separator: u8,
-label: u8,
-block_size: u8,
-identifier: Vec<u8>,
-authentication_code: Vec<u8>,
-application_data: Vec<Type7>,
-terminator: u8
-}
-
-struct Type104 {
-separator: u8,
-label: u8,
-comment_data: Vec<Type7>,
-terminator: u8
-}
-
-struct Type107 {
-separator: u8,
-label: u8,
-block_size: u8,
-text_grid_left_position: u16,
-text_grid_top_position: u16,
-text_grid_width: u16,
-text_grid_height: u16,
-character_cell_width: u8,
-character_cell_height: u8,
-text_foreground_color_index: u8,
-text_background_color_index: u8,
-plain_text_data: Vec<Type7>,
-terminator: u8
-}
-
-struct Type84 {
+struct Type86 {
 length: u32,
 tag: (u8, u8, u8, u8),
-data: Vec<Type2>,
+data: Type62,
 crc: u32
-}
-
-struct Type2 {
-r: u8,
-g: u8,
-b: u8
-}
-
-enum Type22 { literal(u8) }
-
-struct Type6 {
-separator: u8,
-image_left_position: u16,
-image_top_position: u16,
-image_width: u16,
-image_height: u16,
-flags: u8
-}
-
-struct Type41 {
-class_table_id: u8,
-value: u8
-}
-
-struct Type61 {
-palette_index: u8
 }
 
 enum Type23 { dynamic_huffman {
@@ -93,95 +29,29 @@ bytes: Vec<u8>,
 codes_values: Vec<Type22>
 } }
 
-enum Type63 { bKGD {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type58,
-crc: u32
-}, pHYs {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type59,
-crc: u32
-}, PLTE {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Vec<Type2>,
-crc: u32
-}, tIME {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type60,
-crc: u32
-}, tRNS {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type62,
-crc: u32
-} }
-
-struct Type85 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type60,
-crc: u32
-}
-
-struct Type93 {
-marker: Type28,
-length: u16,
-data: Type41
-}
-
-struct Type26 {
-crc: u32,
-length: u32
-}
-
 struct Type92 {
 marker: Type28,
 length: u16,
 data: Type40
 }
 
-struct Type29 {
-string: Vec<u8>,
-null: u8
+struct Type84 {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Vec<Type2>,
+crc: u32
 }
 
-struct Type69 {
-string: Vec<u8>,
-__padding: Vec<u8>
-}
-
-struct Type24 {
-r#final: u8,
-r#type: u8,
-data: Type23
-}
-
-struct Type34 {
-num_fields: u16,
-fields: Vec<Type33>,
-next_ifd_offset: u32,
-next_ifd: Vec<u8>
-}
-
-struct Type95 {
-marker: Type28,
-length: u16,
-data: Vec<u8>
-}
-
-enum Type5 { some {
-separator: u8,
-label: u8,
-block_size: u8,
-flags: u8,
-delay_time: u16,
-transparent_color_index: u8,
-terminator: u8
-}, none() }
+enum Type30 { other(Vec<u8>), jfif {
+version_major: u8,
+version_minor: u8,
+density_units: u8,
+density_x: u16,
+density_y: u16,
+thumbnail_width: u8,
+thumbnail_height: u8,
+thumbnail_pixels: Vec<Vec<Type2>>
+} }
 
 struct Type99 {
 align: (),
@@ -191,31 +61,24 @@ bytes: Vec<u8>,
 codes_values: Vec<Type22>
 }
 
-struct Type101 {
-hlit: u8,
-hdist: u8,
-hclen: u8,
-code_length_alphabet_code_lengths: Vec<u8>,
-literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-literal_length_alphabet_code_lengths_value: Vec<u8>,
-distance_alphabet_code_lengths_value: Vec<u8>,
-codes: Vec<Type18>,
+struct Type39 {
+precision_table_id: u8,
+elements: Vec<u8>
+}
+
+struct Type100 {
+codes: Vec<Type21>,
 codes_values: Vec<Type19>
 }
 
-struct Type13 {
-magic: (u8, u8),
-method: u8,
-file_flags: u8,
-timestamp: u32,
-compression_flags: u8,
-os_id: u8
+struct Type21 {
+code: u16,
+extra: Type20
 }
 
-struct Type37 {
-identifier: Type29,
-data: Type36
+struct Type7 {
+len_bytes: u8,
+data: Vec<u8>
 }
 
 enum Type43 { dqt {
@@ -304,32 +167,124 @@ length: u16,
 data: Vec<u8>
 } }
 
-enum Type20 { none(), some {
-length_extra_bits: u8,
-length: u16,
-distance_code: u8,
-distance_record: Type16
-} }
-
-enum Type62 { color_type_(Vec<Type61>), color_type_ {
-red: u16,
-green: u16,
-blue: u16
-}, color_type_ {
-greyscale: u16
-} }
-
-struct Type78 {
-soi: Type28,
-frame: Type55,
-eoi: Type28
+struct Type28 {
+ff: u8,
+marker: u8
 }
 
-struct Type86 {
+struct Type57 {
 length: u32,
 tag: (u8, u8, u8, u8),
-data: Type62,
+data: Type56,
 crc: u32
+}
+
+struct Type77 {
+header: Type0,
+logical_screen: Type4,
+blocks: Vec<Type11>,
+trailer: Type12
+}
+
+struct Type59 {
+pixels_per_unit_x: u32,
+pixels_per_unit_y: u32,
+unit_specifier: u8
+}
+
+struct Type67 {
+tag: (u8, u8, u8, u8),
+length: u32,
+data: Vec<u8>,
+pad: Type66
+}
+
+struct Type88 {
+marker: Type28,
+length: u16,
+data: Type37
+}
+
+struct Type35 {
+byte_order: Type32,
+magic: u16,
+offset: u32,
+ifd: Type34
+}
+
+enum Type11 { graphic_block {
+graphic_control_extension: Type5,
+graphic_rendering_block: Type9
+}, special_purpose_block(Type10) }
+
+struct Type26 {
+crc: u32,
+length: u32
+}
+
+struct Type87 {
+marker: Type28,
+length: u16,
+data: Type31
+}
+
+struct Type93 {
+marker: Type28,
+length: u16,
+data: Type41
+}
+
+struct Type107 {
+separator: u8,
+label: u8,
+block_size: u8,
+text_grid_left_position: u16,
+text_grid_top_position: u16,
+text_grid_width: u16,
+text_grid_height: u16,
+character_cell_width: u8,
+character_cell_height: u8,
+text_foreground_color_index: u8,
+text_background_color_index: u8,
+plain_text_data: Vec<Type7>,
+terminator: u8
+}
+
+enum Type5 { some {
+separator: u8,
+label: u8,
+block_size: u8,
+flags: u8,
+delay_time: u16,
+transparent_color_index: u8,
+terminator: u8
+}, none() }
+
+struct Type89 {
+marker: Type28,
+length: u16,
+data: Type53
+}
+
+enum Type10 { application_extension {
+separator: u8,
+label: u8,
+block_size: u8,
+identifier: Vec<u8>,
+authentication_code: Vec<u8>,
+application_data: Vec<Type7>,
+terminator: u8
+}, comment_extension {
+separator: u8,
+label: u8,
+comment_data: Vec<Type7>,
+terminator: u8
+} }
+
+struct Type25 {
+blocks: Vec<Type24>,
+codes: Vec<Type19>,
+inflate: Vec<u8>
 }
 
 struct Type33 {
@@ -337,6 +292,150 @@ tag: u16,
 r#type: u16,
 length: u32,
 offset_or_data: u32
+}
+
+struct Type41 {
+class_table_id: u8,
+value: u8
+}
+
+struct Type2 {
+r: u8,
+g: u8,
+b: u8
+}
+
+struct Type45 {
+sample_precision: u8,
+num_lines: u16,
+num_samples_per_line: u16,
+num_image_components: u8,
+image_components: Vec<Type44>
+}
+
+struct Type96 {
+padding: u8,
+exif: Type35
+}
+
+struct Type98 {
+version_major: u8,
+version_minor: u8,
+density_units: u8,
+density_x: u16,
+density_y: u16,
+thumbnail_width: u8,
+thumbnail_height: u8,
+thumbnail_pixels: Vec<Vec<Type2>>
+}
+
+enum Type20 { none(), some {
+length_extra_bits: u8,
+length: u16,
+distance_code: u8,
+distance_record: Type16
+} }
+
+enum Type36 { other(Vec<u8>), xmp {
+xmp: Vec<u8>
+}, exif {
+padding: u8,
+exif: Type35
+} }
+
+struct Type72 {
+name: Type69,
+mode: Type70,
+uid: Type70,
+gid: Type70,
+size: u32,
+mtime: Type70,
+chksum: Type70,
+typeflag: u8,
+linkname: Type69,
+magic: (u8, u8, u8, u8, u8, u8),
+version: (u8, u8),
+uname: Type71,
+gname: Type71,
+devmajor: Type70,
+devminor: Type70,
+prefix: Type69,
+pad: Vec<u8>
+}
+
+struct Type82 {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Type58,
+crc: u32
+}
+
+struct Type42 {
+restart_interval: u16
+}
+
+enum Type19 { literal(u8), reference {
+length: u16,
+distance: u16
+} }
+
+struct Type44 {
+id: u8,
+sampling_factor: u8,
+quantization_table_id: u8
+}
+
+struct Type60 {
+year: u16,
+month: u8,
+day: u8,
+hour: u8,
+minute: u8,
+second: u8
+}
+
+struct Type6 {
+separator: u8,
+image_left_position: u16,
+image_top_position: u16,
+image_width: u16,
+image_height: u16,
+flags: u8
+}
+
+enum Type54 { some {
+marker: Type28,
+length: u16,
+data: Type53
+}, none() }
+
+struct Type31 {
+identifier: Type29,
+data: Type30
+}
+
+struct Type103 {
+separator: u8,
+label: u8,
+block_size: u8,
+identifier: Vec<u8>,
+authentication_code: Vec<u8>,
+application_data: Vec<Type7>,
+terminator: u8
+}
+
+struct Type0 {
+signature: (u8, u8, u8),
+version: Vec<u8>
+}
+
+struct Type55 {
+initial_segment: Type38,
+segments: Vec<Type43>,
+header: Type46,
+scan: Type52,
+dnl: Type54,
+scans: Vec<Type52>
 }
 
 enum Type38 { app0 {
@@ -349,133 +448,34 @@ length: u16,
 data: Type37
 } }
 
-struct Type45 {
-sample_precision: u8,
-num_lines: u16,
-num_samples_per_line: u16,
-num_image_components: u8,
-image_components: Vec<Type44>
-}
-
-struct Type39 {
-precision_table_id: u8,
-elements: Vec<u8>
-}
-
 struct Type51 {
 scan_data: Vec<Type50>,
 scan_data_stream: Vec<u8>
 }
 
-enum Type36 { other(Vec<u8>), xmp {
-xmp: Vec<u8>
-}, exif {
-padding: u8,
-exif: Type35
-} }
-
-struct Type55 {
-initial_segment: Type38,
-segments: Vec<Type43>,
-header: Type46,
-scan: Type52,
-dnl: Type54,
-scans: Vec<Type52>
-}
-
-struct Type67 {
-tag: (u8, u8, u8, u8),
-length: u32,
-data: Vec<u8>,
-pad: Type66
-}
-
-struct Type91 {
-marker: Type28,
-length: u16,
-data: Type39
-}
-
-enum Type74 { ascii(Vec<u8>), utf8(Vec<char>) }
-
-struct Type80 {
-tag: (u8, u8, u8, u8),
-length: u32,
-data: Type68,
-pad: Type66
-}
-
-struct Type44 {
-id: u8,
-sampling_factor: u8,
-quantization_table_id: u8
-}
-
-struct Type52 {
-segments: Vec<Type43>,
-sos: Type49,
-data: Type51
-}
-
-struct Type12 {
-separator: u8
-}
-
-enum Type17 { none(), some {
-length_extra_bits: u8,
-length: u16,
-distance_code: u16,
-distance_record: Type16
-} }
-
-enum Type32 { le(u8, u8), be(u8, u8) }
-
-struct Type81 {
-contents: Vec<Type73>,
-__padding: Vec<u8>,
-__trailing: Vec<u8>
-}
-
-struct Type88 {
-marker: Type28,
-length: u16,
-data: Type37
-}
-
-struct Type1 {
-screen_width: u16,
-screen_height: u16,
-flags: u8,
-bg_color_index: u8,
-pixel_aspect_ratio: u8
-}
-
-struct Type59 {
-pixels_per_unit_x: u32,
-pixels_per_unit_y: u32,
-unit_specifier: u8
-}
-
-enum Type58 { color_type_ {
+enum Type58 { color_type_3 {
 palette_index: u8
-}, color_type_ {
+}, color_type_6 {
 red: u16,
 green: u16,
 blue: u16
-}, color_type_ {
+}, color_type_2 {
 red: u16,
 green: u16,
 blue: u16
-}, color_type_ {
+}, color_type_4 {
 greyscale: u16
-}, color_type_ {
+}, color_type_0 {
 greyscale: u16
 } }
 
-struct Type94 {
-marker: Type28,
-length: u16,
-data: Type42
+struct Type13 {
+magic: (u8, u8),
+method: u8,
+file_flags: u8,
+timestamp: u32,
+compression_flags: u8,
+os_id: u8
 }
 
 struct Type49 {
@@ -484,19 +484,6 @@ length: u16,
 data: Type48
 }
 
-struct Type57 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Type56,
-crc: u32
-}
-
-enum Type54 { some {
-marker: Type28,
-length: u16,
-data: Type53
-}, none() }
-
 enum Type66 { no(u8), yes() }
 
 struct Type68 {
@@ -504,19 +491,23 @@ tag: (u8, u8, u8, u8),
 chunks: Vec<Type67>
 }
 
-enum Type3 { no(), yes(Vec<Type2>) }
-
-struct Type40 {
-class_table_id: u8,
-num_codes: Vec<u8>,
-values: Vec<u8>
+struct Type81 {
+contents: Vec<Type73>,
+__padding: Vec<u8>,
+__trailing: Vec<u8>
 }
 
-struct Type77 {
-header: Type0,
-logical_screen: Type4,
-blocks: Vec<Type11>,
-trailer: Type12
+struct Type101 {
+hlit: u8,
+hdist: u8,
+hclen: u8,
+code_length_alphabet_code_lengths: Vec<u8>,
+literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+literal_length_alphabet_code_lengths_value: Vec<u8>,
+distance_alphabet_code_lengths_value: Vec<u8>,
+codes: Vec<Type18>,
+codes_values: Vec<Type19>
 }
 
 struct Type105 {
@@ -529,45 +520,14 @@ transparent_color_index: u8,
 terminator: u8
 }
 
+struct Type12 {
+separator: u8
+}
+
 struct Type106 {
 descriptor: Type6,
 local_color_table: Type3,
 data: Type8
-}
-
-struct Type73 {
-header: Type72,
-file: Vec<u8>,
-__padding: ()
-}
-
-struct Type28 {
-ff: u8,
-marker: u8
-}
-
-enum Type11 { graphic_block {
-graphic_control_extension: Type5,
-graphic_rendering_block: Type9
-}, special_purpose_block(Type10) }
-
-enum Type14 { no(), yes {
-string: Vec<u8>,
-null: u8
-} }
-
-struct Type25 {
-blocks: Vec<Type24>,
-codes: Vec<Type19>,
-inflate: Vec<u8>
-}
-
-struct Type48 {
-num_image_components: u8,
-image_components: Vec<Type47>,
-start_spectral_selection: u8,
-end_spectral_selection: u8,
-approximation_bit_position: u8
 }
 
 enum Type9 { table_based_image {
@@ -590,96 +550,72 @@ plain_text_data: Vec<Type7>,
 terminator: u8
 } }
 
-struct Type15 {
-code: u16,
-extra: u8
+struct Type56 {
+width: u32,
+height: u32,
+bit_depth: u8,
+color_type: u8,
+compression_method: u8,
+filter_method: u8,
+interlace_method: u8
 }
 
-struct Type60 {
-year: u16,
-month: u8,
-day: u8,
-hour: u8,
-minute: u8,
-second: u8
+enum Type32 { le(u8, u8), be(u8, u8) }
+
+struct Type8 {
+lzw_min_code_size: u8,
+image_data: Vec<Type7>,
+terminator: u8
 }
 
-struct Type72 {
-name: Type69,
-mode: Type70,
-uid: Type70,
-gid: Type70,
-size: u32,
-mtime: Type70,
-chksum: Type70,
-typeflag: u8,
-linkname: Type69,
-magic: (u8, u8, u8, u8, u8, u8),
-version: (u8, u8),
-uname: Type71,
-gname: Type71,
-devmajor: Type70,
-devminor: Type70,
-prefix: Type69,
-pad: Vec<u8>
+struct Type24 {
+r#final: u8,
+r#type: u8,
+data: Type23
 }
 
-struct Type96 {
-padding: u8,
-exif: Type35
-}
-
-struct Type90 {
-marker: Type28,
-length: u16,
-data: Type45
-}
-
-struct Type97 {
-xmp: Vec<u8>
-}
-
-struct Type21 {
-code: u16,
-extra: Type20
-}
-
-struct Type4 {
-descriptor: Type1,
-global_color_table: Type3
-}
-
-struct Type89 {
-marker: Type28,
-length: u16,
-data: Type53
-}
-
-struct Type98 {
-version_major: u8,
-version_minor: u8,
-density_units: u8,
-density_x: u16,
-density_y: u16,
-thumbnail_width: u8,
-thumbnail_height: u8,
-thumbnail_pixels: Vec<Vec<Type2>>
-}
-
-struct Type0 {
-signature: (u8, u8, u8),
-version: Vec<u8>
-}
-
-struct Type16 {
-distance_extra_bits: u16,
-distance: u16
-}
-
-enum Type19 { literal(u8), reference {
-length: u16,
-distance: u16
+enum Type50 { mcu(u8), rst0 {
+ff: u8,
+marker: u8
+}, rst1 {
+ff: u8,
+marker: u8
+}, rst2 {
+ff: u8,
+marker: u8
+}, rst3 {
+ff: u8,
+marker: u8
+}, rst4 {
+ff: u8,
+marker: u8
+}, rst5 {
+ff: u8,
+marker: u8
+}, rst6 {
+ff: u8,
+marker: u8
+}, rst7 {
+ff: u8,
+marker: u8
 } }
+
+struct Type94 {
+marker: Type28,
+length: u16,
+data: Type42
+}
+
+struct Type83 {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Type59,
+crc: u32
+}
+
+struct Type53 {
+num_lines: u16
+}
 
 struct Type79 {
 signature: (u8, u8, u8, u8, u8, u8, u8, u8),
@@ -690,11 +626,87 @@ more_chunks: Vec<Type63>,
 iend: Type65
 }
 
-struct Type65 {
+struct Type85 {
 length: u32,
 tag: (u8, u8, u8, u8),
-data: (),
+data: Type60,
 crc: u32
+}
+
+struct Type4 {
+descriptor: Type1,
+global_color_table: Type3
+}
+
+struct Type15 {
+code: u16,
+extra: u8
+}
+
+enum Type17 { none(), some {
+length_extra_bits: u8,
+length: u16,
+distance_code: u16,
+distance_record: Type16
+} }
+
+enum Type22 { literal(u8) }
+
+struct Type29 {
+string: Vec<u8>,
+null: u8
+}
+
+enum Type3 { no(), yes(Vec<Type2>) }
+
+struct Type37 {
+identifier: Type29,
+data: Type36
+}
+
+struct Type73 {
+header: Type72,
+file: Vec<u8>,
+__padding: ()
+}
+
+struct Type102 {
+graphic_control_extension: Type5,
+graphic_rendering_block: Type9
+}
+
+struct Type69 {
+string: Vec<u8>,
+__padding: Vec<u8>
+}
+
+struct Type104 {
+separator: u8,
+label: u8,
+comment_data: Vec<Type7>,
+terminator: u8
+}
+
+struct Type48 {
+num_image_components: u8,
+image_components: Vec<Type47>,
+start_spectral_selection: u8,
+end_spectral_selection: u8,
+approximation_bit_position: u8
+}
+
+enum Type62 { color_type_3(Vec<Type61>), color_type_2 {
+red: u16,
+green: u16,
+blue: u16
+}, color_type_0 {
+greyscale: u16
+} }
+
+struct Type52 {
+segments: Vec<Type43>,
+sos: Type49,
+data: Type51
 }
 
 enum Type75 { gif {
@@ -724,25 +736,10 @@ __padding: Vec<u8>,
 __trailing: Vec<u8>
 }, text(Type74) }
 
-struct Type102 {
-graphic_control_extension: Type5,
-graphic_rendering_block: Type9
-}
-
-struct Type76 {
-data: Type75,
-end: ()
-}
-
-struct Type8 {
-lzw_min_code_size: u8,
-image_data: Vec<Type7>,
-terminator: u8
-}
-
-struct Type18 {
-code: u16,
-extra: Type17
+struct Type91 {
+marker: Type28,
+length: u16,
+data: Type39
 }
 
 struct Type70 {
@@ -751,72 +748,8 @@ __nul_or_wsp: u8,
 __padding: Vec<u8>
 }
 
-struct Type71 {
-string: Vec<u8>,
-padding: Vec<u8>
-}
-
-struct Type7 {
-len_bytes: u8,
-data: Vec<u8>
-}
-
-enum Type10 { application_extension {
-separator: u8,
-label: u8,
-block_size: u8,
-identifier: Vec<u8>,
-authentication_code: Vec<u8>,
-application_data: Vec<Type7>,
-terminator: u8
-}, comment_extension {
-separator: u8,
-label: u8,
-comment_data: Vec<Type7>,
-terminator: u8
-} }
-
-struct Type87 {
-marker: Type28,
-length: u16,
-data: Type31
-}
-
-struct Type53 {
-num_lines: u16
-}
-
-struct Type27 {
-header: Type13,
-fname: Type14,
-data: Type25,
-footer: Type26
-}
-
-enum Type30 { other(Vec<u8>), jfif {
-version_major: u8,
-version_minor: u8,
-density_units: u8,
-density_x: u16,
-density_y: u16,
-thumbnail_width: u8,
-thumbnail_height: u8,
-thumbnail_pixels: Vec<Vec<Type2>>
-} }
-
-struct Type31 {
-identifier: Type29,
-data: Type30
-}
-
-struct Type56 {
-width: u32,
-height: u32,
-bit_depth: u8,
-color_type: u8,
-compression_method: u8,
-filter_method: u8,
-interlace_method: u8
+struct Type61 {
+palette_index: u8
 }
 
 enum Type46 { sof0 {
@@ -873,11 +806,20 @@ length: u16,
 data: Type45
 } }
 
-struct Type64 {
-length: u32,
-tag: (u8, u8, u8, u8),
-data: Vec<u8>,
-crc: u32
+struct Type71 {
+string: Vec<u8>,
+padding: Vec<u8>
+}
+
+struct Type16 {
+distance_extra_bits: u16,
+distance: u16
+}
+
+struct Type40 {
+class_table_id: u8,
+num_codes: Vec<u8>,
+values: Vec<u8>
 }
 
 struct Type47 {
@@ -885,204 +827,249 @@ component_selector: u8,
 entropy_coding_table_ids: u8
 }
 
-struct Type35 {
-byte_order: Type32,
-magic: u16,
-offset: u32,
-ifd: Type34
+struct Type65 {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: (),
+crc: u32
 }
 
-enum Type50 { mcu(u8), rst0 {
-ff: u8,
-marker: u8
-}, rst1 {
-ff: u8,
-marker: u8
-}, rst2 {
-ff: u8,
-marker: u8
-}, rst3 {
-ff: u8,
-marker: u8
-}, rst4 {
-ff: u8,
-marker: u8
-}, rst5 {
-ff: u8,
-marker: u8
-}, rst6 {
-ff: u8,
-marker: u8
-}, rst7 {
-ff: u8,
-marker: u8
+struct Type80 {
+tag: (u8, u8, u8, u8),
+length: u32,
+data: Type68,
+pad: Type66
+}
+
+struct Type90 {
+marker: Type28,
+length: u16,
+data: Type45
+}
+
+struct Type27 {
+header: Type13,
+fname: Type14,
+data: Type25,
+footer: Type26
+}
+
+enum Type74 { ascii(Vec<u8>), utf8(Vec<char>) }
+
+struct Type95 {
+marker: Type28,
+length: u16,
+data: Vec<u8>
+}
+
+struct Type97 {
+xmp: Vec<u8>
+}
+
+struct Type1 {
+screen_width: u16,
+screen_height: u16,
+flags: u8,
+bg_color_index: u8,
+pixel_aspect_ratio: u8
+}
+
+enum Type14 { no(), yes {
+string: Vec<u8>,
+null: u8
 } }
 
-struct Type42 {
-restart_interval: u16
+struct Type76 {
+data: Type75,
+end: ()
 }
 
-struct Type82 {
+struct Type64 {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Vec<u8>,
+crc: u32
+}
+
+struct Type78 {
+soi: Type28,
+frame: Type55,
+eoi: Type28
+}
+
+enum Type63 { bKGD {
 length: u32,
 tag: (u8, u8, u8, u8),
 data: Type58,
 crc: u32
-}
-
-struct Type83 {
+}, pHYs {
 length: u32,
 tag: (u8, u8, u8, u8),
 data: Type59,
 crc: u32
+}, PLTE {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Vec<Type2>,
+crc: u32
+}, tIME {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Type60,
+crc: u32
+}, tRNS {
+length: u32,
+tag: (u8, u8, u8, u8),
+data: Type62,
+crc: u32
+} }
+
+struct Type18 {
+code: u16,
+extra: Type17
 }
 
-fn Decoder0<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type76> {
-let mut inp = input;
-return Some({
-let tmp = Decoder1(scope, inp)?;
-inp = tmp.1;
-tmp.0
-});
+struct Type34 {
+num_fields: u16,
+fields: Vec<Type33>,
+next_ifd_offset: u32,
+next_ifd: Vec<u8>
 }
 
-fn Decoder1<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type76> {
-let mut inp = input;
-let data = unimplemented!("invoke_decoder");
-let end = {
-let tmp = inp.read_byte();
-if tmp.is_none() {
-inp = tmp.1;
+fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
+return Some(Decoder1(scope, input)?);
+}
+
+fn Decoder1<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let end = if input.read_byte().is_none() {
 ()
 } else {
 return None;
-}
 };
 return Some(Type76 { data, end });
 }
 
-fn Decoder2<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type77> {
-let mut inp = input;
-let header = {
-let tmp = Decoder128(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type77> {
+let header = Decoder128(scope, input)?;
+let logical_screen = Decoder129(scope, input)?;
+let blocks = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let logical_screen = {
-let tmp = Decoder129(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let blocks = unimplemented!("invoke_decoder");
-let trailer = {
-let tmp = Decoder131(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let trailer = Decoder131(scope, input)?;
 return Some(Type77 { header, logical_screen, blocks, trailer });
 }
 
-fn Decoder3<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Vec<Type27>> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<Type27>> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder4<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type78> {
-let mut inp = input;
-let soi = {
-let tmp = Decoder45(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let frame = {
-let tmp = Decoder46(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let eoi = {
-let tmp = Decoder47(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder4<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type78> {
+let soi = Decoder45(scope, input)?;
+let frame = Decoder46(scope, input)?;
+let eoi = Decoder47(scope, input)?;
 return Some(Type78 { soi, frame, eoi });
 }
 
-fn Decoder5<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type79> {
-let mut inp = input;
-let signature = {
-let tmp = Decoder27(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type79> {
+let signature = Decoder27(scope, input)?;
+let ihdr = Decoder28(scope, input)?;
+let chunks = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let ihdr = {
-let tmp = Decoder28(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let idat = {
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let chunks = unimplemented!("invoke_decoder");
-let idat = unimplemented!("invoke_decoder");
-let more_chunks = unimplemented!("invoke_decoder");
-let iend = {
-let tmp = Decoder31(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let more_chunks = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let iend = Decoder31(scope, input)?;
 return Some(Type79 { signature, ihdr, chunks, idat, more_chunks, iend });
 }
 
-fn Decoder6<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type80> {
-let mut inp = input;
-let tag = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder23(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
-let pad = unimplemented!("invoke_decoder");
+let length = Decoder23(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let pad = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type80 { tag, length, data, pad });
 }
 
-fn Decoder7<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type81> {
-let mut inp = input;
-let contents = unimplemented!("invoke_decoder");
-let __padding = unimplemented!("invoke_decoder");
-let __trailing = unimplemented!("invoke_decoder");
+fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
+let contents = {
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let __padding = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let __trailing = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type81 { contents, __padding, __trailing });
 }
 
-fn Decoder8<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type74> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder8<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type74> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(6)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder9<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Vec<u8>> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder10<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Vec<char>> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<char>> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder11<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<char> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder12<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder12<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder13<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder13<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1090,37 +1077,33 @@ return None;
 });
 }
 
-fn Decoder14<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type73> {
-let mut inp = input;
-let header = {
-let tmp = Decoder15(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type73> {
+let header = Decoder15(scope, input)?;
+let file = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let file = unimplemented!("invoke_decoder");
 let __padding = {
-while input.offset % 512 != 0 {
-let tmp = inp.read_byte()?;
-inp = tmp.1;
+while input.offset() % 512 != 0 {
+let _ = input.read_byte()?;
 }
 ()
 };
 return Some(Type73 { header, file, __padding });
 }
 
-fn Decoder15<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type72> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type72> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder16<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1128,21 +1111,23 @@ return None;
 });
 }
 
-fn Decoder17<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type69> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
-let __padding = unimplemented!("invoke_decoder");
+fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let __padding = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type69 { string, __padding });
 }
 
-fn Decoder18<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder18<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([71776119061217280, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1150,14 +1135,11 @@ return None;
 });
 }
 
-fn Decoder19<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([4294967297, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1165,14 +1147,11 @@ return None;
 });
 }
 
-fn Decoder20<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1180,86 +1159,73 @@ return None;
 });
 }
 
-fn Decoder21<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type69> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
-let __padding = unimplemented!("invoke_decoder");
+fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let __padding = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type69 { string, __padding });
 }
 
-fn Decoder22<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type71> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
-let padding = unimplemented!("invoke_decoder");
+fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type71> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let padding = {
+let tmp = r#"invoke_decoder @ Discriminant(11)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type71 { string, padding });
 }
 
-fn Decoder23<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u32> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder24<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type68> {
-let mut inp = input;
-let tag = {
-let tmp = Decoder25(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type68> {
+let tag = Decoder25(scope, input)?;
+let chunks = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let chunks = unimplemented!("invoke_decoder");
 return Some(Type68 { tag, chunks });
 }
 
-fn Decoder25<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let mut inp = input;
-let field0 = {
-let tmp = Decoder20(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let field1 = {
-let tmp = Decoder20(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let field2 = {
-let tmp = Decoder20(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let field3 = {
-let tmp = Decoder20(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder25<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
+let field0 = Decoder20(scope, input)?;
+let field1 = Decoder20(scope, input)?;
+let field2 = Decoder20(scope, input)?;
+let field3 = Decoder20(scope, input)?;
 return Some((field0, field1, field2, field3));
 }
 
-fn Decoder26<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type67> {
-let mut inp = input;
-let tag = {
-let tmp = Decoder25(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type67> {
+let tag = Decoder25(scope, input)?;
+let length = Decoder23(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let length = {
-let tmp = Decoder23(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let pad = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
-let pad = unimplemented!("invoke_decoder");
 return Some(Type67 { tag, length, data, pad });
 }
 
-fn Decoder27<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
-let mut inp = input;
+fn Decoder27<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
 let field0 = {
 let bs = ByteSet::from_bits([0, 0, 512, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1267,10 +1233,8 @@ return None;
 };
 let field1 = {
 let bs = ByteSet::from_bits([0, 65536, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1278,10 +1242,8 @@ return None;
 };
 let field2 = {
 let bs = ByteSet::from_bits([0, 16384, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1289,10 +1251,8 @@ return None;
 };
 let field3 = {
 let bs = ByteSet::from_bits([0, 128, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1300,10 +1260,8 @@ return None;
 };
 let field4 = {
 let bs = ByteSet::from_bits([8192, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1311,10 +1269,8 @@ return None;
 };
 let field5 = {
 let bs = ByteSet::from_bits([1024, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1322,10 +1278,8 @@ return None;
 };
 let field6 = {
 let bs = ByteSet::from_bits([67108864, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1333,10 +1287,8 @@ return None;
 };
 let field7 = {
 let bs = ByteSet::from_bits([1024, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1345,87 +1297,58 @@ return None;
 return Some((field0, field1, field2, field3, field4, field5, field6, field7));
 }
 
-fn Decoder28<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type57> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
+let length = Decoder32(scope, input)?;
+let tag = Decoder43(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = {
-let tmp = Decoder43(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let crc = Decoder32(scope, input)?;
 return Some(Type57 { length, tag, data, crc });
 }
 
-fn Decoder29<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type63> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder30<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type64> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder30<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
+let length = Decoder32(scope, input)?;
+let tag = Decoder35(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = {
-let tmp = Decoder35(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let crc = Decoder32(scope, input)?;
 return Some(Type64 { length, tag, data, crc });
 }
 
-fn Decoder31<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type65> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
+let length = Decoder32(scope, input)?;
+let tag = Decoder33(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = {
-let tmp = Decoder33(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let crc = Decoder32(scope, input)?;
 return Some(Type65 { length, tag, data, crc });
 }
 
-fn Decoder32<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u32> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder33<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let mut inp = input;
+fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
 let field0 = {
 let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1433,10 +1356,8 @@ return None;
 };
 let field1 = {
 let bs = ByteSet::from_bits([0, 32, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1444,10 +1365,8 @@ return None;
 };
 let field2 = {
 let bs = ByteSet::from_bits([0, 16384, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1455,10 +1374,8 @@ return None;
 };
 let field3 = {
 let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1467,18 +1384,15 @@ return None;
 return Some((field0, field1, field2, field3));
 }
 
-fn Decoder34<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<()> {
+fn Decoder34<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<()> {
 Some(())
 }
 
-fn Decoder35<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let mut inp = input;
+fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
 let field0 = {
 let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1486,10 +1400,8 @@ return None;
 };
 let field1 = {
 let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1497,10 +1409,8 @@ return None;
 };
 let field2 = {
 let bs = ByteSet::from_bits([0, 2, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1508,10 +1418,8 @@ return None;
 };
 let field3 = {
 let bs = ByteSet::from_bits([0, 1048576, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1520,109 +1428,95 @@ return None;
 return Some((field0, field1, field2, field3));
 }
 
-fn Decoder36<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Vec<u8>> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder37<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type82> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type82> {
+let length = Decoder32(scope, input)?;
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let crc = Decoder32(scope, input)?;
 return Some(Type82 { length, tag, data, crc });
 }
 
-fn Decoder38<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type83> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type83> {
+let length = Decoder32(scope, input)?;
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let crc = Decoder32(scope, input)?;
 return Some(Type83 { length, tag, data, crc });
 }
 
-fn Decoder39<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type84> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type84> {
+let length = Decoder32(scope, input)?;
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let crc = Decoder32(scope, input)?;
 return Some(Type84 { length, tag, data, crc });
 }
 
-fn Decoder40<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type85> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type85> {
+let length = Decoder32(scope, input)?;
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let crc = Decoder32(scope, input)?;
 return Some(Type85 { length, tag, data, crc });
 }
 
-fn Decoder41<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type86> {
-let mut inp = input;
-let length = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type86> {
+let length = Decoder32(scope, input)?;
+let tag = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let tag = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
-let crc = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let crc = Decoder32(scope, input)?;
 return Some(Type86 { length, tag, data, crc });
 }
 
-fn Decoder42<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u16> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder43<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-let mut inp = input;
+fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
 let field0 = {
 let bs = ByteSet::from_bits([0, 512, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1630,10 +1524,8 @@ return None;
 };
 let field1 = {
 let bs = ByteSet::from_bits([0, 256, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1641,10 +1533,8 @@ return None;
 };
 let field2 = {
 let bs = ByteSet::from_bits([0, 16, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1652,10 +1542,8 @@ return None;
 };
 let field3 = {
 let bs = ByteSet::from_bits([0, 262144, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1664,54 +1552,22 @@ return None;
 return Some((field0, field1, field2, field3));
 }
 
-fn Decoder44<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type56> {
-let mut inp = input;
-let width = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let height = {
-let tmp = Decoder32(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let bit_depth = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let color_type = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let compression_method = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let filter_method = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let interlace_method = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type56> {
+let width = Decoder32(scope, input)?;
+let height = Decoder32(scope, input)?;
+let bit_depth = Decoder16(scope, input)?;
+let color_type = Decoder16(scope, input)?;
+let compression_method = Decoder16(scope, input)?;
+let filter_method = Decoder16(scope, input)?;
+let interlace_method = Decoder16(scope, input)?;
 return Some(Type56 { width, height, bit_depth, color_type, compression_method, filter_method, interlace_method });
 }
 
-fn Decoder45<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1719,10 +1575,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 16777216]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1731,33 +1585,33 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder46<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type55> {
-let mut inp = input;
-let initial_segment = unimplemented!("invoke_decoder");
-let segments = unimplemented!("invoke_decoder");
-let header = {
-let tmp = Decoder51(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
+let initial_segment = {
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let scan = {
-let tmp = Decoder52(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let segments = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let dnl = unimplemented!("invoke_decoder");
-let scans = unimplemented!("invoke_decoder");
+let header = Decoder51(scope, input)?;
+let scan = Decoder52(scope, input)?;
+let dnl = {
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let scans = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type55 { initial_segment, segments, header, scan, dnl, scans });
 }
 
-fn Decoder47<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1765,10 +1619,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 33554432]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1777,116 +1629,116 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder48<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type87> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type87> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type87 { marker, length, data });
 }
 
-fn Decoder49<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type88> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type88 { marker, length, data });
 }
 
-fn Decoder50<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type43> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder51<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type46> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder52<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type52> {
-let mut inp = input;
-let segments = unimplemented!("invoke_decoder");
-let sos = {
-let tmp = Decoder55(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
+let segments = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = {
-let tmp = Decoder69(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let sos = Decoder55(scope, input)?;
+let data = Decoder69(scope, input)?;
 return Some(Type52 { segments, sos, data });
 }
 
-fn Decoder53<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type89> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type89> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type89 { marker, length, data });
 }
 
-fn Decoder54<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type52> {
-let mut inp = input;
-let segments = unimplemented!("invoke_decoder");
-let sos = {
-let tmp = Decoder55(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
+let segments = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = {
-let tmp = Decoder56(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let sos = Decoder55(scope, input)?;
+let data = Decoder56(scope, input)?;
 return Some(Type52 { segments, sos, data });
 }
 
-fn Decoder55<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type49> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type49> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type49 { marker, length, data });
 }
 
-fn Decoder56<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type51> {
-let mut inp = input;
-let scan_data = unimplemented!("invoke_decoder");
-let scan_data_stream = unimplemented!("invoke_decoder");
+fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
+let scan_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let scan_data_stream = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type51 { scan_data, scan_data_stream });
 }
 
-fn Decoder57<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder58<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1894,10 +1746,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 65536]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1906,14 +1756,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder59<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1921,10 +1768,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 131072]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1933,14 +1778,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder60<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1948,10 +1790,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 262144]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1960,14 +1800,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder61<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1975,10 +1812,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 524288]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -1987,14 +1822,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder62<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2002,10 +1834,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 1048576]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2014,14 +1844,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder63<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2029,10 +1856,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 2097152]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2041,14 +1866,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder64<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2056,10 +1878,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 4194304]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2068,14 +1888,11 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder65<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type28> {
-let mut inp = input;
+fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
 let ff = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2083,10 +1900,8 @@ return None;
 };
 let marker = {
 let bs = ByteSet::from_bits([0, 0, 0, 8388608]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2095,562 +1910,527 @@ return None;
 return Some(Type28 { ff, marker });
 }
 
-fn Decoder66<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type48> {
-let mut inp = input;
-let num_image_components = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type48> {
+let num_image_components = Decoder16(scope, input)?;
+let image_components = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let image_components = unimplemented!("invoke_decoder");
-let start_spectral_selection = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let end_spectral_selection = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let approximation_bit_position = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let start_spectral_selection = Decoder16(scope, input)?;
+let end_spectral_selection = Decoder16(scope, input)?;
+let approximation_bit_position = Decoder16(scope, input)?;
 return Some(Type48 { num_image_components, image_components, start_spectral_selection, end_spectral_selection, approximation_bit_position });
 }
 
-fn Decoder67<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type47> {
-let mut inp = input;
-let component_selector = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let entropy_coding_table_ids = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder67<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
+let component_selector = Decoder16(scope, input)?;
+let entropy_coding_table_ids = Decoder16(scope, input)?;
 return Some(Type47 { component_selector, entropy_coding_table_ids });
 }
 
-fn Decoder68<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type53> {
-let mut inp = input;
-let num_lines = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder68<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type53> {
+let num_lines = Decoder42(scope, input)?;
 return Some(Type53 { num_lines });
 }
 
-fn Decoder69<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type51> {
-let mut inp = input;
-let scan_data = unimplemented!("invoke_decoder");
-let scan_data_stream = unimplemented!("invoke_decoder");
+fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
+let scan_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let scan_data_stream = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type51 { scan_data, scan_data_stream });
 }
 
-fn Decoder70<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder71<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder72<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder73<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder74<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder75<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder76<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder77<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder78<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder79<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder80<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder81<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder82<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type90> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder82<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type90 { marker, length, data });
 }
 
-fn Decoder83<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type45> {
-let mut inp = input;
-let sample_precision = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type45> {
+let sample_precision = Decoder16(scope, input)?;
+let num_lines = Decoder42(scope, input)?;
+let num_samples_per_line = Decoder42(scope, input)?;
+let num_image_components = Decoder16(scope, input)?;
+let image_components = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let num_lines = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let num_samples_per_line = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let num_image_components = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let image_components = unimplemented!("invoke_decoder");
 return Some(Type45 { sample_precision, num_lines, num_samples_per_line, num_image_components, image_components });
 }
 
-fn Decoder84<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type44> {
-let mut inp = input;
-let id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let sampling_factor = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let quantization_table_id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type44> {
+let id = Decoder16(scope, input)?;
+let sampling_factor = Decoder16(scope, input)?;
+let quantization_table_id = Decoder16(scope, input)?;
 return Some(Type44 { id, sampling_factor, quantization_table_id });
 }
 
-fn Decoder85<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type91> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type91> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type91 { marker, length, data });
 }
 
-fn Decoder86<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type92> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type92> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type92 { marker, length, data });
 }
 
-fn Decoder87<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type93> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type93 { marker, length, data });
 }
 
-fn Decoder88<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type94> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type94> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type94 { marker, length, data });
 }
 
-fn Decoder89<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder90<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder91<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder92<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder93<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder94<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder95<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder96<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder97<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder98<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder99<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder100<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder101<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder102<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder103<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type95> {
-let mut inp = input;
-let marker = unimplemented!("invoke_decoder");
-let length = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+let marker = {
+let tmp = r#"invoke_decoder @ Discriminant(9)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
+let length = Decoder42(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(17)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type95 { marker, length, data });
 }
 
-fn Decoder104<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type42> {
-let mut inp = input;
-let restart_interval = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
+let restart_interval = Decoder42(scope, input)?;
 return Some(Type42 { restart_interval });
 }
 
-fn Decoder105<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type41> {
-let mut inp = input;
-let class_table_id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let value = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type41> {
+let class_table_id = Decoder16(scope, input)?;
+let value = Decoder16(scope, input)?;
 return Some(Type41 { class_table_id, value });
 }
 
-fn Decoder106<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type40> {
-let mut inp = input;
-let class_table_id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type40> {
+let class_table_id = Decoder16(scope, input)?;
+let num_codes = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let num_codes = unimplemented!("invoke_decoder");
-let values = unimplemented!("invoke_decoder");
+let values = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type40 { class_table_id, num_codes, values });
 }
 
-fn Decoder107<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type39> {
-let mut inp = input;
-let precision_table_id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type39> {
+let precision_table_id = Decoder16(scope, input)?;
+let elements = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let elements = unimplemented!("invoke_decoder");
 return Some(Type39 { precision_table_id, elements });
 }
 
-fn Decoder108<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type37> {
-let mut inp = input;
-let identifier = {
-let tmp = Decoder109(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type37> {
+let identifier = Decoder109(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
 return Some(Type37 { identifier, data });
 }
 
-fn Decoder109<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type29> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
+fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 let null = {
 let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2659,67 +2439,73 @@ return None;
 return Some(Type29 { string, null });
 }
 
-fn Decoder110<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type96> {
-let mut inp = input;
+fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
 let padding = {
 let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let exif = {
-let tmp = Decoder112(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let exif = Decoder112(scope, input)?;
 return Some(Type96 { padding, exif });
 }
 
-fn Decoder111<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type97> {
-let mut inp = input;
-let xmp = unimplemented!("invoke_decoder");
+fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type97> {
+let xmp = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type97 { xmp });
 }
 
-fn Decoder112<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type35> {
-let mut inp = input;
-let byte_order = unimplemented!("invoke_decoder");
-let magic = unimplemented!("invoke_decoder");
-let offset = unimplemented!("invoke_decoder");
-let ifd = unimplemented!("invoke_decoder");
+fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type35> {
+let byte_order = {
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let magic = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let offset = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let ifd = {
+let tmp = r#"invoke_decoder @ Discriminant(19)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type35 { byte_order, magic, offset, ifd });
 }
 
-fn Decoder113<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u16> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder114<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type31> {
-let mut inp = input;
-let identifier = {
-let tmp = Decoder115(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type31> {
+let identifier = Decoder115(scope, input)?;
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let data = unimplemented!("invoke_decoder");
 return Some(Type31 { identifier, data });
 }
 
-fn Decoder115<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type29> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
+fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 let null = {
 let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2728,150 +2514,85 @@ return None;
 return Some(Type29 { string, null });
 }
 
-fn Decoder116<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type98> {
-let mut inp = input;
-let version_major = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type98> {
+let version_major = Decoder16(scope, input)?;
+let version_minor = Decoder16(scope, input)?;
+let density_units = Decoder16(scope, input)?;
+let density_x = Decoder42(scope, input)?;
+let density_y = Decoder42(scope, input)?;
+let thumbnail_width = Decoder16(scope, input)?;
+let thumbnail_height = Decoder16(scope, input)?;
+let thumbnail_pixels = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let version_minor = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let density_units = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let density_x = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let density_y = {
-let tmp = Decoder42(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let thumbnail_width = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let thumbnail_height = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let thumbnail_pixels = unimplemented!("invoke_decoder");
 return Some(Type98 { version_major, version_minor, density_units, density_x, density_y, thumbnail_width, thumbnail_height, thumbnail_pixels });
 }
 
-fn Decoder117<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type2> {
-let mut inp = input;
-let r = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let g = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let b = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder117<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
+let r = Decoder16(scope, input)?;
+let g = Decoder16(scope, input)?;
+let b = Decoder16(scope, input)?;
 return Some(Type2 { r, g, b });
 }
 
-fn Decoder118<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type13> {
-let mut inp = input;
-let magic = unimplemented!("invoke_decoder");
-let method = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder118<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
+let magic = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let file_flags = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let timestamp = {
-let tmp = Decoder23(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let compression_flags = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let os_id = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let method = Decoder16(scope, input)?;
+let file_flags = Decoder16(scope, input)?;
+let timestamp = Decoder23(scope, input)?;
+let compression_flags = Decoder16(scope, input)?;
+let os_id = Decoder16(scope, input)?;
 return Some(Type13 { magic, method, file_flags, timestamp, compression_flags, os_id });
 }
 
-fn Decoder119<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type29> {
-let mut inp = input;
-return Some({
-let tmp = Decoder127(scope, inp)?;
-inp = tmp.1;
-tmp.0
-});
+fn Decoder119<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+return Some(Decoder127(scope, input)?);
 }
 
-fn Decoder120<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type25> {
-let mut inp = input;
-let blocks = unimplemented!("invoke_decoder");
-let codes = unimplemented!("invoke_decoder");
-let inflate = unimplemented!("invoke_decoder");
+fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type25> {
+let blocks = {
+let tmp = r#"invoke_decoder @ Discriminant(13)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let codes = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let inflate = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type25 { blocks, codes, inflate });
 }
 
-fn Decoder121<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type26> {
-let mut inp = input;
-let crc = {
-let tmp = Decoder23(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let length = {
-let tmp = Decoder23(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder121<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type26> {
+let crc = Decoder23(scope, input)?;
+let length = Decoder23(scope, input)?;
 return Some(Type26 { crc, length });
 }
 
-fn Decoder122<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type24> {
-let mut inp = input;
-let r#final = {
-let tmp = Decoder123(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type24> {
+let r#final = Decoder123(scope, input)?;
+let r#type = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let r#type = unimplemented!("invoke_decoder");
-let data = unimplemented!("invoke_decoder");
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type24 { r#final, r#type, data });
 }
 
-fn Decoder123<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder123<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([18446744073709551615, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2879,53 +2600,97 @@ return None;
 });
 }
 
-fn Decoder124<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type99> {
-let mut inp = input;
+fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type99> {
 let align = {
-while input.offset % 8 != 0 {
-let tmp = inp.read_byte()?;
-inp = tmp.1;
+while input.offset() % 8 != 0 {
+let _ = input.read_byte()?;
 }
 ()
 };
-let len = unimplemented!("invoke_decoder");
-let nlen = unimplemented!("invoke_decoder");
-let bytes = unimplemented!("invoke_decoder");
-let codes_values = unimplemented!("invoke_decoder");
+let len = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let nlen = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let bytes = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let codes_values = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type99 { align, len, nlen, bytes, codes_values });
 }
 
-fn Decoder125<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type100> {
-let mut inp = input;
-let codes = unimplemented!("invoke_decoder");
-let codes_values = unimplemented!("invoke_decoder");
+fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type100> {
+let codes = {
+let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let codes_values = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type100 { codes, codes_values });
 }
 
-fn Decoder126<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type101> {
-let mut inp = input;
-let hlit = unimplemented!("invoke_decoder");
-let hdist = unimplemented!("invoke_decoder");
-let hclen = unimplemented!("invoke_decoder");
-let code_length_alphabet_code_lengths = unimplemented!("invoke_decoder");
-let literal_length_distance_alphabet_code_lengths = unimplemented!("invoke_decoder");
-let literal_length_distance_alphabet_code_lengths_value = unimplemented!("invoke_decoder");
-let literal_length_alphabet_code_lengths_value = unimplemented!("invoke_decoder");
-let distance_alphabet_code_lengths_value = unimplemented!("invoke_decoder");
-let codes = unimplemented!("invoke_decoder");
-let codes_values = unimplemented!("invoke_decoder");
+fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type101> {
+let hlit = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let hdist = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let hclen = {
+let tmp = r#"invoke_decoder @ Discriminant(20)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let code_length_alphabet_code_lengths = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let literal_length_distance_alphabet_code_lengths = {
+let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let literal_length_distance_alphabet_code_lengths_value = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let literal_length_alphabet_code_lengths_value = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let distance_alphabet_code_lengths_value = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let codes = {
+let tmp = r#"invoke_decoder @ Discriminant(24)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let codes_values = {
+let tmp = r#"invoke_decoder @ Discriminant(21)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type101 { hlit, hdist, hclen, code_length_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths_value, literal_length_alphabet_code_lengths_value, distance_alphabet_code_lengths_value, codes, codes_values });
 }
 
-fn Decoder127<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type29> {
-let mut inp = input;
-let string = unimplemented!("invoke_decoder");
+fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+let string = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 let null = {
 let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2934,37 +2699,39 @@ return None;
 return Some(Type29 { string, null });
 }
 
-fn Decoder128<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type0> {
-let mut inp = input;
-let signature = unimplemented!("invoke_decoder");
-let version = unimplemented!("invoke_decoder");
+fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type0> {
+let signature = {
+let tmp = r#"invoke_decoder @ Discriminant(8)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let version = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type0 { signature, version });
 }
 
-fn Decoder129<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type4> {
-let mut inp = input;
-let descriptor = {
-let tmp = Decoder145(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type4> {
+let descriptor = Decoder145(scope, input)?;
+let global_color_table = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let global_color_table = unimplemented!("invoke_decoder");
 return Some(Type4 { descriptor, global_color_table });
 }
 
-fn Decoder130<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type11> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type11> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder131<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type12> {
-let mut inp = input;
+fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
 let separator = {
 let bs = ByteSet::from_bits([576460752303423488, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -2973,30 +2740,27 @@ return None;
 return Some(Type12 { separator });
 }
 
-fn Decoder132<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type102> {
-let mut inp = input;
-let graphic_control_extension = unimplemented!("invoke_decoder");
-let graphic_rendering_block = {
-let tmp = Decoder139(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
+let graphic_control_extension = {
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let graphic_rendering_block = Decoder139(scope, input)?;
 return Some(Type102 { graphic_control_extension, graphic_rendering_block });
 }
 
-fn Decoder133<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type10> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder134<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type103> {
-let mut inp = input;
+fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
 let separator = {
 let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3004,10 +2768,8 @@ return None;
 };
 let label = {
 let bs = ByteSet::from_bits([0, 0, 0, 9223372036854775808]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3015,34 +2777,34 @@ return None;
 };
 let block_size = {
 let bs = ByteSet::from_bits([2048, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let identifier = unimplemented!("invoke_decoder");
-let authentication_code = unimplemented!("invoke_decoder");
-let application_data = unimplemented!("invoke_decoder");
-let terminator = {
-let tmp = Decoder137(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let identifier = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let authentication_code = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let application_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
+};
+let terminator = Decoder137(scope, input)?;
 return Some(Type103 { separator, label, block_size, identifier, authentication_code, application_data, terminator });
 }
 
-fn Decoder135<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type104> {
-let mut inp = input;
+fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
 let separator = {
 let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3050,49 +2812,43 @@ return None;
 };
 let label = {
 let bs = ByteSet::from_bits([0, 0, 0, 4611686018427387904]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let comment_data = unimplemented!("invoke_decoder");
-let terminator = {
-let tmp = Decoder137(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let comment_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
+let terminator = Decoder137(scope, input)?;
 return Some(Type104 { separator, label, comment_data, terminator });
 }
 
-fn Decoder136<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type7> {
-let mut inp = input;
+fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
 let len_bytes = {
 let bs = ByteSet::from_bits([18446744073709551614, 18446744073709551615, 18446744073709551615, 18446744073709551615]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let data = unimplemented!("invoke_decoder");
+let data = {
+let tmp = r#"invoke_decoder @ Discriminant(12)"#;
+unimplemented!(r#"{}"#, tmp)
+};
 return Some(Type7 { len_bytes, data });
 }
 
-fn Decoder137<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<u8> {
-let mut inp = input;
+fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
 return Some({
 let bs = ByteSet::from_bits([1, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3100,14 +2856,11 @@ return None;
 });
 }
 
-fn Decoder138<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type105> {
-let mut inp = input;
+fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type105> {
 let separator = {
 let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3115,10 +2868,8 @@ return None;
 };
 let label = {
 let bs = ByteSet::from_bits([0, 0, 0, 144115188075855872]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3126,67 +2877,42 @@ return None;
 };
 let block_size = {
 let bs = ByteSet::from_bits([16, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let flags = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let delay_time = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let transparent_color_index = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let terminator = {
-let tmp = Decoder137(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let flags = Decoder16(scope, input)?;
+let delay_time = Decoder113(scope, input)?;
+let transparent_color_index = Decoder16(scope, input)?;
+let terminator = Decoder137(scope, input)?;
 return Some(Type105 { separator, label, block_size, flags, delay_time, transparent_color_index, terminator });
 }
 
-fn Decoder139<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type9> {
-let mut inp = input;
-return Some(unimplemented!("invoke_decoder"));
+fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
+return Some({
+let tmp = r#"invoke_decoder @ Discriminant(7)"#;
+unimplemented!(r#"{}"#, tmp)
+});
 }
 
-fn Decoder140<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type106> {
-let mut inp = input;
-let descriptor = {
-let tmp = Decoder142(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type106> {
+let descriptor = Decoder142(scope, input)?;
+let local_color_table = {
+let tmp = r#"invoke_decoder @ Discriminant(23)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let local_color_table = unimplemented!("invoke_decoder");
-let data = {
-let tmp = Decoder144(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let data = Decoder144(scope, input)?;
 return Some(Type106 { descriptor, local_color_table, data });
 }
 
-fn Decoder141<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type107> {
-let mut inp = input;
+fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
 let separator = {
 let bs = ByteSet::from_bits([8589934592, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3194,10 +2920,8 @@ return None;
 };
 let label = {
 let bs = ByteSet::from_bits([2, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
@@ -3205,168 +2929,80 @@ return None;
 };
 let block_size = {
 let bs = ByteSet::from_bits([4096, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let text_grid_left_position = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
+let text_grid_left_position = Decoder113(scope, input)?;
+let text_grid_top_position = Decoder113(scope, input)?;
+let text_grid_width = Decoder113(scope, input)?;
+let text_grid_height = Decoder113(scope, input)?;
+let character_cell_width = Decoder16(scope, input)?;
+let character_cell_height = Decoder16(scope, input)?;
+let text_foreground_color_index = Decoder16(scope, input)?;
+let text_background_color_index = Decoder16(scope, input)?;
+let plain_text_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let text_grid_top_position = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let text_grid_width = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let text_grid_height = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let character_cell_width = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let character_cell_height = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let text_foreground_color_index = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let text_background_color_index = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let plain_text_data = unimplemented!("invoke_decoder");
-let terminator = {
-let tmp = Decoder137(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let terminator = Decoder137(scope, input)?;
 return Some(Type107 { separator, label, block_size, text_grid_left_position, text_grid_top_position, text_grid_width, text_grid_height, character_cell_width, character_cell_height, text_foreground_color_index, text_background_color_index, plain_text_data, terminator });
 }
 
-fn Decoder142<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type6> {
-let mut inp = input;
+fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
 let separator = {
 let bs = ByteSet::from_bits([17592186044416, 0, 0, 0]);
-let tmp = input.read_byte()?;
-let b = tmp.0;
+let b = input.read_byte()?;
 if bs.contains(b) {
-inp = tmp.1;
 b
 } else {
 return None;
 }
 };
-let image_left_position = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let image_top_position = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let image_width = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let image_height = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let flags = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let image_left_position = Decoder113(scope, input)?;
+let image_top_position = Decoder113(scope, input)?;
+let image_width = Decoder113(scope, input)?;
+let image_height = Decoder113(scope, input)?;
+let flags = Decoder16(scope, input)?;
 return Some(Type6 { separator, image_left_position, image_top_position, image_width, image_height, flags });
 }
 
-fn Decoder143<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type2> {
-let mut inp = input;
-let r = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let g = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let b = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder143<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
+let r = Decoder16(scope, input)?;
+let g = Decoder16(scope, input)?;
+let b = Decoder16(scope, input)?;
 return Some(Type2 { r, g, b });
 }
 
-fn Decoder144<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type8> {
-let mut inp = input;
-let lzw_min_code_size = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
+fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
+let lzw_min_code_size = Decoder16(scope, input)?;
+let image_data = {
+let tmp = r#"invoke_decoder @ Discriminant(10)"#;
+unimplemented!(r#"{}"#, tmp)
 };
-let image_data = unimplemented!("invoke_decoder");
-let terminator = {
-let tmp = Decoder137(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+let terminator = Decoder137(scope, input)?;
 return Some(Type8 { lzw_min_code_size, image_data, terminator });
 }
 
-fn Decoder145<'input>(scope: &mut Scope, input: ReadCtxt<'input>) -> Option<Type1> {
-let mut inp = input;
-let screen_width = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let screen_height = {
-let tmp = Decoder113(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let flags = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let bg_color_index = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
-let pixel_aspect_ratio = {
-let tmp = Decoder16(scope, inp)?;
-inp = tmp.1;
-tmp.0
-};
+fn Decoder145<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type1> {
+let screen_width = Decoder113(scope, input)?;
+let screen_height = Decoder113(scope, input)?;
+let flags = Decoder16(scope, input)?;
+let bg_color_index = Decoder16(scope, input)?;
+let pixel_aspect_ratio = Decoder16(scope, input)?;
 return Some(Type1 { screen_width, screen_height, flags, bg_color_index, pixel_aspect_ratio });
 }
 
+
+#[test]
+fn test_decoder_27() {
+    // PNG signature
+    let input = b"\x89PNG\r\n\x1A\n";
+    let mut parse_ctxt = ParseCtxt::new(input);
+    let mut scope = Scope::Empty;
+    let ret = Decoder27(&mut scope, &mut parse_ctxt);
+    assert!(ret.is_some());
+}

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,8 +1,206 @@
 use doodle::prelude::*;
 
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+enum Type3 {
+    no,
+    yes(Vec<Type2>),
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type5 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+enum Type6 {
+    some(Type5),
+    none,
+}
+
+struct Type7 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type8 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+struct Type9 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type10 {
+    descriptor: Type7,
+    local_color_table: Type3,
+    data: Type9,
+}
+
+struct Type11 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type8>,
+    terminator: u8,
+}
+
 enum Type12 {
     table_based_image(Type10),
     plain_text_extension(Type11),
+}
+
+struct Type13 {
+    graphic_control_extension: Type6,
+    graphic_rendering_block: Type12,
+}
+
+struct Type14 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type15 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type8>,
+    terminator: u8,
+}
+
+enum Type16 {
+    application_extension(Type14),
+    comment_extension(Type15),
+}
+
+enum Type17 {
+    graphic_block(Type13),
+    special_purpose_block(Type16),
+}
+
+struct Type18 {
+    separator: u8,
+}
+
+struct Type19 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type17>,
+    trailer: Type18,
+}
+
+struct Type20 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type21 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+enum Type22 {
+    no,
+    yes(Type21),
+}
+
+struct Type23 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type24 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type25 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u16,
+    distance_record: Type24,
+}
+
+enum Type26 {
+    none,
+    some(Type25),
+}
+
+struct Type27 {
+    code: u16,
+    extra: Type26,
+}
+
+struct Type28 {
+    length: u16,
+    distance: u16,
+}
+
+enum Type29 {
+    literal(u8),
+    reference(Type28),
+}
+
+struct Type30 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type27>,
+    codes_values: Vec<Type29>,
 }
 
 struct Type31 {
@@ -12,6 +210,111 @@ struct Type31 {
     distance_record: Type24,
 }
 
+enum Type32 {
+    none,
+    some(Type31),
+}
+
+struct Type33 {
+    code: u16,
+    extra: Type32,
+}
+
+struct Type34 {
+    codes: Vec<Type33>,
+    codes_values: Vec<Type29>,
+}
+
+enum Type35 {
+    literal(u8),
+}
+
+struct Type36 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type35>,
+}
+
+enum Type37 {
+    dynamic_huffman(Type30),
+    fixed_huffman(Type34),
+    uncompressed(Type36),
+}
+
+struct Type38 {
+    r#final: u8,
+    r#type: u8,
+    data: Type37,
+}
+
+struct Type39 {
+    blocks: Vec<Type38>,
+    codes: Vec<Type29>,
+    inflate: Vec<u8>,
+}
+
+struct Type40 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type41 {
+    header: Type20,
+    fname: Type22,
+    data: Type39,
+    footer: Type40,
+}
+
+struct Type42 {
+    ff: u8,
+    marker: u8,
+}
+
+struct Type43 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+enum Type44 {
+    other(Vec<u8>),
+    jfif(Type43),
+}
+
+struct Type45 {
+    identifier: Type21,
+    data: Type44,
+}
+
+struct Type46 {
+    marker: Type42,
+    length: u16,
+    data: Type45,
+}
+
+struct Type47 {
+    xmp: Vec<u8>,
+}
+
+enum Type48 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+struct Type49 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
 struct Type50 {
     num_fields: u16,
     fields: Vec<Type49>,
@@ -19,10 +322,88 @@ struct Type50 {
     next_ifd: Vec<u8>,
 }
 
-struct Type9 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type8>,
-    terminator: u8,
+struct Type51 {
+    byte_order: Type48,
+    magic: u16,
+    offset: u32,
+    ifd: Type50,
+}
+
+struct Type52 {
+    padding: u8,
+    exif: Type51,
+}
+
+enum Type53 {
+    other(Vec<u8>),
+    xmp(Type47),
+    exif(Type52),
+}
+
+struct Type54 {
+    identifier: Type21,
+    data: Type53,
+}
+
+struct Type55 {
+    marker: Type42,
+    length: u16,
+    data: Type54,
+}
+
+enum Type56 {
+    app0(Type46),
+    app1(Type55),
+}
+
+struct Type57 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+struct Type58 {
+    marker: Type42,
+    length: u16,
+    data: Type57,
+}
+
+struct Type59 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+struct Type60 {
+    marker: Type42,
+    length: u16,
+    data: Type59,
+}
+
+struct Type61 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type62 {
+    marker: Type42,
+    length: u16,
+    data: Type61,
+}
+
+struct Type63 {
+    restart_interval: u16,
+}
+
+struct Type64 {
+    marker: Type42,
+    length: u16,
+    data: Type63,
+}
+
+struct Type65 {
+    marker: Type42,
+    length: u16,
+    data: Vec<u8>,
 }
 
 enum Type66 {
@@ -49,15 +430,59 @@ enum Type66 {
     com(Type65),
 }
 
-struct Type46 {
+struct Type67 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+struct Type68 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type67>,
+}
+
+struct Type69 {
     marker: Type42,
     length: u16,
-    data: Type45,
+    data: Type68,
+}
+
+enum Type70 {
+    sof0(Type69),
+    sof1(Type69),
+    sof2(Type69),
+    sof3(Type69),
+    sof5(Type69),
+    sof6(Type69),
+    sof7(Type69),
+    sof9(Type69),
+    sof10(Type69),
+    sof11(Type69),
+    sof13(Type69),
+    sof14(Type69),
+    sof15(Type69),
 }
 
 struct Type71 {
     component_selector: u8,
     entropy_coding_table_ids: u8,
+}
+
+struct Type72 {
+    num_image_components: u8,
+    image_components: Vec<Type71>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type73 {
+    marker: Type42,
+    length: u16,
+    data: Type72,
 }
 
 enum Type74 {
@@ -72,20 +497,211 @@ enum Type74 {
     rst7(Type42),
 }
 
-enum Type37 {
-    dynamic_huffman(Type30),
-    fixed_huffman(Type34),
-    uncompressed(Type36),
+struct Type75 {
+    scan_data: Vec<Type74>,
+    scan_data_stream: Vec<u8>,
 }
 
-struct Type33 {
-    code: u16,
-    extra: Type32,
+struct Type76 {
+    segments: Vec<Type66>,
+    sos: Type73,
+    data: Type75,
 }
 
-struct Type8 {
-    len_bytes: u8,
+struct Type77 {
+    num_lines: u16,
+}
+
+struct Type78 {
+    marker: Type42,
+    length: u16,
+    data: Type77,
+}
+
+enum Type79 {
+    some(Type78),
+    none,
+}
+
+struct Type80 {
+    initial_segment: Type56,
+    segments: Vec<Type66>,
+    header: Type70,
+    scan: Type76,
+    dnl: Type79,
+    scans: Vec<Type76>,
+}
+
+struct Type81 {
+    soi: Type42,
+    frame: Type80,
+    eoi: Type42,
+}
+
+struct Type82 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type82,
+    crc: u32,
+}
+
+struct Type84 {
+    palette_index: u8,
+}
+
+struct Type85 {
+    red: u16,
+    green: u16,
+    blue: u16,
+}
+
+struct Type86 {
+    greyscale: u16,
+}
+
+enum Type87 {
+    color_type_3(Type84),
+    color_type_6(Type85),
+    color_type_2(Type85),
+    color_type_4(Type86),
+    color_type_0(Type86),
+}
+
+struct Type88 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type87,
+    crc: u32,
+}
+
+struct Type89 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+struct Type90 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type89,
+    crc: u32,
+}
+
+struct Type91 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
+}
+
+struct Type92 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type93 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type92,
+    crc: u32,
+}
+
+enum Type94 {
+    color_type_3(Vec<Type84>),
+    color_type_2(Type85),
+    color_type_0(Type86),
+}
+
+struct Type95 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type94,
+    crc: u32,
+}
+
+enum Type96 {
+    bKGD(Type88),
+    pHYs(Type90),
+    PLTE(Type91),
+    tIME(Type93),
+    tRNS(Type95),
+}
+
+struct Type97 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
     data: Vec<u8>,
+    crc: u32,
+}
+
+struct Type98 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
+}
+
+struct Type99 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type83,
+    chunks: Vec<Type96>,
+    idat: Vec<Type97>,
+    more_chunks: Vec<Type96>,
+    iend: Type98,
+}
+
+enum Type100 {
+    no(u8),
+    yes,
+}
+
+struct Type101 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type100,
+}
+
+struct Type102 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type101>,
+}
+
+struct Type103 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type102,
+    pad: Type100,
+}
+
+struct Type104 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type105 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
+}
+
+struct Type106 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
 }
 
 struct Type107 {
@@ -108,183 +724,10 @@ struct Type107 {
     pad: Vec<u8>,
 }
 
-struct Type20 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type104 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-enum Type6 {
-    some(Type5),
-    none,
-}
-
-struct Type36 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type35>,
-}
-
-struct Type72 {
-    num_image_components: u8,
-    image_components: Vec<Type71>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type14 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type59 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-struct Type23 {
-    code: u16,
-    extra: u8,
-}
-
-struct Type105 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-struct Type63 {
-    restart_interval: u16,
-}
-
-struct Type27 {
-    code: u16,
-    extra: Type26,
-}
-
-struct Type77 {
-    num_lines: u16,
-}
-
-struct Type88 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type87,
-    crc: u32,
-}
-
-struct Type18 {
-    separator: u8,
-}
-
-struct Type19 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type17>,
-    trailer: Type18,
-}
-
-struct Type86 {
-    greyscale: u16,
-}
-
-struct Type91 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
-}
-
-struct Type92 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type21 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-struct Type76 {
-    segments: Vec<Type66>,
-    sos: Type73,
-    data: Type75,
-}
-
-struct Type49 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-enum Type3 {
-    no,
-    yes(Vec<Type2>),
-}
-
-enum Type87 {
-    color_type_3(Type84),
-    color_type_6(Type85),
-    color_type_2(Type85),
-    color_type_4(Type86),
-    color_type_0(Type86),
-}
-
-struct Type43 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
-struct Type64 {
-    marker: Type42,
-    length: u16,
-    data: Type63,
-}
-
-enum Type16 {
-    application_extension(Type14),
-    comment_extension(Type15),
-}
-
-struct Type78 {
-    marker: Type42,
-    length: u16,
-    data: Type77,
-}
-
-struct Type41 {
-    header: Type20,
-    fname: Type22,
-    data: Type39,
-    footer: Type40,
+struct Type108 {
+    header: Type107,
+    file: Vec<u8>,
+    __padding: (),
 }
 
 struct Type109 {
@@ -293,388 +736,9 @@ struct Type109 {
     __trailing: Vec<u8>,
 }
 
-struct Type80 {
-    initial_segment: Type56,
-    segments: Vec<Type66>,
-    header: Type70,
-    scan: Type76,
-    dnl: Type79,
-    scans: Vec<Type76>,
-}
-
-struct Type54 {
-    identifier: Type21,
-    data: Type53,
-}
-
-enum Type29 {
-    literal(u8),
-    reference(Type28),
-}
-
-struct Type52 {
-    padding: u8,
-    exif: Type51,
-}
-
-struct Type57 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-enum Type70 {
-    sof0(Type69),
-    sof1(Type69),
-    sof2(Type69),
-    sof3(Type69),
-    sof5(Type69),
-    sof6(Type69),
-    sof7(Type69),
-    sof9(Type69),
-    sof10(Type69),
-    sof11(Type69),
-    sof13(Type69),
-    sof14(Type69),
-    sof15(Type69),
-}
-
-struct Type58 {
-    marker: Type42,
-    length: u16,
-    data: Type57,
-}
-
-struct Type108 {
-    header: Type107,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type99 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type83,
-    chunks: Vec<Type96>,
-    idat: Vec<Type97>,
-    more_chunks: Vec<Type96>,
-    iend: Type98,
-}
-
-struct Type65 {
-    marker: Type42,
-    length: u16,
-    data: Vec<u8>,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type90 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type89,
-    crc: u32,
-}
-
-enum Type44 {
-    other(Vec<u8>),
-    jfif(Type43),
-}
-
-struct Type93 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type92,
-    crc: u32,
-}
-
-struct Type28 {
-    length: u16,
-    distance: u16,
-}
-
-struct Type67 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type34 {
-    codes: Vec<Type33>,
-    codes_values: Vec<Type29>,
-}
-
-struct Type13 {
-    graphic_control_extension: Type6,
-    graphic_rendering_block: Type12,
-}
-
-struct Type82 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type82,
-    crc: u32,
-}
-
-struct Type85 {
-    red: u16,
-    green: u16,
-    blue: u16,
-}
-
-struct Type7 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type55 {
-    marker: Type42,
-    length: u16,
-    data: Type54,
-}
-
-struct Type39 {
-    blocks: Vec<Type38>,
-    codes: Vec<Type29>,
-    inflate: Vec<u8>,
-}
-
-enum Type17 {
-    graphic_block(Type13),
-    special_purpose_block(Type16),
-}
-
-struct Type45 {
-    identifier: Type21,
-    data: Type44,
-}
-
-struct Type30 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type27>,
-    codes_values: Vec<Type29>,
-}
-
-struct Type38 {
-    r#final: u8,
-    r#type: u8,
-    data: Type37,
-}
-
-enum Type26 {
-    none,
-    some(Type25),
-}
-
-struct Type89 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-struct Type95 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type94,
-    crc: u32,
-}
-
-struct Type101 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type100,
-}
-
-struct Type47 {
-    xmp: Vec<u8>,
-}
-
-struct Type61 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type81 {
-    soi: Type42,
-    frame: Type80,
-    eoi: Type42,
-}
-
-struct Type15 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type8>,
-    terminator: u8,
-}
-
-enum Type48 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type69 {
-    marker: Type42,
-    length: u16,
-    data: Type68,
-}
-
-enum Type22 {
-    no,
-    yes(Type21),
-}
-
-struct Type84 {
-    palette_index: u8,
-}
-
-enum Type96 {
-    bKGD(Type88),
-    pHYs(Type90),
-    PLTE(Type91),
-    tIME(Type93),
-    tRNS(Type95),
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type10 {
-    descriptor: Type7,
-    local_color_table: Type3,
-    data: Type9,
-}
-
-struct Type5 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-enum Type35 {
-    literal(u8),
-}
-
-struct Type75 {
-    scan_data: Vec<Type74>,
-    scan_data_stream: Vec<u8>,
-}
-
-struct Type42 {
-    ff: u8,
-    marker: u8,
-}
-
-enum Type53 {
-    other(Vec<u8>),
-    xmp(Type47),
-    exif(Type52),
-}
-
-enum Type56 {
-    app0(Type46),
-    app1(Type55),
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
-struct Type73 {
-    marker: Type42,
-    length: u16,
-    data: Type72,
-}
-
-struct Type60 {
-    marker: Type42,
-    length: u16,
-    data: Type59,
-}
-
-struct Type97 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
-    crc: u32,
-}
-
 enum Type110 {
     ascii(Vec<u8>),
     utf8(Vec<char>),
-}
-
-struct Type98 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: (),
-    crc: u32,
-}
-
-struct Type68 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type67>,
-}
-
-struct Type112 {
-    data: Type111,
-    end: (),
-}
-
-struct Type106 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-enum Type100 {
-    no(u8),
-    yes,
-}
-
-struct Type102 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type101>,
 }
 
 enum Type111 {
@@ -687,73 +751,9 @@ enum Type111 {
     text(Type110),
 }
 
-struct Type11 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type24 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-struct Type40 {
-    crc: u32,
-    length: u32,
-}
-
-enum Type79 {
-    some(Type78),
-    none,
-}
-
-enum Type94 {
-    color_type_3(Vec<Type84>),
-    color_type_2(Type85),
-    color_type_0(Type86),
-}
-
-struct Type62 {
-    marker: Type42,
-    length: u16,
-    data: Type61,
-}
-
-enum Type32 {
-    none,
-    some(Type31),
-}
-
-struct Type25 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u16,
-    distance_record: Type24,
-}
-
-struct Type51 {
-    byte_order: Type48,
-    magic: u16,
-    offset: u32,
-    ifd: Type50,
-}
-
-struct Type103 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type102,
-    pad: Type100,
+struct Type112 {
+    data: Type111,
+    end: (),
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
@@ -782,11 +782,11 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    59 => 1,
-
                     33 => 0,
 
                     44 => 0,
+
+                    59 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -899,9 +899,9 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     73 => {
                         let b = (lookahead.read_byte())?;
                         match b {
-                            68 => 1,
-
                             69 => 0,
+
+                            68 => 1,
                         }
                     }
 
@@ -1035,9 +1035,9 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 1,
-
                     0 => 0,
+
+                    tmp if (tmp != 0) => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1177,16 +1177,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
-                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
-
-                224 => 2,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
-
-                237 => 2,
-
-                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
-
                 tmp if ((ByteSet::from_bits([
                     18446744073709551615,
                     18446744073709551615,
@@ -1198,11 +1188,21 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     0
                 }
 
+                224 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
+
+                237 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
+
                 240 => 3,
 
                 tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
 
                 244 => 3,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
             }
         };
         match tree_index {
@@ -1255,6 +1255,8 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                                 3
                             }
 
+                            237 => 2,
+
                             224 => 0,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
@@ -1262,8 +1264,6 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             {
                                 1
                             }
-
-                            237 => 2,
                         }
                     };
                     match tree_index {
@@ -1374,15 +1374,15 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
+                            244 => 2,
+
+                            240 => 0,
+
                             tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
                                 .contains(tmp)) =>
                             {
                                 1
                             }
-
-                            244 => 2,
-
-                            240 => 0,
                         }
                     };
                     match tree_index {
@@ -1685,9 +1685,9 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -1900,20 +1900,20 @@ fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            116 => {
-                let b = (lookahead.read_byte())?;
-                match b {
-                    82 => 4,
-
-                    73 => 3,
-                }
-            }
-
             80 => 2,
 
             112 => 1,
 
             98 => 0,
+
+            116 => {
+                let b = (lookahead.read_byte())?;
+                match b {
+                    73 => 3,
+
+                    82 => 4,
+                }
+            }
         }
     };
     (Some(match tree_index {
@@ -2401,9 +2401,9 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             if (b == 255) {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    225 => 1,
-
                     224 => 0,
+
+                    225 => 1,
                 }
             } else {
                 return None;
@@ -2593,8 +2593,6 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        217 => 1,
-
                         218 => 0,
 
                         219 => 0,
@@ -2638,6 +2636,8 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
+
+                        217 => 1,
                     }
                 } else {
                     return None;
@@ -2747,47 +2747,47 @@ fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                226 => 6,
-
-                224 => 4,
-
-                231 => 11,
-
-                204 => 2,
-
-                237 => 17,
-
-                233 => 13,
-
-                196 => 1,
-
-                225 => 5,
-
-                230 => 10,
-
-                219 => 0,
-
-                238 => 18,
-
-                236 => 16,
-
-                221 => 3,
-
-                232 => 12,
-
-                235 => 15,
-
-                234 => 14,
-
                 227 => 7,
 
-                229 => 9,
+                224 => 4,
 
                 239 => 19,
 
                 228 => 8,
 
+                196 => 1,
+
+                236 => 16,
+
+                235 => 15,
+
+                204 => 2,
+
+                234 => 14,
+
+                225 => 5,
+
+                233 => 13,
+
+                221 => 3,
+
+                231 => 11,
+
+                238 => 18,
+
+                229 => 9,
+
+                219 => 0,
+
+                230 => 10,
+
+                226 => 6,
+
                 254 => 20,
+
+                237 => 17,
+
+                232 => 12,
             }
         } else {
             return None;
@@ -2908,31 +2908,31 @@ fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                202 => 8,
-
                 198 => 5,
 
                 193 => 1,
 
-                203 => 9,
+                202 => 8,
 
-                192 => 0,
-
-                199 => 6,
+                205 => 10,
 
                 197 => 4,
 
-                205 => 10,
+                192 => 0,
+
+                201 => 7,
+
+                207 => 12,
+
+                203 => 9,
+
+                195 => 3,
 
                 194 => 2,
 
                 206 => 11,
 
-                207 => 12,
-
-                201 => 7,
-
-                195 => 3,
+                199 => 6,
             }
         } else {
             return None;
@@ -3305,21 +3305,21 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    212 => 5,
-
-                                    209 => 2,
-
-                                    210 => 3,
-
-                                    213 => 6,
-
-                                    0 => 0,
-
                                     215 => 8,
 
                                     214 => 7,
 
                                     211 => 4,
+
+                                    210 => 3,
+
+                                    0 => 0,
+
+                                    213 => 6,
+
+                                    212 => 5,
+
+                                    209 => 2,
 
                                     208 => 1,
                                 }
@@ -3678,8 +3678,6 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 255) => 0,
-
                     255 => {
                         let b = (lookahead.read_byte())?;
                         match b {
@@ -3750,6 +3748,8 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             254 => 1,
                         }
                     }
+
+                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -3761,23 +3761,23 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    213 => 6,
-
-                                    211 => 4,
-
-                                    208 => 1,
-
                                     215 => 8,
 
-                                    212 => 5,
-
-                                    210 => 3,
+                                    213 => 6,
 
                                     214 => 7,
 
-                                    0 => 0,
+                                    208 => 1,
+
+                                    210 => 3,
 
                                     209 => 2,
+
+                                    0 => 0,
+
+                                    212 => 5,
+
+                                    211 => 4,
                                 }
                             }
 
@@ -4963,9 +4963,9 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -5034,9 +5034,9 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
             let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
-                73 => 0,
-
                 77 => 1,
+
+                73 => 0,
             }
         };
         match tree_index {
@@ -5057,7 +5057,7 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                         return None;
                     }
                 };
-                (Type48::le((field0, field1)))
+                (Type48::le(field0, field1))
             }
 
             1 => {
@@ -5077,7 +5077,7 @@ fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                         return None;
                     }
                 };
-                (Type48::be((field0, field1)))
+                (Type48::be(field0, field1))
             }
         }
     };
@@ -6340,9 +6340,9 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -6492,9 +6492,9 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 33 => {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        1 => 1,
-
                         249 => 0,
+
+                        1 => 1,
                     }
                 }
 
@@ -6594,9 +6594,9 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -6644,9 +6644,9 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    tmp if (tmp != 0) => 0,
-
                     0 => 1,
+
+                    tmp if (tmp != 0) => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -6740,9 +6740,9 @@ fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            33 => 1,
-
             44 => 0,
+
+            33 => 1,
         }
     };
     (Some(match tree_index {
@@ -6827,9 +6827,9 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                 let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,61 +1,15 @@
 use doodle::prelude::*;
 
+enum Type12 {
+    table_based_image(Type10),
+    plain_text_extension(Type11),
+}
+
 struct Type31 {
     length_extra_bits: u8,
     length: u16,
     distance_code: u8,
     distance_record: Type24,
-}
-
-enum Type44 {
-    other(Vec<u8>),
-    jfif(Type43),
-}
-
-struct Type109 {
-    contents: Vec<Type108>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-struct Type34 {
-    codes: Vec<Type33>,
-    codes_values: Vec<Type29>,
-}
-
-enum Type74 {
-    mcu(u8),
-    rst0(Type42),
-    rst1(Type42),
-    rst2(Type42),
-    rst3(Type42),
-    rst4(Type42),
-    rst5(Type42),
-    rst6(Type42),
-    rst7(Type42),
-}
-
-enum Type87 {
-    color_type_3(Type84),
-    color_type_6(Type85),
-    color_type_2(Type85),
-    color_type_4(Type86),
-    color_type_0(Type86),
-}
-
-struct Type64 {
-    marker: Type42,
-    length: u16,
-    data: Type63,
-}
-
-struct Type20 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
 }
 
 struct Type50 {
@@ -65,167 +19,10 @@ struct Type50 {
     next_ifd: Vec<u8>,
 }
 
-struct Type52 {
-    padding: u8,
-    exif: Type51,
-}
-
-enum Type70 {
-    sof0(Type69),
-    sof1(Type69),
-    sof2(Type69),
-    sof3(Type69),
-    sof5(Type69),
-    sof6(Type69),
-    sof7(Type69),
-    sof9(Type69),
-    sof10(Type69),
-    sof11(Type69),
-    sof13(Type69),
-    sof14(Type69),
-    sof15(Type69),
-}
-
-enum Type79 {
-    some(Type78),
-    none,
-}
-
-struct Type93 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type92,
-    crc: u32,
-}
-
-struct Type101 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type100,
-}
-
-struct Type62 {
-    marker: Type42,
-    length: u16,
-    data: Type61,
-}
-
-struct Type8 {
-    len_bytes: u8,
-    data: Vec<u8>,
-}
-
 struct Type9 {
     lzw_min_code_size: u8,
     image_data: Vec<Type8>,
     terminator: u8,
-}
-
-enum Type12 {
-    table_based_image(Type10),
-    plain_text_extension(Type11),
-}
-
-struct Type77 {
-    num_lines: u16,
-}
-
-struct Type88 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type87,
-    crc: u32,
-}
-
-struct Type59 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-struct Type65 {
-    marker: Type42,
-    length: u16,
-    data: Vec<u8>,
-}
-
-struct Type82 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-struct Type102 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type101>,
-}
-
-enum Type32 {
-    none,
-    some(Type31),
-}
-
-struct Type60 {
-    marker: Type42,
-    length: u16,
-    data: Type59,
-}
-
-struct Type33 {
-    code: u16,
-    extra: Type32,
-}
-
-struct Type10 {
-    descriptor: Type7,
-    local_color_table: Type3,
-    data: Type9,
-}
-
-struct Type13 {
-    graphic_control_extension: Type6,
-    graphic_rendering_block: Type12,
-}
-
-enum Type26 {
-    none,
-    some(Type25),
-}
-
-struct Type81 {
-    soi: Type42,
-    frame: Type80,
-    eoi: Type42,
-}
-
-struct Type76 {
-    segments: Vec<Type66>,
-    sos: Type73,
-    data: Type75,
-}
-
-struct Type112 {
-    data: Type111,
-    end: (),
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type18 {
-    separator: u8,
-}
-
-struct Type57 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
 }
 
 enum Type66 {
@@ -252,168 +49,27 @@ enum Type66 {
     com(Type65),
 }
 
-struct Type43 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
-enum Type3 {
-    no,
-    yes(Vec<Type2>),
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
-}
-
-enum Type17 {
-    graphic_block(Type13),
-    special_purpose_block(Type16),
-}
-
-struct Type86 {
-    greyscale: u16,
-}
-
-enum Type111 {
-    gif(Type19),
-    gzip(Vec<Type41>),
-    jpeg(Type81),
-    png(Type99),
-    riff(Type103),
-    tar(Type109),
-    text(Type110),
-}
-
-struct Type108 {
-    header: Type107,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type67 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-struct Type72 {
-    num_image_components: u8,
-    image_components: Vec<Type71>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type41 {
-    header: Type20,
-    fname: Type22,
-    data: Type39,
-    footer: Type40,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type105 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-struct Type73 {
+struct Type46 {
     marker: Type42,
     length: u16,
-    data: Type72,
+    data: Type45,
 }
 
-struct Type97 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
-    crc: u32,
+struct Type71 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
-struct Type84 {
-    palette_index: u8,
-}
-
-struct Type38 {
-    r#final: u8,
-    r#type: u8,
-    data: Type37,
-}
-
-struct Type68 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type67>,
-}
-
-struct Type11 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type5 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type63 {
-    restart_interval: u16,
-}
-
-struct Type98 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: (),
-    crc: u32,
-}
-
-struct Type15 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type95 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type94,
-    crc: u32,
+enum Type74 {
+    mcu(u8),
+    rst0(Type42),
+    rst1(Type42),
+    rst2(Type42),
+    rst3(Type42),
+    rst4(Type42),
+    rst5(Type42),
+    rst6(Type42),
+    rst7(Type42),
 }
 
 enum Type37 {
@@ -422,302 +78,14 @@ enum Type37 {
     uncompressed(Type36),
 }
 
-struct Type104 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-struct Type49 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type24 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-struct Type21 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-struct Type103 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type102,
-    pad: Type100,
-}
-
-struct Type30 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type27>,
-    codes_values: Vec<Type29>,
-}
-
-struct Type27 {
+struct Type33 {
     code: u16,
-    extra: Type26,
+    extra: Type32,
 }
 
-struct Type99 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type83,
-    chunks: Vec<Type96>,
-    idat: Vec<Type97>,
-    more_chunks: Vec<Type96>,
-    iend: Type98,
-}
-
-enum Type96 {
-    bKGD(Type88),
-    pHYs(Type90),
-    PLTE(Type91),
-    tIME(Type93),
-    tRNS(Type95),
-}
-
-struct Type45 {
-    identifier: Type21,
-    data: Type44,
-}
-
-struct Type106 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-struct Type78 {
-    marker: Type42,
-    length: u16,
-    data: Type77,
-}
-
-struct Type89 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-enum Type53 {
-    other(Vec<u8>),
-    xmp(Type47),
-    exif(Type52),
-}
-
-enum Type29 {
-    literal(u8),
-    reference(Type28),
-}
-
-struct Type36 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type35>,
-}
-
-struct Type51 {
-    byte_order: Type48,
-    magic: u16,
-    offset: u32,
-    ifd: Type50,
-}
-
-enum Type94 {
-    color_type_3(Vec<Type84>),
-    color_type_2(Type85),
-    color_type_0(Type86),
-}
-
-enum Type100 {
-    no(u8),
-    yes,
-}
-
-struct Type90 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type89,
-    crc: u32,
-}
-
-enum Type16 {
-    application_extension(Type14),
-    comment_extension(Type15),
-}
-
-enum Type56 {
-    app0(Type46),
-    app1(Type55),
-}
-
-struct Type46 {
-    marker: Type42,
-    length: u16,
-    data: Type45,
-}
-
-struct Type80 {
-    initial_segment: Type56,
-    segments: Vec<Type66>,
-    header: Type70,
-    scan: Type76,
-    dnl: Type79,
-    scans: Vec<Type76>,
-}
-
-struct Type7 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type25 {
-    length_extra_bits: u8,
-    length: u16,
-    distance_code: u16,
-    distance_record: Type24,
-}
-
-struct Type91 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type58 {
-    marker: Type42,
-    length: u16,
-    data: Type57,
-}
-
-struct Type47 {
-    xmp: Vec<u8>,
-}
-
-enum Type110 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-enum Type48 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-enum Type6 {
-    some(Type5),
-    none,
-}
-
-struct Type23 {
-    code: u16,
-    extra: u8,
-}
-
-struct Type54 {
-    identifier: Type21,
-    data: Type53,
-}
-
-enum Type35 {
-    literal(u8),
-}
-
-struct Type40 {
-    crc: u32,
-    length: u32,
-}
-
-struct Type61 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type14 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type8>,
-    terminator: u8,
-}
-
-struct Type19 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type17>,
-    trailer: Type18,
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type82,
-    crc: u32,
-}
-
-struct Type28 {
-    length: u16,
-    distance: u16,
-}
-
-struct Type69 {
-    marker: Type42,
-    length: u16,
-    data: Type68,
-}
-
-struct Type42 {
-    ff: u8,
-    marker: u8,
-}
-
-struct Type75 {
-    scan_data: Vec<Type74>,
-    scan_data_stream: Vec<u8>,
-}
-
-struct Type92 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type39 {
-    blocks: Vec<Type38>,
-    codes: Vec<Type29>,
-    inflate: Vec<u8>,
-}
-
-struct Type55 {
-    marker: Type42,
-    length: u16,
-    data: Type54,
+struct Type8 {
+    len_bytes: u8,
+    data: Vec<u8>,
 }
 
 struct Type107 {
@@ -740,9 +108,331 @@ struct Type107 {
     pad: Vec<u8>,
 }
 
-struct Type71 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
+struct Type20 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type104 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+enum Type6 {
+    some(Type5),
+    none,
+}
+
+struct Type36 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type35>,
+}
+
+struct Type72 {
+    num_image_components: u8,
+    image_components: Vec<Type71>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type14 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type59 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+struct Type23 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type105 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
+}
+
+struct Type63 {
+    restart_interval: u16,
+}
+
+struct Type27 {
+    code: u16,
+    extra: Type26,
+}
+
+struct Type77 {
+    num_lines: u16,
+}
+
+struct Type88 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type87,
+    crc: u32,
+}
+
+struct Type18 {
+    separator: u8,
+}
+
+struct Type19 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type17>,
+    trailer: Type18,
+}
+
+struct Type86 {
+    greyscale: u16,
+}
+
+struct Type91 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
+}
+
+struct Type92 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type21 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+struct Type76 {
+    segments: Vec<Type66>,
+    sos: Type73,
+    data: Type75,
+}
+
+struct Type49 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
+enum Type3 {
+    no,
+    yes(Vec<Type2>),
+}
+
+enum Type87 {
+    color_type_3(Type84),
+    color_type_6(Type85),
+    color_type_2(Type85),
+    color_type_4(Type86),
+    color_type_0(Type86),
+}
+
+struct Type43 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+struct Type64 {
+    marker: Type42,
+    length: u16,
+    data: Type63,
+}
+
+enum Type16 {
+    application_extension(Type14),
+    comment_extension(Type15),
+}
+
+struct Type78 {
+    marker: Type42,
+    length: u16,
+    data: Type77,
+}
+
+struct Type41 {
+    header: Type20,
+    fname: Type22,
+    data: Type39,
+    footer: Type40,
+}
+
+struct Type109 {
+    contents: Vec<Type108>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
+}
+
+struct Type80 {
+    initial_segment: Type56,
+    segments: Vec<Type66>,
+    header: Type70,
+    scan: Type76,
+    dnl: Type79,
+    scans: Vec<Type76>,
+}
+
+struct Type54 {
+    identifier: Type21,
+    data: Type53,
+}
+
+enum Type29 {
+    literal(u8),
+    reference(Type28),
+}
+
+struct Type52 {
+    padding: u8,
+    exif: Type51,
+}
+
+struct Type57 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+enum Type70 {
+    sof0(Type69),
+    sof1(Type69),
+    sof2(Type69),
+    sof3(Type69),
+    sof5(Type69),
+    sof6(Type69),
+    sof7(Type69),
+    sof9(Type69),
+    sof10(Type69),
+    sof11(Type69),
+    sof13(Type69),
+    sof14(Type69),
+    sof15(Type69),
+}
+
+struct Type58 {
+    marker: Type42,
+    length: u16,
+    data: Type57,
+}
+
+struct Type108 {
+    header: Type107,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type99 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type83,
+    chunks: Vec<Type96>,
+    idat: Vec<Type97>,
+    more_chunks: Vec<Type96>,
+    iend: Type98,
+}
+
+struct Type65 {
+    marker: Type42,
+    length: u16,
+    data: Vec<u8>,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type90 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type89,
+    crc: u32,
+}
+
+enum Type44 {
+    other(Vec<u8>),
+    jfif(Type43),
+}
+
+struct Type93 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type92,
+    crc: u32,
+}
+
+struct Type28 {
+    length: u16,
+    distance: u16,
+}
+
+struct Type67 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+struct Type34 {
+    codes: Vec<Type33>,
+    codes_values: Vec<Type29>,
+}
+
+struct Type13 {
+    graphic_control_extension: Type6,
+    graphic_rendering_block: Type12,
+}
+
+struct Type82 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type82,
+    crc: u32,
 }
 
 struct Type85 {
@@ -751,9 +441,319 @@ struct Type85 {
     blue: u16,
 }
 
+struct Type7 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type55 {
+    marker: Type42,
+    length: u16,
+    data: Type54,
+}
+
+struct Type39 {
+    blocks: Vec<Type38>,
+    codes: Vec<Type29>,
+    inflate: Vec<u8>,
+}
+
+enum Type17 {
+    graphic_block(Type13),
+    special_purpose_block(Type16),
+}
+
+struct Type45 {
+    identifier: Type21,
+    data: Type44,
+}
+
+struct Type30 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type27>,
+    codes_values: Vec<Type29>,
+}
+
+struct Type38 {
+    r#final: u8,
+    r#type: u8,
+    data: Type37,
+}
+
+enum Type26 {
+    none,
+    some(Type25),
+}
+
+struct Type89 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+struct Type95 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type94,
+    crc: u32,
+}
+
+struct Type101 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type100,
+}
+
+struct Type47 {
+    xmp: Vec<u8>,
+}
+
+struct Type61 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type81 {
+    soi: Type42,
+    frame: Type80,
+    eoi: Type42,
+}
+
+struct Type15 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type8>,
+    terminator: u8,
+}
+
+enum Type48 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+struct Type69 {
+    marker: Type42,
+    length: u16,
+    data: Type68,
+}
+
 enum Type22 {
     no,
     yes(Type21),
+}
+
+struct Type84 {
+    palette_index: u8,
+}
+
+enum Type96 {
+    bKGD(Type88),
+    pHYs(Type90),
+    PLTE(Type91),
+    tIME(Type93),
+    tRNS(Type95),
+}
+
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+struct Type10 {
+    descriptor: Type7,
+    local_color_table: Type3,
+    data: Type9,
+}
+
+struct Type5 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+enum Type35 {
+    literal(u8),
+}
+
+struct Type75 {
+    scan_data: Vec<Type74>,
+    scan_data_stream: Vec<u8>,
+}
+
+struct Type42 {
+    ff: u8,
+    marker: u8,
+}
+
+enum Type53 {
+    other(Vec<u8>),
+    xmp(Type47),
+    exif(Type52),
+}
+
+enum Type56 {
+    app0(Type46),
+    app1(Type55),
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+struct Type73 {
+    marker: Type42,
+    length: u16,
+    data: Type72,
+}
+
+struct Type60 {
+    marker: Type42,
+    length: u16,
+    data: Type59,
+}
+
+struct Type97 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<u8>,
+    crc: u32,
+}
+
+enum Type110 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+struct Type98 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
+}
+
+struct Type68 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type67>,
+}
+
+struct Type112 {
+    data: Type111,
+    end: (),
+}
+
+struct Type106 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+enum Type100 {
+    no(u8),
+    yes,
+}
+
+struct Type102 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type101>,
+}
+
+enum Type111 {
+    gif(Type19),
+    gzip(Vec<Type41>),
+    jpeg(Type81),
+    png(Type99),
+    riff(Type103),
+    tar(Type109),
+    text(Type110),
+}
+
+struct Type11 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type24 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type40 {
+    crc: u32,
+    length: u32,
+}
+
+enum Type79 {
+    some(Type78),
+    none,
+}
+
+enum Type94 {
+    color_type_3(Vec<Type84>),
+    color_type_2(Type85),
+    color_type_0(Type86),
+}
+
+struct Type62 {
+    marker: Type42,
+    length: u16,
+    data: Type61,
+}
+
+enum Type32 {
+    none,
+    some(Type31),
+}
+
+struct Type25 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u16,
+    distance_record: Type24,
+}
+
+struct Type51 {
+    byte_order: Type48,
+    magic: u16,
+    offset: u32,
+    ifd: Type50,
+}
+
+struct Type103 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type102,
+    pad: Type100,
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
@@ -779,14 +779,14 @@ fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
+                    59 => 1,
+
                     33 => 0,
 
                     44 => 0,
-
-                    59 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -811,7 +811,7 @@ fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     let mut accum = (Vec::new());
     while true {
         let matching_ix = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             if (b == 31) {
                 1
@@ -866,11 +866,9 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    73 => 1,
-
                     98 => 0,
 
                     112 => 0,
@@ -878,6 +876,8 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     80 => 0,
 
                     116 => 0,
+
+                    73 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -893,7 +893,7 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     73 => {
@@ -927,11 +927,9 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    73 => 1,
-
                     98 => 0,
 
                     112 => 0,
@@ -939,6 +937,8 @@ fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
                     80 => 0,
 
                     116 => 0,
+
+                    73 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1032,12 +1032,12 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 0,
-
                     tmp if (tmp != 0) => 1,
+
+                    0 => 0,
                 }
             };
             if (matching_ix == 0) {
@@ -1067,7 +1067,7 @@ fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
@@ -1106,7 +1106,7 @@ fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<
     let mut accum = (Vec::new());
     while true {
         let matching_ix = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             if ((ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]))
                 .contains(b))
@@ -1130,7 +1130,7 @@ fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let mut accum = (Vec::new());
     while true {
         let matching_ix = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
                 tmp if ((ByteSet::from_bits([
@@ -1174,7 +1174,7 @@ fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
     let inner = {
         let tree_index = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
                 tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
@@ -1246,21 +1246,21 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             2 => {
                 let inner = {
                     let tree_index = {
-                        let lookahead = (input.clone());
+                        let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
+                                .contains(tmp)) =>
+                            {
+                                3
+                            }
+
                             224 => 0,
 
                             tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
                                 .contains(tmp)) =>
                             {
                                 1
-                            }
-
-                            tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
-                                .contains(tmp)) =>
-                            {
-                                3
                             }
 
                             237 => 2,
@@ -1371,11 +1371,9 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             3 => {
                 let inner = {
                     let tree_index = {
-                        let lookahead = (input.clone());
+                        let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
-                            240 => 0,
-
                             tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
                                 .contains(tmp)) =>
                             {
@@ -1383,6 +1381,8 @@ fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             }
 
                             244 => 2,
+
+                            240 => 0,
                         }
                     };
                     match tree_index {
@@ -1535,7 +1535,7 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 1,
@@ -1563,7 +1563,7 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
@@ -1622,7 +1622,7 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
@@ -1650,7 +1650,7 @@ fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     0
@@ -1682,12 +1682,12 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
-                    0 => 1,
-
                     tmp if (tmp != 0) => 0,
+
+                    0 => 1,
                 }
             };
             if (matching_ix == 0) {
@@ -1710,7 +1710,7 @@ fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 0) {
                     1
@@ -1754,7 +1754,7 @@ fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 0
             };
             if (matching_ix == 0) {
@@ -1897,23 +1897,23 @@ fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            112 => 1,
-
-            80 => 2,
-
-            98 => 0,
-
             116 => {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    73 => 3,
-
                     82 => 4,
+
+                    73 => 3,
                 }
             }
+
+            80 => 2,
+
+            112 => 1,
+
+            98 => 0,
         }
     };
     (Some(match tree_index {
@@ -2061,7 +2061,7 @@ fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let mut accum = (Vec::new());
     while true {
         let matching_ix = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             0
         };
         if (matching_ix == 0) {
@@ -2396,7 +2396,7 @@ fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
     let initial_segment = {
         let tree_index = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             if (b == 255) {
                 let b = (lookahead.read_byte())?;
@@ -2425,37 +2425,11 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        192 => 1,
-
-                        193 => 1,
-
-                        194 => 1,
-
-                        195 => 1,
-
-                        197 => 1,
-
-                        198 => 1,
-
-                        199 => 1,
-
-                        201 => 1,
-
-                        202 => 1,
-
-                        203 => 1,
-
-                        205 => 1,
-
-                        206 => 1,
-
-                        207 => 1,
-
                         219 => 0,
 
                         196 => 0,
@@ -2497,6 +2471,32 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
+
+                        192 => 1,
+
+                        193 => 1,
+
+                        194 => 1,
+
+                        195 => 1,
+
+                        197 => 1,
+
+                        198 => 1,
+
+                        199 => 1,
+
+                        201 => 1,
+
+                        202 => 1,
+
+                        203 => 1,
+
+                        205 => 1,
+
+                        206 => 1,
+
+                        207 => 1,
                     }
                 } else {
                     return None;
@@ -2515,13 +2515,11 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
     let scan = { (Decoder52(scope, input))? };
     let dnl = {
         let tree_index = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             if (b == 255) {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    220 => 0,
-
                     217 => 1,
 
                     218 => 1,
@@ -2567,6 +2565,8 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                     239 => 1,
 
                     254 => 1,
+
+                    220 => 0,
                 }
             } else {
                 return None;
@@ -2588,11 +2588,13 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
+                        217 => 1,
+
                         218 => 0,
 
                         219 => 0,
@@ -2636,8 +2638,6 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
-
-                        217 => 1,
                     }
                 } else {
                     return None;
@@ -2742,52 +2742,52 @@ fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type66> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                232 => 12,
-
-                233 => 13,
-
-                204 => 2,
-
                 226 => 6,
-
-                254 => 20,
-
-                237 => 17,
-
-                239 => 19,
-
-                196 => 1,
-
-                229 => 9,
-
-                231 => 11,
-
-                230 => 10,
-
-                238 => 18,
-
-                221 => 3,
-
-                219 => 0,
-
-                227 => 7,
-
-                228 => 8,
 
                 224 => 4,
 
+                231 => 11,
+
+                204 => 2,
+
+                237 => 17,
+
+                233 => 13,
+
+                196 => 1,
+
                 225 => 5,
 
-                234 => 14,
+                230 => 10,
+
+                219 => 0,
+
+                238 => 18,
+
+                236 => 16,
+
+                221 => 3,
+
+                232 => 12,
 
                 235 => 15,
 
-                236 => 16,
+                234 => 14,
+
+                227 => 7,
+
+                229 => 9,
+
+                239 => 19,
+
+                228 => 8,
+
+                254 => 20,
             }
         } else {
             return None;
@@ -2903,36 +2903,36 @@ fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type70> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         if (b == 255) {
             let b = (lookahead.read_byte())?;
             match b {
-                205 => 10,
+                202 => 8,
 
                 198 => 5,
 
-                201 => 7,
-
-                207 => 12,
-
                 193 => 1,
-
-                195 => 3,
-
-                194 => 2,
-
-                197 => 4,
-
-                206 => 11,
-
-                202 => 8,
 
                 203 => 9,
 
+                192 => 0,
+
                 199 => 6,
 
-                192 => 0,
+                197 => 4,
+
+                205 => 10,
+
+                194 => 2,
+
+                206 => 11,
+
+                207 => 12,
+
+                201 => 7,
+
+                195 => 3,
             }
         } else {
             return None;
@@ -3011,11 +3011,13 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
                     match b {
+                        218 => 1,
+
                         219 => 0,
 
                         196 => 0,
@@ -3057,8 +3059,6 @@ fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                         239 => 0,
 
                         254 => 0,
-
-                        218 => 1,
                     }
                 } else {
                     return None;
@@ -3116,7 +3116,7 @@ fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 if (b == 255) {
                     let b = (lookahead.read_byte())?;
@@ -3221,9 +3221,11 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
+                    tmp if (tmp != 255) => 0,
+
                     255 => {
                         let b = (lookahead.read_byte())?;
                         match b {
@@ -3292,36 +3294,34 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
                             254 => 1,
                         }
                     }
-
-                    tmp if (tmp != 255) => 0,
                 }
             };
             if (matching_ix == 0) {
                 let next_elem = {
                     let tree_index = {
-                        let lookahead = (input.clone());
+                        let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    211 => 4,
-
-                                    208 => 1,
-
-                                    213 => 6,
+                                    212 => 5,
 
                                     209 => 2,
 
-                                    214 => 7,
+                                    210 => 3,
 
-                                    215 => 8,
+                                    213 => 6,
 
                                     0 => 0,
 
-                                    210 => 3,
+                                    215 => 8,
 
-                                    212 => 5,
+                                    214 => 7,
+
+                                    211 => 4,
+
+                                    208 => 1,
                                 }
                             }
 
@@ -3432,7 +3432,7 @@ fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
             255 => 1,
@@ -3675,7 +3675,7 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 255) => 0,
@@ -3755,29 +3755,29 @@ fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
             if (matching_ix == 0) {
                 let next_elem = {
                     let tree_index = {
-                        let lookahead = (input.clone());
+                        let lookahead = &mut (input.clone());
                         let b = (lookahead.read_byte())?;
                         match b {
                             255 => {
                                 let b = (lookahead.read_byte())?;
                                 match b {
-                                    211 => 4,
-
-                                    214 => 7,
-
-                                    209 => 2,
-
-                                    0 => 0,
-
                                     213 => 6,
 
-                                    210 => 3,
-
-                                    215 => 8,
+                                    211 => 4,
 
                                     208 => 1,
 
+                                    215 => 8,
+
                                     212 => 5,
+
+                                    210 => 3,
+
+                                    214 => 7,
+
+                                    0 => 0,
+
+                                    209 => 2,
                                 }
                             }
 
@@ -4873,7 +4873,7 @@ fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 0
             };
             if (matching_ix == 0) {
@@ -4898,7 +4898,7 @@ fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 0
             };
             if (matching_ix == 0) {
@@ -4936,7 +4936,7 @@ fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                     let mut accum = (Vec::new());
                     while true {
                         let matching_ix = {
-                            let lookahead = (input.clone());
+                            let lookahead = &mut (input.clone());
                             0
                         };
                         if (matching_ix == 0) {
@@ -4960,7 +4960,7 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
@@ -5013,7 +5013,7 @@ fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 0
             };
             if (matching_ix == 0) {
@@ -5031,12 +5031,12 @@ fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
     let byte_order = {
         let tree_index = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
-                77 => 1,
-
                 73 => 0,
+
+                77 => 1,
             }
         };
         match tree_index {
@@ -5127,7 +5127,7 @@ fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
                     let mut accum = (Vec::new());
                     while true {
                         let matching_ix = {
-                            let lookahead = (input.clone());
+                            let lookahead = &mut (input.clone());
                             0
                         };
                         if (matching_ix == 0) {
@@ -5151,7 +5151,7 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
@@ -6337,7 +6337,7 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
@@ -6439,19 +6439,19 @@ fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type17> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
             33 => {
                 let b = (lookahead.read_byte())?;
                 match b {
-                    249 => 0,
-
-                    1 => 0,
-
                     255 => 1,
 
                     254 => 1,
+
+                    249 => 0,
+
+                    1 => 0,
                 }
             }
 
@@ -6486,19 +6486,19 @@ fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
     let graphic_control_extension = {
         let tree_index = {
-            let lookahead = (input.clone());
+            let lookahead = &mut (input.clone());
             let b = (lookahead.read_byte())?;
             match b {
-                44 => 1,
-
                 33 => {
                     let b = (lookahead.read_byte())?;
                     match b {
-                        249 => 0,
-
                         1 => 1,
+
+                        249 => 0,
                     }
                 }
+
+                44 => 1,
             }
         };
         match tree_index {
@@ -6522,14 +6522,14 @@ fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type16> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         if (b == 33) {
             let b = (lookahead.read_byte())?;
             match b {
-                255 => 0,
-
                 254 => 1,
+
+                255 => 0,
             }
         } else {
             return None;
@@ -6591,7 +6591,7 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
@@ -6641,7 +6641,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,
@@ -6737,12 +6737,12 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
     let tree_index = {
-        let lookahead = (input.clone());
+        let lookahead = &mut (input.clone());
         let b = (lookahead.read_byte())?;
         match b {
-            44 => 0,
-
             33 => 1,
+
+            44 => 0,
         }
     };
     (Some(match tree_index {
@@ -6824,7 +6824,7 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     0 => 1,
@@ -6896,7 +6896,7 @@ fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         let mut accum = (Vec::new());
         while true {
             let matching_ix = {
-                let lookahead = (input.clone());
+                let lookahead = &mut (input.clone());
                 let b = (lookahead.read_byte())?;
                 match b {
                     tmp if (tmp != 0) => 0,

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,8 +1,179 @@
 use doodle::prelude::*;
 
-struct Type7 {
-    len_bytes: u8,
-    data: Vec<u8>,
+struct Type28 {
+    ff: u8,
+    marker: u8,
+}
+
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+enum Type9 {
+    table_based_image {
+        descriptor: Type6,
+        local_color_table: Type3,
+        data: Type8,
+    },
+    plain_text_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        text_grid_left_position: u16,
+        text_grid_top_position: u16,
+        text_grid_width: u16,
+        text_grid_height: u16,
+        character_cell_width: u8,
+        character_cell_height: u8,
+        text_foreground_color_index: u8,
+        text_background_color_index: u8,
+        plain_text_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+struct Type89 {
+    marker: Type28,
+    length: u16,
+    data: Type53,
+}
+
+struct Type42 {
+    restart_interval: u16,
+}
+
+struct Type91 {
+    marker: Type28,
+    length: u16,
+    data: Type39,
+}
+
+struct Type77 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type11>,
+    trailer: Type12,
+}
+
+enum Type54 {
+    some {
+        marker: Type28,
+        length: u16,
+        data: Type53,
+    },
+    none(),
+}
+
+struct Type98 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+struct Type49 {
+    marker: Type28,
+    length: u16,
+    data: Type48,
+}
+
+struct Type82 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type58,
+    crc: u32,
+}
+
+enum Type5 {
+    some {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        flags: u8,
+        delay_time: u16,
+        transparent_color_index: u8,
+        terminator: u8,
+    },
+    none(),
+}
+
+enum Type3 {
+    no(),
+    yes(Vec<Type2>),
+}
+
+struct Type90 {
+    marker: Type28,
+    length: u16,
+    data: Type45,
+}
+
+struct Type48 {
+    num_image_components: u8,
+    image_components: Vec<Type47>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type69 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+enum Type38 {
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
+}
+
+struct Type6 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type41 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type44 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
+}
+
+enum Type58 {
+    color_type_3 { palette_index: u8 },
+    color_type_6 { red: u16, green: u16, blue: u16 },
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_4 { greyscale: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type81 {
+    contents: Vec<Type73>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
 }
 
 enum Type23 {
@@ -31,51 +202,51 @@ enum Type23 {
     },
 }
 
-struct Type29 {
+struct Type40 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+struct Type55 {
+    initial_segment: Type38,
+    segments: Vec<Type43>,
+    header: Type46,
+    scan: Type52,
+    dnl: Type54,
+    scans: Vec<Type52>,
+}
+
+struct Type56 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
+struct Type71 {
     string: Vec<u8>,
-    null: u8,
+    padding: Vec<u8>,
 }
 
-struct Type45 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type44>,
+struct Type76 {
+    data: Type75,
+    end: (),
 }
 
-enum Type58 {
-    color_type_3 { palette_index: u8 },
-    color_type_6 { red: u16, green: u16, blue: u16 },
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_4 { greyscale: u16 },
-    color_type_0 { greyscale: u16 },
+enum Type36 {
+    other(Vec<u8>),
+    xmp { xmp: Vec<u8> },
+    exif { padding: u8, exif: Type35 },
 }
 
-struct Type86 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type62,
-    crc: u32,
-}
-
-struct Type88 {
-    marker: Type28,
-    length: u16,
-    data: Type37,
-}
-
-struct Type101 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type18>,
-    codes_values: Vec<Type19>,
+struct Type25 {
+    blocks: Vec<Type24>,
+    codes: Vec<Type19>,
+    inflate: Vec<u8>,
 }
 
 enum Type50 {
@@ -88,6 +259,50 @@ enum Type50 {
     rst5 { ff: u8, marker: u8 },
     rst6 { ff: u8, marker: u8 },
     rst7 { ff: u8, marker: u8 },
+}
+
+struct Type45 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type44>,
+}
+
+struct Type73 {
+    header: Type72,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type80 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type68,
+    pad: Type66,
+}
+
+struct Type99 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type22>,
+}
+
+struct Type7 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+enum Type19 {
+    literal(u8),
+    reference { length: u16, distance: u16 },
+}
+
+struct Type21 {
+    code: u16,
+    extra: Type20,
 }
 
 struct Type107 {
@@ -106,327 +321,11 @@ struct Type107 {
     terminator: u8,
 }
 
-struct Type48 {
-    num_image_components: u8,
-    image_components: Vec<Type47>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type80 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type68,
-    pad: Type66,
-}
-
-struct Type39 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
-}
-
-struct Type105 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type103 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type59 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-enum Type30 {
-    other(Vec<u8>),
-    jfif {
-        version_major: u8,
-        version_minor: u8,
-        density_units: u8,
-        density_x: u16,
-        density_y: u16,
-        thumbnail_width: u8,
-        thumbnail_height: u8,
-        thumbnail_pixels: Vec<Vec<Type2>>,
-    },
-}
-
-struct Type65 {
+struct Type57 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: (),
+    data: Type56,
     crc: u32,
-}
-
-struct Type93 {
-    marker: Type28,
-    length: u16,
-    data: Type41,
-}
-
-struct Type90 {
-    marker: Type28,
-    length: u16,
-    data: Type45,
-}
-
-struct Type71 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-struct Type67 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type66,
-}
-
-struct Type41 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type82 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type58,
-    crc: u32,
-}
-
-struct Type95 {
-    marker: Type28,
-    length: u16,
-    data: Vec<u8>,
-}
-
-enum Type3 {
-    no(),
-    yes(Vec<Type2>),
-}
-
-struct Type61 {
-    palette_index: u8,
-}
-
-enum Type9 {
-    table_based_image {
-        descriptor: Type6,
-        local_color_table: Type3,
-        data: Type8,
-    },
-    plain_text_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        text_grid_left_position: u16,
-        text_grid_top_position: u16,
-        text_grid_width: u16,
-        text_grid_height: u16,
-        character_cell_width: u8,
-        character_cell_height: u8,
-        text_foreground_color_index: u8,
-        text_background_color_index: u8,
-        plain_text_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type15 {
-    code: u16,
-    extra: u8,
-}
-
-struct Type44 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-enum Type54 {
-    some {
-        marker: Type28,
-        length: u16,
-        data: Type53,
-    },
-    none(),
-}
-
-struct Type64 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
-    crc: u32,
-}
-
-struct Type78 {
-    soi: Type28,
-    frame: Type55,
-    eoi: Type28,
-}
-
-struct Type100 {
-    codes: Vec<Type21>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type12 {
-    separator: u8,
-}
-
-struct Type89 {
-    marker: Type28,
-    length: u16,
-    data: Type53,
-}
-
-struct Type34 {
-    num_fields: u16,
-    fields: Vec<Type33>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type69 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-struct Type91 {
-    marker: Type28,
-    length: u16,
-    data: Type39,
-}
-
-struct Type94 {
-    marker: Type28,
-    length: u16,
-    data: Type42,
-}
-
-struct Type81 {
-    contents: Vec<Type73>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-enum Type38 {
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-}
-
-struct Type72 {
-    name: Type69,
-    mode: Type70,
-    uid: Type70,
-    gid: Type70,
-    size: u32,
-    mtime: Type70,
-    chksum: Type70,
-    typeflag: u8,
-    linkname: Type69,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type71,
-    gname: Type71,
-    devmajor: Type70,
-    devminor: Type70,
-    prefix: Type69,
-    pad: Vec<u8>,
-}
-
-struct Type87 {
-    marker: Type28,
-    length: u16,
-    data: Type31,
-}
-
-struct Type31 {
-    identifier: Type29,
-    data: Type30,
-}
-
-struct Type60 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type97 {
-    xmp: Vec<u8>,
-}
-
-struct Type85 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type60,
-    crc: u32,
-}
-
-struct Type49 {
-    marker: Type28,
-    length: u16,
-    data: Type48,
-}
-
-struct Type76 {
-    data: Type75,
-    end: (),
-}
-
-struct Type104 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type68 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type67>,
-}
-
-struct Type53 {
-    num_lines: u16,
 }
 
 struct Type27 {
@@ -436,107 +335,54 @@ struct Type27 {
     footer: Type26,
 }
 
-struct Type57 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type56,
-    crc: u32,
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
 }
 
-enum Type17 {
+struct Type53 {
+    num_lines: u16,
+}
+
+struct Type8 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type7>,
+    terminator: u8,
+}
+
+enum Type20 {
     none(),
     some {
         length_extra_bits: u8,
         length: u16,
-        distance_code: u16,
+        distance_code: u8,
         distance_record: Type16,
     },
 }
 
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
+struct Type47 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
-enum Type36 {
-    other(Vec<u8>),
-    xmp { xmp: Vec<u8> },
-    exif { padding: u8, exif: Type35 },
-}
-
-struct Type18 {
-    code: u16,
-    extra: Type17,
-}
-
-struct Type56 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
-}
-
-struct Type70 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-struct Type106 {
-    descriptor: Type6,
-    local_color_table: Type3,
-    data: Type8,
-}
-
-struct Type52 {
-    segments: Vec<Type43>,
-    sos: Type49,
-    data: Type51,
-}
-
-struct Type73 {
-    header: Type72,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type13 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type16 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-struct Type84 {
+struct Type33 {
+    tag: u16,
+    r#type: u16,
     length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
+    offset_or_data: u32,
 }
 
-struct Type96 {
-    padding: u8,
-    exif: Type35,
+enum Type22 {
+    literal(u8),
 }
 
-struct Type102 {
-    graphic_control_extension: Type5,
-    graphic_rendering_block: Type9,
-}
-
-struct Type42 {
-    restart_interval: u16,
+struct Type60 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
 }
 
 enum Type63 {
@@ -572,109 +418,45 @@ enum Type63 {
     },
 }
 
-struct Type79 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type57,
-    chunks: Vec<Type63>,
-    idat: Vec<Type64>,
-    more_chunks: Vec<Type63>,
-    iend: Type65,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-struct Type6 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type24 {
-    r#final: u8,
-    r#type: u8,
-    data: Type23,
-}
-
-enum Type10 {
-    application_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        identifier: Vec<u8>,
-        authentication_code: Vec<u8>,
-        application_data: Vec<Type7>,
-        terminator: u8,
-    },
-    comment_extension {
-        separator: u8,
-        label: u8,
-        comment_data: Vec<Type7>,
-        terminator: u8,
+enum Type30 {
+    other(Vec<u8>),
+    jfif {
+        version_major: u8,
+        version_minor: u8,
+        density_units: u8,
+        density_x: u16,
+        density_y: u16,
+        thumbnail_width: u8,
+        thumbnail_height: u8,
+        thumbnail_pixels: Vec<Vec<Type2>>,
     },
 }
 
-struct Type47 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
+struct Type65 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
 }
 
-struct Type55 {
-    initial_segment: Type38,
-    segments: Vec<Type43>,
-    header: Type46,
-    scan: Type52,
-    dnl: Type54,
-    scans: Vec<Type52>,
-}
-
-enum Type11 {
-    graphic_block {
-        graphic_control_extension: Type5,
-        graphic_rendering_block: Type9,
-    },
-    special_purpose_block(Type10),
-}
-
-enum Type62 {
-    color_type_3(Vec<Type61>),
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-enum Type14 {
-    no(),
-    yes { string: Vec<u8>, null: u8 },
-}
-
-enum Type19 {
-    literal(u8),
-    reference { length: u16, distance: u16 },
-}
-
-struct Type35 {
-    byte_order: Type32,
-    magic: u16,
-    offset: u32,
-    ifd: Type34,
-}
-
-enum Type5 {
-    some {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        flags: u8,
-        delay_time: u16,
-        transparent_color_index: u8,
-        terminator: u8,
-    },
-    none(),
+struct Type72 {
+    name: Type69,
+    mode: Type70,
+    uid: Type70,
+    gid: Type70,
+    size: u32,
+    mtime: Type70,
+    chksum: Type70,
+    typeflag: u8,
+    linkname: Type69,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type71,
+    gname: Type71,
+    devmajor: Type70,
+    devminor: Type70,
+    prefix: Type69,
+    pad: Vec<u8>,
 }
 
 struct Type37 {
@@ -717,94 +499,94 @@ enum Type75 {
     text(Type74),
 }
 
-struct Type99 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type22>,
+struct Type13 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
 }
 
-enum Type32 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-enum Type22 {
-    literal(u8),
-}
-
-enum Type46 {
-    sof0 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
+enum Type10 {
+    application_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        identifier: Vec<u8>,
+        authentication_code: Vec<u8>,
+        application_data: Vec<Type7>,
+        terminator: u8,
     },
-    sof1 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof2 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof3 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof5 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof6 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof7 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof9 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof10 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof11 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof13 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof14 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof15 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
+    comment_extension {
+        separator: u8,
+        label: u8,
+        comment_data: Vec<Type7>,
+        terminator: u8,
     },
 }
 
-enum Type66 {
-    no(u8),
-    yes(),
+struct Type85 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type60,
+    crc: u32,
+}
+
+struct Type87 {
+    marker: Type28,
+    length: u16,
+    data: Type31,
+}
+
+struct Type93 {
+    marker: Type28,
+    length: u16,
+    data: Type41,
+}
+
+struct Type96 {
+    padding: u8,
+    exif: Type35,
+}
+
+struct Type95 {
+    marker: Type28,
+    length: u16,
+    data: Vec<u8>,
+}
+
+struct Type101 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type18>,
+    codes_values: Vec<Type19>,
+}
+
+enum Type14 {
+    no(),
+    yes { string: Vec<u8>, null: u8 },
+}
+
+struct Type29 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+struct Type31 {
+    identifier: Type29,
+    data: Type30,
+}
+
+struct Type68 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type67>,
 }
 
 struct Type83 {
@@ -814,10 +596,44 @@ struct Type83 {
     crc: u32,
 }
 
-struct Type92 {
-    marker: Type28,
-    length: u16,
-    data: Type40,
+struct Type52 {
+    segments: Vec<Type43>,
+    sos: Type49,
+    data: Type51,
+}
+
+enum Type32 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+struct Type103 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type7>,
+    terminator: u8,
+}
+
+enum Type62 {
+    color_type_3(Vec<Type61>),
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type61 {
+    palette_index: u8,
+}
+
+struct Type79 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type57,
+    chunks: Vec<Type63>,
+    idat: Vec<Type64>,
+    more_chunks: Vec<Type63>,
+    iend: Type65,
 }
 
 enum Type74 {
@@ -825,49 +641,22 @@ enum Type74 {
     utf8(Vec<char>),
 }
 
-struct Type8 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type7>,
-    terminator: u8,
+struct Type102 {
+    graphic_control_extension: Type5,
+    graphic_rendering_block: Type9,
 }
 
-struct Type28 {
-    ff: u8,
-    marker: u8,
+struct Type34 {
+    num_fields: u16,
+    fields: Vec<Type33>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
 }
 
-enum Type20 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u8,
-        distance_record: Type16,
-    },
-}
-
-struct Type25 {
-    blocks: Vec<Type24>,
-    codes: Vec<Type19>,
-    inflate: Vec<u8>,
-}
-
-struct Type77 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type11>,
-    trailer: Type12,
-}
-
-struct Type26 {
-    crc: u32,
-    length: u32,
-}
-
-struct Type40 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
+struct Type88 {
+    marker: Type28,
+    length: u16,
+    data: Type37,
 }
 
 enum Type43 {
@@ -978,32 +767,243 @@ enum Type43 {
     },
 }
 
-struct Type98 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
-struct Type33 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
 struct Type51 {
     scan_data: Vec<Type50>,
     scan_data_stream: Vec<u8>,
 }
 
-struct Type21 {
+struct Type35 {
+    byte_order: Type32,
+    magic: u16,
+    offset: u32,
+    ifd: Type34,
+}
+
+struct Type70 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
+}
+
+struct Type78 {
+    soi: Type28,
+    frame: Type55,
+    eoi: Type28,
+}
+
+struct Type84 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<Type2>,
+    crc: u32,
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+enum Type46 {
+    sof0 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof1 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof2 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof3 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof5 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof6 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof7 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof9 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof10 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof11 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof13 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof14 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+    sof15 {
+        marker: Type28,
+        length: u16,
+        data: Type45,
+    },
+}
+
+struct Type104 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type7>,
+    terminator: u8,
+}
+
+enum Type11 {
+    graphic_block {
+        graphic_control_extension: Type5,
+        graphic_rendering_block: Type9,
+    },
+    special_purpose_block(Type10),
+}
+
+struct Type94 {
+    marker: Type28,
+    length: u16,
+    data: Type42,
+}
+
+struct Type106 {
+    descriptor: Type6,
+    local_color_table: Type3,
+    data: Type8,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type12 {
+    separator: u8,
+}
+
+struct Type18 {
     code: u16,
-    extra: Type20,
+    extra: Type17,
+}
+
+struct Type67 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type66,
+}
+
+struct Type16 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type64 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<u8>,
+    crc: u32,
+}
+
+enum Type17 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u16,
+        distance_record: Type16,
+    },
+}
+
+struct Type92 {
+    marker: Type28,
+    length: u16,
+    data: Type40,
+}
+
+struct Type39 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+struct Type24 {
+    r#final: u8,
+    r#type: u8,
+    data: Type23,
+}
+
+enum Type66 {
+    no(u8),
+    yes(),
+}
+
+struct Type86 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type62,
+    crc: u32,
+}
+
+struct Type100 {
+    codes: Vec<Type21>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type26 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type105 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+struct Type97 {
+    xmp: Vec<u8>,
+}
+
+struct Type15 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type59 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
@@ -1158,9 +1158,8 @@ fn Decoder12<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder13<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]).contains(b) {
             b
         } else {
             return None;
@@ -1196,13 +1195,8 @@ fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::full();
         let b = input.read_byte()?;
-        if bs.contains(b) {
-            b
-        } else {
-            return None;
-        }
+        b
     });
 }
 
@@ -1220,9 +1214,8 @@ fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder18<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([71776119061217280, 0, 0, 0]);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if ByteSet::from_bits([71776119061217280, 0, 0, 0]).contains(b) {
             b
         } else {
             return None;
@@ -1232,9 +1225,8 @@ fn Decoder18<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::from_bits([4294967297, 0, 0, 0]);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if ByteSet::from_bits([4294967297, 0, 0, 0]).contains(b) {
             b
         } else {
             return None;
@@ -1244,13 +1236,8 @@ fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::full();
         let b = input.read_byte()?;
-        if bs.contains(b) {
-            b
-        } else {
-            return None;
-        }
+        b
     });
 }
 
@@ -1326,72 +1313,64 @@ fn Decoder27<'input>(
     input: &mut ParseCtxt<'input>,
 ) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::singleton(137);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 137 {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let bs = ByteSet::singleton(80);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 80 {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let bs = ByteSet::singleton(78);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 78 {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let bs = ByteSet::singleton(71);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 71 {
             b
         } else {
             return None;
         }
     };
     let field4 = {
-        let bs = ByteSet::singleton(13);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 13 {
             b
         } else {
             return None;
         }
     };
     let field5 = {
-        let bs = ByteSet::singleton(10);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 10 {
             b
         } else {
             return None;
         }
     };
     let field6 = {
-        let bs = ByteSet::singleton(26);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 26 {
             b
         } else {
             return None;
         }
     };
     let field7 = {
-        let bs = ByteSet::singleton(10);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 10 {
             b
         } else {
             return None;
@@ -1466,36 +1445,32 @@ fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 73 {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let bs = ByteSet::singleton(69);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 69 {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let bs = ByteSet::singleton(78);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 78 {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 68 {
             b
         } else {
             return None;
@@ -1510,36 +1485,32 @@ fn Decoder34<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 73 {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 68 {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let bs = ByteSet::singleton(65);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 65 {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let bs = ByteSet::singleton(84);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 84 {
             b
         } else {
             return None;
@@ -1659,36 +1630,32 @@ fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let bs = ByteSet::singleton(73);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 73 {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let bs = ByteSet::singleton(72);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 72 {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let bs = ByteSet::singleton(68);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 68 {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let bs = ByteSet::singleton(82);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 82 {
             b
         } else {
             return None;
@@ -1718,18 +1685,16 @@ fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(216);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 216 {
             b
         } else {
             return None;
@@ -1769,18 +1734,16 @@ fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(217);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 217 {
             b
         } else {
             return None;
@@ -1923,18 +1886,16 @@ fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(208);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 208 {
             b
         } else {
             return None;
@@ -1945,18 +1906,16 @@ fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(209);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 209 {
             b
         } else {
             return None;
@@ -1967,18 +1926,16 @@ fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(210);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 210 {
             b
         } else {
             return None;
@@ -1989,18 +1946,16 @@ fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(211);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 211 {
             b
         } else {
             return None;
@@ -2011,18 +1966,16 @@ fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(212);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 212 {
             b
         } else {
             return None;
@@ -2033,18 +1986,16 @@ fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(213);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 213 {
             b
         } else {
             return None;
@@ -2055,18 +2006,16 @@ fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(214);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 214 {
             b
         } else {
             return None;
@@ -2077,18 +2026,16 @@ fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
 
 fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
     let ff = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let bs = ByteSet::singleton(215);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 215 {
             b
         } else {
             return None;
@@ -2775,9 +2722,8 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 0 {
             b
         } else {
             return None;
@@ -2788,9 +2734,8 @@ fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
     let padding = {
-        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 0 {
             b
         } else {
             return None;
@@ -2855,9 +2800,8 @@ fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 0 {
             b
         } else {
             return None;
@@ -2966,13 +2910,8 @@ fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder123<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::full();
         let b = input.read_byte()?;
-        if bs.contains(b) {
-            b
-        } else {
-            return None;
-        }
+        b
     });
 }
 
@@ -3084,9 +3023,8 @@ fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         unimplemented!(r#"{}"#, tmp)
     };
     let null = {
-        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 0 {
             b
         } else {
             return None;
@@ -3128,9 +3066,8 @@ fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
     let separator = {
-        let bs = ByteSet::singleton(59);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 59 {
             b
         } else {
             return None;
@@ -3160,27 +3097,24 @@ fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
     let separator = {
-        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 33 {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let bs = ByteSet::singleton(255);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 255 {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let bs = ByteSet::singleton(11);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 11 {
             b
         } else {
             return None;
@@ -3212,18 +3146,16 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
     let separator = {
-        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 33 {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let bs = ByteSet::singleton(254);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 254 {
             b
         } else {
             return None;
@@ -3244,14 +3176,15 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
     let len_bytes = {
-        let bs = ByteSet::from_bits([
+        let b = input.read_byte()?;
+        if ByteSet::from_bits([
             18446744073709551614,
             18446744073709551615,
             18446744073709551615,
             18446744073709551615,
-        ]);
-        let b = input.read_byte()?;
-        if bs.contains(b) {
+        ])
+        .contains(b)
+        {
             b
         } else {
             return None;
@@ -3266,9 +3199,8 @@ fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
     return Some({
-        let bs = ByteSet::singleton(0);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 0 {
             b
         } else {
             return None;
@@ -3278,27 +3210,24 @@ fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type105> {
     let separator = {
-        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 33 {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let bs = ByteSet::singleton(249);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 249 {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let bs = ByteSet::singleton(4);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 4 {
             b
         } else {
             return None;
@@ -3342,27 +3271,24 @@ fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
     let separator = {
-        let bs = ByteSet::singleton(33);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 33 {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let bs = ByteSet::singleton(1);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 1 {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let bs = ByteSet::singleton(12);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 12 {
             b
         } else {
             return None;
@@ -3400,9 +3326,8 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 
 fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
     let separator = {
-        let bs = ByteSet::singleton(44);
         let b = input.read_byte()?;
-        if bs.contains(b) {
+        if b == 44 {
             b
         } else {
             return None;

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,685 +1,306 @@
 use doodle::prelude::*;
 
-struct Type13 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-struct Type89 {
-    marker: Type28,
-    length: u16,
-    data: Type53,
-}
-
-struct Type92 {
-    marker: Type28,
-    length: u16,
-    data: Type40,
-}
-
-enum Type23 {
-    dynamic_huffman {
-        hlit: u8,
-        hdist: u8,
-        hclen: u8,
-        code_length_alphabet_code_lengths: Vec<u8>,
-        literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-        literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-        literal_length_alphabet_code_lengths_value: Vec<u8>,
-        distance_alphabet_code_lengths_value: Vec<u8>,
-        codes: Vec<Type18>,
-        codes_values: Vec<Type19>,
-    },
-    fixed_huffman {
-        codes: Vec<Type21>,
-        codes_values: Vec<Type19>,
-    },
-    uncompressed {
-        align: (),
-        len: u16,
-        nlen: u16,
-        bytes: Vec<u8>,
-        codes_values: Vec<Type22>,
-    },
-}
-
-struct Type44 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-struct Type81 {
-    contents: Vec<Type73>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
-}
-
-struct Type95 {
-    marker: Type28,
-    length: u16,
-    data: Vec<u8>,
-}
-
-enum Type17 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u16,
-        distance_record: Type16,
-    },
-}
-
 struct Type21 {
-    code: u16,
-    extra: Type20,
-}
-
-struct Type33 {
-    tag: u16,
-    r#type: u16,
-    length: u32,
-    offset_or_data: u32,
-}
-
-struct Type57 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type56,
-    crc: u32,
-}
-
-struct Type87 {
-    marker: Type28,
-    length: u16,
-    data: Type31,
-}
-
-struct Type70 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
-}
-
-enum Type75 {
-    gif {
-        header: Type0,
-        logical_screen: Type4,
-        blocks: Vec<Type11>,
-        trailer: Type12,
-    },
-    gzip(Vec<Type27>),
-    jpeg {
-        soi: Type28,
-        frame: Type55,
-        eoi: Type28,
-    },
-    png {
-        signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-        ihdr: Type57,
-        chunks: Vec<Type63>,
-        idat: Vec<Type64>,
-        more_chunks: Vec<Type63>,
-        iend: Type65,
-    },
-    riff {
-        tag: (u8, u8, u8, u8),
-        length: u32,
-        data: Type68,
-        pad: Type66,
-    },
-    tar {
-        contents: Vec<Type73>,
-        __padding: Vec<u8>,
-        __trailing: Vec<u8>,
-    },
-    text(Type74),
-}
-
-enum Type9 {
-    table_based_image {
-        descriptor: Type6,
-        local_color_table: Type3,
-        data: Type8,
-    },
-    plain_text_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        text_grid_left_position: u16,
-        text_grid_top_position: u16,
-        text_grid_width: u16,
-        text_grid_height: u16,
-        character_cell_width: u8,
-        character_cell_height: u8,
-        text_foreground_color_index: u8,
-        text_background_color_index: u8,
-        plain_text_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-struct Type76 {
-    data: Type75,
-    end: (),
-}
-
-struct Type16 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-struct Type67 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Vec<u8>,
-    pad: Type66,
-}
-
-struct Type104 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
-}
-
-enum Type50 {
-    mcu(u8),
-    rst0 { ff: u8, marker: u8 },
-    rst1 { ff: u8, marker: u8 },
-    rst2 { ff: u8, marker: u8 },
-    rst3 { ff: u8, marker: u8 },
-    rst4 { ff: u8, marker: u8 },
-    rst5 { ff: u8, marker: u8 },
-    rst6 { ff: u8, marker: u8 },
-    rst7 { ff: u8, marker: u8 },
-}
-
-struct Type34 {
-    num_fields: u16,
-    fields: Vec<Type33>,
-    next_ifd_offset: u32,
-    next_ifd: Vec<u8>,
-}
-
-struct Type28 {
-    ff: u8,
-    marker: u8,
-}
-
-struct Type8 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type55 {
-    initial_segment: Type38,
-    segments: Vec<Type43>,
-    header: Type46,
-    scan: Type52,
-    dnl: Type54,
-    scans: Vec<Type52>,
-}
-
-enum Type14 {
-    no(),
-    yes { string: Vec<u8>, null: u8 },
-}
-
-struct Type47 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
-}
-
-enum Type43 {
-    dqt {
-        marker: Type28,
-        length: u16,
-        data: Type39,
-    },
-    dht {
-        marker: Type28,
-        length: u16,
-        data: Type40,
-    },
-    dac {
-        marker: Type28,
-        length: u16,
-        data: Type41,
-    },
-    dri {
-        marker: Type28,
-        length: u16,
-        data: Type42,
-    },
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-    app2 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app3 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app4 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app5 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app6 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app7 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app8 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app9 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app10 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app11 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app12 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app13 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app14 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    app15 {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-    com {
-        marker: Type28,
-        length: u16,
-        data: Vec<u8>,
-    },
-}
-
-struct Type64 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
-    crc: u32,
-}
-
-struct Type40 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
-}
-
-enum Type10 {
-    application_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        identifier: Vec<u8>,
-        authentication_code: Vec<u8>,
-        application_data: Vec<Type7>,
-        terminator: u8,
-    },
-    comment_extension {
-        separator: u8,
-        label: u8,
-        comment_data: Vec<Type7>,
-        terminator: u8,
-    },
-}
-
-enum Type22 {
-    literal(u8),
-}
-
-struct Type12 {
-    separator: u8,
-}
-
-struct Type15 {
-    code: u16,
-    extra: u8,
-}
-
-struct Type18 {
-    code: u16,
-    extra: Type17,
-}
-
-struct Type25 {
-    blocks: Vec<Type24>,
-    codes: Vec<Type19>,
-    inflate: Vec<u8>,
-}
-
-struct Type26 {
-    crc: u32,
-    length: u32,
-}
-
-struct Type31 {
-    identifier: Type29,
-    data: Type30,
-}
-
-struct Type6 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type41 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type37 {
-    identifier: Type29,
-    data: Type36,
-}
-
-struct Type45 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type44>,
-}
-
-struct Type59 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
-}
-
-struct Type68 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type67>,
-}
-
-struct Type29 {
     string: Vec<u8>,
     null: u8,
 }
 
-struct Type69 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
+enum Type6 {
+    some(Type5),
+    none,
 }
 
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
+enum Type32 {
+    none,
+    some(Type31),
 }
 
-struct Type72 {
-    name: Type69,
-    mode: Type70,
-    uid: Type70,
-    gid: Type70,
-    size: u32,
-    mtime: Type70,
-    chksum: Type70,
-    typeflag: u8,
-    linkname: Type69,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type71,
-    gname: Type71,
-    devmajor: Type70,
-    devminor: Type70,
-    prefix: Type69,
-    pad: Vec<u8>,
+enum Type87 {
+    color_type_3(Type84),
+    color_type_6(Type85),
+    color_type_2(Type85),
+    color_type_4(Type86),
+    color_type_0(Type86),
 }
 
-struct Type35 {
-    byte_order: Type32,
-    magic: u16,
-    offset: u32,
-    ifd: Type34,
-}
-
-struct Type24 {
-    r#final: u8,
-    r#type: u8,
-    data: Type23,
-}
-
-enum Type58 {
-    color_type_3 { palette_index: u8 },
-    color_type_6 { red: u16, green: u16, blue: u16 },
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_4 { greyscale: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-enum Type46 {
-    sof0 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof1 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof2 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof3 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof5 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof6 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof7 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof9 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof10 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof11 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof13 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof14 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-    sof15 {
-        marker: Type28,
-        length: u16,
-        data: Type45,
-    },
-}
-
-struct Type71 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-struct Type52 {
-    segments: Vec<Type43>,
-    sos: Type49,
-    data: Type51,
-}
-
-struct Type51 {
-    scan_data: Vec<Type50>,
-    scan_data_stream: Vec<u8>,
-}
-
-struct Type61 {
-    palette_index: u8,
-}
-
-struct Type73 {
-    header: Type72,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type78 {
-    soi: Type28,
-    frame: Type55,
-    eoi: Type28,
-}
-
-struct Type80 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type68,
-    pad: Type66,
-}
-
-struct Type84 {
+struct Type91 {
     length: u32,
     tag: (u8, u8, u8, u8),
     data: Vec<Type2>,
     crc: u32,
 }
 
-struct Type88 {
-    marker: Type28,
+struct Type28 {
     length: u16,
-    data: Type37,
+    distance: u16,
 }
 
-struct Type91 {
-    marker: Type28,
+struct Type69 {
+    marker: Type42,
     length: u16,
+    data: Type68,
+}
+
+struct Type77 {
+    num_lines: u16,
+}
+
+enum Type94 {
+    color_type_3(Vec<Type84>),
+    color_type_2(Type85),
+    color_type_0(Type86),
+}
+
+struct Type39 {
+    blocks: Vec<Type38>,
+    codes: Vec<Type29>,
+    inflate: Vec<u8>,
+}
+
+struct Type41 {
+    header: Type20,
+    fname: Type22,
     data: Type39,
+    footer: Type40,
 }
 
-struct Type99 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type22>,
-}
-
-struct Type105 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    flags: u8,
-    delay_time: u16,
-    transparent_color_index: u8,
-    terminator: u8,
-}
-
-struct Type27 {
-    header: Type13,
-    fname: Type14,
-    data: Type25,
-    footer: Type26,
-}
-
-enum Type32 {
+enum Type48 {
     le(u8, u8),
     be(u8, u8),
 }
 
-struct Type49 {
-    marker: Type28,
+struct Type58 {
+    marker: Type42,
     length: u16,
-    data: Type48,
+    data: Type57,
+}
+
+struct Type72 {
+    num_image_components: u8,
+    image_components: Vec<Type71>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type51 {
+    byte_order: Type48,
+    magic: u16,
+    offset: u32,
+    ifd: Type50,
+}
+
+struct Type40 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type49 {
+    tag: u16,
+    r#type: u16,
+    length: u32,
+    offset_or_data: u32,
+}
+
+struct Type101 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Vec<u8>,
+    pad: Type100,
+}
+
+enum Type37 {
+    dynamic_huffman(Type30),
+    fixed_huffman(Type34),
+    uncompressed(Type36),
+}
+
+enum Type100 {
+    no(u8),
+    yes,
+}
+
+enum Type111 {
+    gif(Type19),
+    gzip(Vec<Type41>),
+    jpeg(Type81),
+    png(Type99),
+    riff(Type103),
+    tar(Type109),
+    text(Type110),
+}
+
+enum Type12 {
+    table_based_image(Type10),
+    plain_text_extension(Type11),
+}
+
+struct Type75 {
+    scan_data: Vec<Type74>,
+    scan_data_stream: Vec<u8>,
+}
+
+enum Type74 {
+    mcu(u8),
+    rst0(Type42),
+    rst1(Type42),
+    rst2(Type42),
+    rst3(Type42),
+    rst4(Type42),
+    rst5(Type42),
+    rst6(Type42),
+    rst7(Type42),
+}
+
+struct Type38 {
+    r#final: u8,
+    r#type: u8,
+    data: Type37,
+}
+
+struct Type60 {
+    marker: Type42,
+    length: u16,
+    data: Type59,
+}
+
+struct Type27 {
+    code: u16,
+    extra: Type26,
+}
+
+enum Type26 {
+    none,
+    some(Type25),
+}
+
+struct Type31 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u8,
+    distance_record: Type24,
+}
+
+enum Type56 {
+    app0(Type46),
+    app1(Type55),
+}
+
+struct Type65 {
+    marker: Type42,
+    length: u16,
+    data: Vec<u8>,
+}
+
+enum Type44 {
+    other(Vec<u8>),
+    jfif(Type43),
+}
+
+struct Type99 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type83,
+    chunks: Vec<Type96>,
+    idat: Vec<Type97>,
+    more_chunks: Vec<Type96>,
+    iend: Type98,
 }
 
 struct Type107 {
+    name: Type104,
+    mode: Type105,
+    uid: Type105,
+    gid: Type105,
+    size: u32,
+    mtime: Type105,
+    chksum: Type105,
+    typeflag: u8,
+    linkname: Type104,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type106,
+    gname: Type106,
+    devmajor: Type105,
+    devminor: Type105,
+    prefix: Type104,
+    pad: Vec<u8>,
+}
+
+enum Type3 {
+    no,
+    yes(Vec<Type2>),
+}
+
+struct Type54 {
+    identifier: Type21,
+    data: Type53,
+}
+
+struct Type55 {
+    marker: Type42,
+    length: u16,
+    data: Type54,
+}
+
+struct Type88 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type87,
+    crc: u32,
+}
+
+struct Type62 {
+    marker: Type42,
+    length: u16,
+    data: Type61,
+}
+
+struct Type92 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type24 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+enum Type70 {
+    sof0(Type69),
+    sof1(Type69),
+    sof2(Type69),
+    sof3(Type69),
+    sof5(Type69),
+    sof6(Type69),
+    sof7(Type69),
+    sof9(Type69),
+    sof10(Type69),
+    sof11(Type69),
+    sof13(Type69),
+    sof14(Type69),
+    sof15(Type69),
+}
+
+enum Type16 {
+    application_extension(Type14),
+    comment_extension(Type15),
+}
+
+struct Type23 {
+    code: u16,
+    extra: u8,
+}
+
+enum Type110 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+struct Type11 {
     separator: u8,
     label: u8,
     block_size: u8,
@@ -691,36 +312,78 @@ struct Type107 {
     character_cell_height: u8,
     text_foreground_color_index: u8,
     text_background_color_index: u8,
-    plain_text_data: Vec<Type7>,
+    plain_text_data: Vec<Type8>,
     terminator: u8,
 }
 
-enum Type11 {
-    graphic_block {
-        graphic_control_extension: Type5,
-        graphic_rendering_block: Type9,
-    },
-    special_purpose_block(Type10),
+struct Type13 {
+    graphic_control_extension: Type6,
+    graphic_rendering_block: Type12,
 }
 
-struct Type39 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
+struct Type30 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type23>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type27>,
+    codes_values: Vec<Type29>,
 }
 
 enum Type66 {
-    no(u8),
-    yes(),
+    dqt(Type58),
+    dht(Type60),
+    dac(Type62),
+    dri(Type64),
+    app0(Type46),
+    app1(Type55),
+    app2(Type65),
+    app3(Type65),
+    app4(Type65),
+    app5(Type65),
+    app6(Type65),
+    app7(Type65),
+    app8(Type65),
+    app9(Type65),
+    app10(Type65),
+    app11(Type65),
+    app12(Type65),
+    app13(Type65),
+    app14(Type65),
+    app15(Type65),
+    com(Type65),
 }
 
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type59,
-    crc: u32,
+struct Type71 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
-struct Type56 {
+struct Type80 {
+    initial_segment: Type56,
+    segments: Vec<Type66>,
+    header: Type70,
+    scan: Type76,
+    dnl: Type79,
+    scans: Vec<Type76>,
+}
+
+struct Type64 {
+    marker: Type42,
+    length: u16,
+    data: Type63,
+}
+
+struct Type112 {
+    data: Type111,
+    end: (),
+}
+
+struct Type82 {
     width: u32,
     height: u32,
     bit_depth: u8,
@@ -730,16 +393,272 @@ struct Type56 {
     interlace_method: u8,
 }
 
-struct Type97 {
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+struct Type95 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type94,
+    crc: u32,
+}
+
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
+}
+
+struct Type34 {
+    codes: Vec<Type33>,
+    codes_values: Vec<Type29>,
+}
+
+struct Type102 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type101>,
+}
+
+struct Type9 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type93 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type92,
+    crc: u32,
+}
+
+struct Type85 {
+    red: u16,
+    green: u16,
+    blue: u16,
+}
+
+struct Type109 {
+    contents: Vec<Type108>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
+}
+
+struct Type63 {
+    restart_interval: u16,
+}
+
+struct Type52 {
+    padding: u8,
+    exif: Type51,
+}
+
+struct Type76 {
+    segments: Vec<Type66>,
+    sos: Type73,
+    data: Type75,
+}
+
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
+}
+
+struct Type57 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+enum Type53 {
+    other(Vec<u8>),
+    xmp(Type47),
+    exif(Type52),
+}
+
+struct Type47 {
     xmp: Vec<u8>,
 }
 
-enum Type3 {
-    no(),
-    yes(Vec<Type2>),
+struct Type89 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
 }
 
-struct Type98 {
+enum Type96 {
+    bKGD(Type88),
+    pHYs(Type90),
+    PLTE(Type91),
+    tIME(Type93),
+    tRNS(Type95),
+}
+
+enum Type17 {
+    graphic_block(Type13),
+    special_purpose_block(Type16),
+}
+
+struct Type108 {
+    header: Type107,
+    file: Vec<u8>,
+    __padding: (),
+}
+
+struct Type81 {
+    soi: Type42,
+    frame: Type80,
+    eoi: Type42,
+}
+
+struct Type15 {
+    separator: u8,
+    label: u8,
+    comment_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type46 {
+    marker: Type42,
+    length: u16,
+    data: Type45,
+}
+
+struct Type90 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type89,
+    crc: u32,
+}
+
+struct Type84 {
+    palette_index: u8,
+}
+
+struct Type20 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
+}
+
+struct Type103 {
+    tag: (u8, u8, u8, u8),
+    length: u32,
+    data: Type102,
+    pad: Type100,
+}
+
+struct Type10 {
+    descriptor: Type7,
+    local_color_table: Type3,
+    data: Type9,
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type82,
+    crc: u32,
+}
+
+struct Type61 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type106 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
+}
+
+struct Type68 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type67>,
+}
+
+enum Type22 {
+    no,
+    yes(Type21),
+}
+
+struct Type19 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type17>,
+    trailer: Type18,
+}
+
+struct Type25 {
+    length_extra_bits: u8,
+    length: u16,
+    distance_code: u16,
+    distance_record: Type24,
+}
+
+struct Type14 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type8>,
+    terminator: u8,
+}
+
+struct Type33 {
+    code: u16,
+    extra: Type32,
+}
+
+enum Type35 {
+    literal(u8),
+}
+
+struct Type50 {
+    num_fields: u16,
+    fields: Vec<Type49>,
+    next_ifd_offset: u32,
+    next_ifd: Vec<u8>,
+}
+
+enum Type79 {
+    some(Type78),
+    none,
+}
+
+struct Type73 {
+    marker: Type42,
+    length: u16,
+    data: Type72,
+}
+
+struct Type7 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type36 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type35>,
+}
+
+struct Type43 {
     version_major: u8,
     version_minor: u8,
     density_units: u8,
@@ -750,74 +669,63 @@ struct Type98 {
     thumbnail_pixels: Vec<Vec<Type2>>,
 }
 
-struct Type82 {
+struct Type45 {
+    identifier: Type21,
+    data: Type44,
+}
+
+struct Type59 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+struct Type104 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type98 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Type58,
+    data: (),
     crc: u32,
 }
 
-enum Type36 {
-    other(Vec<u8>),
-    xmp { xmp: Vec<u8> },
-    exif { padding: u8, exif: Type35 },
+struct Type78 {
+    marker: Type42,
+    length: u16,
+    data: Type77,
 }
 
-enum Type63 {
-    bKGD {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type58,
-        crc: u32,
-    },
-    pHYs {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type59,
-        crc: u32,
-    },
-    PLTE {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Vec<Type2>,
-        crc: u32,
-    },
-    tIME {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type60,
-        crc: u32,
-    },
-    tRNS {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type62,
-        crc: u32,
-    },
+struct Type86 {
+    greyscale: u16,
 }
 
-enum Type30 {
-    other(Vec<u8>),
-    jfif {
-        version_major: u8,
-        version_minor: u8,
-        density_units: u8,
-        density_x: u16,
-        density_y: u16,
-        thumbnail_width: u8,
-        thumbnail_height: u8,
-        thumbnail_pixels: Vec<Vec<Type2>>,
-    },
+struct Type8 {
+    len_bytes: u8,
+    data: Vec<u8>,
 }
 
-enum Type62 {
-    color_type_3(Vec<Type61>),
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_0 { greyscale: u16 },
+struct Type67 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
 }
 
-struct Type42 {
-    restart_interval: u16,
+struct Type5 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    flags: u8,
+    delay_time: u16,
+    transparent_color_index: u8,
+    terminator: u8,
+}
+
+enum Type29 {
+    literal(u8),
+    reference(Type28),
 }
 
 struct Type2 {
@@ -826,486 +734,1079 @@ struct Type2 {
     b: u8,
 }
 
-struct Type7 {
-    len_bytes: u8,
+struct Type97 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
     data: Vec<u8>,
-}
-
-enum Type19 {
-    literal(u8),
-    reference { length: u16, distance: u16 },
-}
-
-struct Type65 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: (),
     crc: u32,
 }
 
-struct Type53 {
-    num_lines: u16,
+struct Type42 {
+    ff: u8,
+    marker: u8,
 }
 
-enum Type74 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-struct Type77 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type11>,
-    trailer: Type12,
-}
-
-struct Type60 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-struct Type79 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type57,
-    chunks: Vec<Type63>,
-    idat: Vec<Type64>,
-    more_chunks: Vec<Type63>,
-    iend: Type65,
-}
-
-struct Type86 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type62,
-    crc: u32,
-}
-
-struct Type90 {
-    marker: Type28,
-    length: u16,
-    data: Type45,
-}
-
-struct Type94 {
-    marker: Type28,
-    length: u16,
-    data: Type42,
-}
-
-struct Type96 {
-    padding: u8,
-    exif: Type35,
-}
-
-enum Type20 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u8,
-        distance_record: Type16,
-    },
-}
-
-enum Type54 {
-    some {
-        marker: Type28,
-        length: u16,
-        data: Type53,
-    },
-    none(),
-}
-
-struct Type48 {
-    num_image_components: u8,
-    image_components: Vec<Type47>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type100 {
-    codes: Vec<Type21>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type101 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type18>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type103 {
+struct Type18 {
     separator: u8,
-    label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type7>,
-    terminator: u8,
 }
 
-struct Type102 {
-    graphic_control_extension: Type5,
-    graphic_rendering_block: Type9,
+struct Type105 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
 }
 
-struct Type106 {
-    descriptor: Type6,
-    local_color_table: Type3,
-    data: Type8,
+fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
+    (Some((Decoder1(scope, input))?))
 }
 
-struct Type93 {
-    marker: Type28,
-    length: u16,
-    data: Type41,
-}
-
-enum Type5 {
-    some {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        flags: u8,
-        delay_time: u16,
-        transparent_color_index: u8,
-        terminator: u8,
-    },
-    none(),
-}
-
-struct Type85 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type60,
-    crc: u32,
-}
-
-enum Type38 {
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-}
-
-fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
-    return Some(Decoder1(scope, input)?);
-}
-
-fn Decoder1<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
-    let data = {
-        let tmp = r#"invoke_decoder @ Parallel"#;
-        unimplemented!(r#"{}"#, tmp)
+fn Decoder1<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type112> {
+    let data = { (unimplemented!(r#"ParallelLogic::Alts.to_ast(..)"#)) };
+    let end = {
+        if ((input.read_byte()).is_none()) {
+            ()
+        } else {
+            return None;
+        }
     };
-    let end = if input.read_byte().is_none() {
-        ()
-    } else {
-        return None;
-    };
-    return Some(Type76 { data, end });
+    (Some(Type112 { data, end }))
 }
 
-fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type77> {
-    let header = Decoder128(scope, input)?;
-    let logical_screen = Decoder129(scope, input)?;
+fn Decoder2<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type19> {
+    let header = { (Decoder128(scope, input))? };
+    let logical_screen = { (Decoder129(scope, input))? };
     let blocks = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    59 => 1,
+
+                    33 => 0,
+
+                    44 => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder130(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let trailer = Decoder131(scope, input)?;
-    return Some(Type77 {
+    let trailer = { (Decoder131(scope, input))? };
+    (Some(Type19 {
         header,
         logical_screen,
         blocks,
         trailer,
-    });
+    }))
 }
 
-fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<Type27>> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder3<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<Type41>> {
+    let mut accum = (Vec::new());
+    while true {
+        let matching_ix = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            if (b == 31) {
+                1
+            } else {
+                0
+            }
+        };
+        if (matching_ix == 0) {
+            break;
+        } else {
+            let next_elem = {
+                let header = { (Decoder118(scope, input))? };
+                let fname = {
+                    match (header.file_flags & 8 != 0) {
+                        true => {
+                            let inner = (Decoder119(scope, input))?;
+                            (Type22::yes(inner))
+                        }
+
+                        false => {
+                            let inner = ();
+                            (Type22::no(inner))
+                        }
+                    }
+                };
+                let data = { (unimplemented!(r#"translate @ Decoder::Bits"#)) };
+                let footer = { (Decoder121(scope, input))? };
+                Type41 {
+                    header,
+                    fname,
+                    data,
+                    footer,
+                }
+            };
+            (accum.push(next_elem));
+        }
+    }
+    (Some((Some(accum))))
 }
 
-fn Decoder4<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type78> {
-    let soi = Decoder45(scope, input)?;
-    let frame = Decoder46(scope, input)?;
-    let eoi = Decoder47(scope, input)?;
-    return Some(Type78 { soi, frame, eoi });
+fn Decoder4<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
+    let soi = { (Decoder45(scope, input))? };
+    let frame = { (Decoder46(scope, input))? };
+    let eoi = { (Decoder47(scope, input))? };
+    (Some(Type81 { soi, frame, eoi }))
 }
 
-fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type79> {
-    let signature = Decoder27(scope, input)?;
-    let ihdr = Decoder28(scope, input)?;
+fn Decoder5<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type99> {
+    let signature = { (Decoder27(scope, input))? };
+    let ihdr = { (Decoder28(scope, input))? };
     let chunks = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    73 => 1,
+
+                    98 => 0,
+
+                    112 => 0,
+
+                    80 => 0,
+
+                    116 => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder29(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let idat = {
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    73 => {
+                        let b = (lookahead.read_byte());
+                        match b {
+                            69 => 0,
+
+                            68 => 1,
+                        }
+                    }
+
+                    98 => 0,
+
+                    112 => 0,
+
+                    80 => 0,
+
+                    116 => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                break;
+            } else {
+                let next_elem = (Decoder30(scope, input))?;
+                (accum.push(next_elem));
+            }
+        }
+        (Some(accum))
     };
     let more_chunks = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    98 => 0,
+
+                    112 => 0,
+
+                    80 => 0,
+
+                    116 => 0,
+
+                    73 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder29(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let iend = Decoder31(scope, input)?;
-    return Some(Type79 {
+    let iend = { (Decoder31(scope, input))? };
+    (Some(Type99 {
         signature,
         ihdr,
         chunks,
         idat,
         more_chunks,
         iend,
-    });
+    }))
 }
 
-fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
+fn Decoder6<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 82) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 73) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 70) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 70) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let length = Decoder23(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
+    let length = { (Decoder23(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let pad = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match (length % 2 == 0) {
+            true => {
+                let inner = ();
+                (Type100::yes(inner))
+            }
+
+            false => {
+                let inner = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type100::no(inner))
+            }
+        }
     };
-    return Some(Type80 {
+    (Some(Type103 {
         tag,
         length,
         data,
         pad,
-    });
+    }))
 }
 
-fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type81> {
+fn Decoder7<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type109> {
     let contents = {
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 1,
+
+                    0 => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                break;
+            } else {
+                let next_elem = (Decoder14(scope, input))?;
+                (accum.push(next_elem));
+            }
+        }
+        (Some(accum))
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..1024 {
+            (accum.push({
+                let b = (input.read_byte())?;
+                if (b == 0) {
+                    b
+                } else {
+                    return None;
+                }
+            }));
+        }
+        (Some(accum))
     };
     let __trailing = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 0) {
+                    0
+                } else {
+                    1
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type81 {
+    (Some(Type109 {
         contents,
         __padding,
         __trailing,
-    });
+    }))
 }
 
-fn Decoder8<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type74> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Parallel"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder8<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type110> {
+    (Some((unimplemented!(r#"ParallelLogic::Alts.to_ast(..)"#))))
 }
 
 fn Decoder9<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let mut accum = (Vec::new());
+    while true {
+        let matching_ix = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            if ((ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]))
+                .contains(b))
+            {
+                1
+            } else {
+                0
+            }
+        };
+        if (matching_ix == 0) {
+            break;
+        } else {
+            let next_elem = (Decoder13(scope, input))?;
+            (accum.push(next_elem));
+        }
+    }
+    (Some((Some(accum))))
 }
 
 fn Decoder10<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<char>> {
-    return Some({
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let mut accum = (Vec::new());
+    while true {
+        let matching_ix = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            match b {
+                tmp if ((ByteSet::from_bits([
+                    18446744073709551615,
+                    18446744073709551615,
+                    0,
+                    0,
+                ]))
+                .contains(tmp)) =>
+                {
+                    0
+                }
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 0,
+
+                224 => 0,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 0,
+
+                237 => 0,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 0,
+
+                240 => 0,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 0,
+
+                244 => 0,
+            }
+        };
+        if (matching_ix == 0) {
+            let next_elem = (Decoder11(scope, input))?;
+            (accum.push(next_elem));
+        } else {
+            break;
+        }
+    }
+    (Some((Some(accum))))
 }
 
 fn Decoder11<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<char> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let inner = {
+        let tree_index = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            match b {
+                tmp if ((ByteSet::from_bits([
+                    18446744073709551615,
+                    18446744073709551615,
+                    0,
+                    0,
+                ]))
+                .contains(tmp)) =>
+                {
+                    0
+                }
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(tmp)) => 1,
+
+                224 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(tmp)) => 2,
+
+                237 => 2,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => 2,
+
+                240 => 3,
+
+                tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => 3,
+
+                244 => 3,
+            }
+        };
+        match tree_index {
+            0 => {
+                let inner = {
+                    let b = (input.read_byte())?;
+                    if ((ByteSet::from_bits([18446744073709551615, 18446744073709551615, 0, 0]))
+                        .contains(b))
+                    {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                ((|byte| byte as u32)(inner))
+            }
+
+            1 => {
+                let inner = {
+                    let field0 = {
+                        let inner = {
+                            let b = (input.read_byte())?;
+                            if ((ByteSet::from_bits([0, 0, 0, 4294967292])).contains(b)) {
+                                b
+                            } else {
+                                return None;
+                            }
+                        };
+                        ((|raw| raw & 31)(inner))
+                    };
+                    let field1 = { (Decoder12(scope, input))? };
+                    (field0, field1)
+                };
+                ((|bytes| match bytes {
+                    (x1, x0) => {
+                        ((x1 as u32) << 6 | (x0 as u32));
+                    }
+                })(inner))
+            }
+
+            2 => {
+                let inner = {
+                    let tree_index = {
+                        let lookahead = (input.clone());
+                        let b = (lookahead.read_byte());
+                        match b {
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
+                                .contains(tmp)) =>
+                            {
+                                3
+                            }
+
+                            224 => 0,
+
+                            237 => 2,
+
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 35175782154240]))
+                                .contains(tmp)) =>
+                            {
+                                1
+                            }
+                        }
+                    };
+                    match tree_index {
+                        0 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if (b == 224) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 15)(inner))
+                            };
+                            let field1 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 18446744069414584320, 0]))
+                                        .contains(b))
+                                    {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 63)(inner))
+                            };
+                            let field2 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2)
+                        }
+
+                        1 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(b))
+                                    {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 15)(inner))
+                            };
+                            let field1 = { (Decoder12(scope, input))? };
+                            let field2 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2)
+                        }
+
+                        2 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if (b == 237) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 15)(inner))
+                            };
+                            let field1 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 4294967295, 0])).contains(b)) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 63)(inner))
+                            };
+                            let field2 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2)
+                        }
+
+                        3 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 0, 211106232532992]))
+                                        .contains(b))
+                                    {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 15)(inner))
+                            };
+                            let field1 = { (Decoder12(scope, input))? };
+                            let field2 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2)
+                        }
+                    }
+                };
+                ((|bytes| match bytes {
+                    (x2, x1, x0) => {
+                        ((x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32));
+                    }
+                })(inner))
+            }
+
+            3 => {
+                let inner = {
+                    let tree_index = {
+                        let lookahead = (input.clone());
+                        let b = (lookahead.read_byte());
+                        match b {
+                            tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
+                                .contains(tmp)) =>
+                            {
+                                1
+                            }
+
+                            244 => 2,
+
+                            240 => 0,
+                        }
+                    };
+                    match tree_index {
+                        0 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if (b == 240) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 7)(inner))
+                            };
+                            let field1 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 18446744073709486080, 0]))
+                                        .contains(b))
+                                    {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 63)(inner))
+                            };
+                            let field2 = { (Decoder12(scope, input))? };
+                            let field3 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2, field3)
+                        }
+
+                        1 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 0, 3940649673949184]))
+                                        .contains(b))
+                                    {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 7)(inner))
+                            };
+                            let field1 = { (Decoder12(scope, input))? };
+                            let field2 = { (Decoder12(scope, input))? };
+                            let field3 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2, field3)
+                        }
+
+                        2 => {
+                            let field0 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if (b == 244) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 7)(inner))
+                            };
+                            let field1 = {
+                                let inner = {
+                                    let b = (input.read_byte())?;
+                                    if ((ByteSet::from_bits([0, 0, 65535, 0])).contains(b)) {
+                                        b
+                                    } else {
+                                        return None;
+                                    }
+                                };
+                                ((|raw| raw & 63)(inner))
+                            };
+                            let field2 = { (Decoder12(scope, input))? };
+                            let field3 = { (Decoder12(scope, input))? };
+                            (field0, field1, field2, field3)
+                        }
+                    }
+                };
+                ((|bytes| match bytes {
+                    (x3, x2, x1, x0) => {
+                        ((x3 as u32) << 18 | (x2 as u32) << 12 | (x1 as u32) << 6 | (x0 as u32));
+                    }
+                })(inner))
+            }
+        }
+    };
+    (Some(((|codepoint| (char::from_u32(codepoint)).unwrap())(inner))))
 }
 
 fn Decoder12<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let inner = {
+        let b = (input.read_byte())?;
+        if ((ByteSet::from_bits([0, 0, 18446744073709551615, 0])).contains(b)) {
+            b
+        } else {
+            return None;
+        }
+    };
+    (Some(((|raw| raw & 63)(inner))))
 }
 
 fn Decoder13<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        if ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0]).contains(b) {
+    let b = (input.read_byte())?;
+    (Some(
+        if ((ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0])).contains(b)) {
             b
         } else {
             return None;
-        }
-    });
+        },
+    ))
 }
 
-fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type73> {
-    let header = Decoder15(scope, input)?;
+fn Decoder14<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type108> {
+    let header = { (Decoder15(scope, input))? };
     let file = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..header.size {
+            (accum.push((Decoder16(scope, input))?));
+        }
+        (Some(accum))
     };
     let __padding = {
-        while input.offset() % 512 != 0 {
-            let _ = input.read_byte()?;
+        while (input.offset() % 512 != 0) {
+            let _ = (input.read_byte())?;
         }
         ()
     };
-    return Some(Type73 {
+    (Some(Type108 {
         header,
         file,
         __padding,
-    });
+    }))
 }
 
-fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type72> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder15<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
+    (Some((unimplemented!(r#"translate @ Decoder::Slice"#))))
 }
 
 fn Decoder16<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        b
-    });
+    let b = (input.read_byte())?;
+    (Some(b))
 }
 
-fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
+fn Decoder17<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
     let string = {
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 1,
+
+                    0 => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                break;
+            } else {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            }
+        }
+        (Some(accum))
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 0) {
+                    0
+                } else {
+                    1
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type69 { string, __padding });
+    (Some(Type104 { string, __padding }))
 }
 
 fn Decoder18<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        if ByteSet::from_bits([71776119061217280, 0, 0, 0]).contains(b) {
+    let b = (input.read_byte())?;
+    (Some(
+        if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(b)) {
             b
         } else {
             return None;
-        }
-    });
+        },
+    ))
 }
 
 fn Decoder19<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        if ByteSet::from_bits([4294967297, 0, 0, 0]).contains(b) {
+    let b = (input.read_byte())?;
+    (Some(
+        if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(b)) {
             b
         } else {
             return None;
-        }
-    });
+        },
+    ))
 }
 
 fn Decoder20<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        b
-    });
+    let b = (input.read_byte())?;
+    (Some(b))
 }
 
-fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
+fn Decoder21<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
     let string = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    0 => 1,
+
+                    tmp if (tmp != 0) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let __padding = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 0) {
+                    0
+                } else {
+                    1
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type69 { string, __padding });
+    (Some(Type104 { string, __padding }))
 }
 
-fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type71> {
+fn Decoder22<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type106> {
     let string = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let padding = {
-        let tmp = r#"invoke_decoder @ Until"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 0) {
+                    1
+                } else {
+                    0
+                }
+            };
+            if (matching_ix == 0) {
+                break;
+            } else {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type71 { string, padding });
+    (Some(Type106 { string, padding }))
 }
 
 fn Decoder23<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let inner = {
+        let field0 = { (Decoder16(scope, input))? };
+        let field1 = { (Decoder16(scope, input))? };
+        let field2 = { (Decoder16(scope, input))? };
+        let field3 = { (Decoder16(scope, input))? };
+        (field0, field1, field2, field3)
+    };
+    (Some(((|x| u32::from_le_bytes(x))(inner))))
 }
 
-fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type68> {
-    let tag = Decoder25(scope, input)?;
+fn Decoder24<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
+    let tag = { (Decoder25(scope, input))? };
     let chunks = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                0
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder26(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type68 { tag, chunks });
+    (Some(Type102 { tag, chunks }))
 }
 
 fn Decoder25<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
-    let field0 = Decoder20(scope, input)?;
-    let field1 = Decoder20(scope, input)?;
-    let field2 = Decoder20(scope, input)?;
-    let field3 = Decoder20(scope, input)?;
-    return Some((field0, field1, field2, field3));
+    let field0 = { (Decoder20(scope, input))? };
+    let field1 = { (Decoder20(scope, input))? };
+    let field2 = { (Decoder20(scope, input))? };
+    let field3 = { (Decoder20(scope, input))? };
+    (Some((field0, field1, field2, field3)))
 }
 
-fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type67> {
-    let tag = Decoder25(scope, input)?;
-    let length = Decoder23(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
+fn Decoder26<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type101> {
+    let tag = { (Decoder25(scope, input))? };
+    let length = { (Decoder23(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
     let pad = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match (length % 2 == 0) {
+            true => {
+                let inner = ();
+                (Type100::yes(inner))
+            }
+
+            false => {
+                let inner = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type100::no(inner))
+            }
+        }
     };
-    return Some(Type67 {
+    (Some(Type101 {
         tag,
         length,
         data,
         pad,
-    });
+    }))
 }
 
 fn Decoder27<'input>(
@@ -1313,366 +1814,555 @@ fn Decoder27<'input>(
     input: &mut ParseCtxt<'input>,
 ) -> Option<(u8, u8, u8, u8, u8, u8, u8, u8)> {
     let field0 = {
-        let b = input.read_byte()?;
-        if b == 137 {
+        let b = (input.read_byte())?;
+        if (b == 137) {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let b = input.read_byte()?;
-        if b == 80 {
+        let b = (input.read_byte())?;
+        if (b == 80) {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let b = input.read_byte()?;
-        if b == 78 {
+        let b = (input.read_byte())?;
+        if (b == 78) {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let b = input.read_byte()?;
-        if b == 71 {
+        let b = (input.read_byte())?;
+        if (b == 71) {
             b
         } else {
             return None;
         }
     };
     let field4 = {
-        let b = input.read_byte()?;
-        if b == 13 {
+        let b = (input.read_byte())?;
+        if (b == 13) {
             b
         } else {
             return None;
         }
     };
     let field5 = {
-        let b = input.read_byte()?;
-        if b == 10 {
+        let b = (input.read_byte())?;
+        if (b == 10) {
             b
         } else {
             return None;
         }
     };
     let field6 = {
-        let b = input.read_byte()?;
-        if b == 26 {
+        let b = (input.read_byte())?;
+        if (b == 26) {
             b
         } else {
             return None;
         }
     };
     let field7 = {
-        let b = input.read_byte()?;
-        if b == 10 {
+        let b = (input.read_byte())?;
+        if (b == 10) {
             b
         } else {
             return None;
         }
     };
-    return Some((
+    (Some((
         field0, field1, field2, field3, field4, field5, field6, field7,
-    ));
+    )))
 }
 
-fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
-    let length = Decoder32(scope, input)?;
-    let tag = Decoder43(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type57 {
+fn Decoder28<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type83> {
+    let length = { (Decoder32(scope, input))? };
+    let tag = { (Decoder43(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type83 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
-}
+fn Decoder29<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        match b {
+            98 => 0,
 
-fn Decoder30<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
-    let length = Decoder32(scope, input)?;
-    let tag = Decoder35(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
+            80 => 2,
+
+            116 => {
+                let b = (lookahead.read_byte());
+                match b {
+                    73 => 3,
+
+                    82 => 4,
+                }
+            }
+
+            112 => 1,
+        }
     };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type64 {
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder37(scope, input))?;
+            (Type96::bKGD(inner))
+        }
+
+        1 => {
+            let inner = (Decoder38(scope, input))?;
+            (Type96::pHYs(inner))
+        }
+
+        2 => {
+            let inner = (Decoder39(scope, input))?;
+            (Type96::PLTE(inner))
+        }
+
+        3 => {
+            let inner = (Decoder40(scope, input))?;
+            (Type96::tIME(inner))
+        }
+
+        4 => {
+            let inner = (Decoder41(scope, input))?;
+            (Type96::tRNS(inner))
+        }
+    }))
+}
+
+fn Decoder30<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type97> {
+    let length = { (Decoder32(scope, input))? };
+    let tag = { (Decoder35(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type97 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
-    let length = Decoder32(scope, input)?;
-    let tag = Decoder33(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type65 {
+fn Decoder31<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type98> {
+    let length = { (Decoder32(scope, input))? };
+    let tag = { (Decoder33(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type98 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
 fn Decoder32<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u32> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let inner = {
+        let field0 = { (Decoder16(scope, input))? };
+        let field1 = { (Decoder16(scope, input))? };
+        let field2 = { (Decoder16(scope, input))? };
+        let field3 = { (Decoder16(scope, input))? };
+        (field0, field1, field2, field3)
+    };
+    (Some(((|x| u32::from_be_bytes(x))(inner))))
 }
 
 fn Decoder33<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let b = input.read_byte()?;
-        if b == 73 {
+        let b = (input.read_byte())?;
+        if (b == 73) {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let b = input.read_byte()?;
-        if b == 69 {
+        let b = (input.read_byte())?;
+        if (b == 69) {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let b = input.read_byte()?;
-        if b == 78 {
+        let b = (input.read_byte())?;
+        if (b == 78) {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let b = input.read_byte()?;
-        if b == 68 {
+        let b = (input.read_byte())?;
+        if (b == 68) {
             b
         } else {
             return None;
         }
     };
-    return Some((field0, field1, field2, field3));
+    (Some((field0, field1, field2, field3)))
 }
 
 fn Decoder34<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<()> {
-    Some(())
+    (Some(()))
 }
 
 fn Decoder35<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let b = input.read_byte()?;
-        if b == 73 {
+        let b = (input.read_byte())?;
+        if (b == 73) {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let b = input.read_byte()?;
-        if b == 68 {
+        let b = (input.read_byte())?;
+        if (b == 68) {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let b = input.read_byte()?;
-        if b == 65 {
+        let b = (input.read_byte())?;
+        if (b == 65) {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let b = input.read_byte()?;
-        if b == 84 {
+        let b = (input.read_byte())?;
+        if (b == 84) {
             b
         } else {
             return None;
         }
     };
-    return Some((field0, field1, field2, field3));
+    (Some((field0, field1, field2, field3)))
 }
 
 fn Decoder36<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Vec<u8>> {
-    return Some({
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let mut accum = (Vec::new());
+    while true {
+        let matching_ix = {
+            let lookahead = (input.clone());
+            0
+        };
+        if (matching_ix == 0) {
+            let next_elem = (Decoder16(scope, input))?;
+            (accum.push(next_elem));
+        } else {
+            break;
+        }
+    }
+    (Some((Some(accum))))
 }
 
-fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type82> {
-    let length = Decoder32(scope, input)?;
+fn Decoder37<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
+    let length = { (Decoder32(scope, input))? };
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 98) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 75) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 71) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 68) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type82 {
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type88 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type83> {
-    let length = Decoder32(scope, input)?;
+fn Decoder38<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+    let length = { (Decoder32(scope, input))? };
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 112) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 72) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 89) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 115) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type83 {
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type90 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type84> {
-    let length = Decoder32(scope, input)?;
+fn Decoder39<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type91> {
+    let length = { (Decoder32(scope, input))? };
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 80) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 76) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 84) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 69) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type84 {
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type91 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type85> {
-    let length = Decoder32(scope, input)?;
+fn Decoder40<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
+    let length = { (Decoder32(scope, input))? };
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 116) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 73) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 77) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 69) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type85 {
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type93 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
-fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type86> {
-    let length = Decoder32(scope, input)?;
+fn Decoder41<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+    let length = { (Decoder32(scope, input))? };
     let tag = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 116) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 82) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 78) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field3 = {
+            let b = (input.read_byte())?;
+            if (b == 83) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2, field3)
     };
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    let crc = Decoder32(scope, input)?;
-    return Some(Type86 {
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    let crc = { (Decoder32(scope, input))? };
+    (Some(Type95 {
         length,
         tag,
         data,
         crc,
-    });
+    }))
 }
 
 fn Decoder42<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let inner = {
+        let field0 = { (Decoder16(scope, input))? };
+        let field1 = { (Decoder16(scope, input))? };
+        (field0, field1)
+    };
+    (Some(((|x| u16::from_be_bytes(x))(inner))))
 }
 
 fn Decoder43<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<(u8, u8, u8, u8)> {
     let field0 = {
-        let b = input.read_byte()?;
-        if b == 73 {
+        let b = (input.read_byte())?;
+        if (b == 73) {
             b
         } else {
             return None;
         }
     };
     let field1 = {
-        let b = input.read_byte()?;
-        if b == 72 {
+        let b = (input.read_byte())?;
+        if (b == 72) {
             b
         } else {
             return None;
         }
     };
     let field2 = {
-        let b = input.read_byte()?;
-        if b == 68 {
+        let b = (input.read_byte())?;
+        if (b == 68) {
             b
         } else {
             return None;
         }
     };
     let field3 = {
-        let b = input.read_byte()?;
-        if b == 82 {
+        let b = (input.read_byte())?;
+        if (b == 82) {
             b
         } else {
             return None;
         }
     };
-    return Some((field0, field1, field2, field3));
+    (Some((field0, field1, field2, field3)))
 }
 
-fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type56> {
-    let width = Decoder32(scope, input)?;
-    let height = Decoder32(scope, input)?;
-    let bit_depth = Decoder16(scope, input)?;
-    let color_type = Decoder16(scope, input)?;
-    let compression_method = Decoder16(scope, input)?;
-    let filter_method = Decoder16(scope, input)?;
-    let interlace_method = Decoder16(scope, input)?;
-    return Some(Type56 {
+fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type82> {
+    let width = { (Decoder32(scope, input))? };
+    let height = { (Decoder32(scope, input))? };
+    let bit_depth = { (Decoder16(scope, input))? };
+    let color_type = { (Decoder16(scope, input))? };
+    let compression_method = { (Decoder16(scope, input))? };
+    let filter_method = { (Decoder16(scope, input))? };
+    let interlace_method = { (Decoder16(scope, input))? };
+    (Some(Type82 {
         width,
         height,
         bit_depth,
@@ -1680,1149 +2370,2844 @@ fn Decoder44<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option
         compression_method,
         filter_method,
         interlace_method,
-    });
+    }))
 }
 
-fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder45<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 216 {
+        let b = (input.read_byte())?;
+        if (b == 216) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
+fn Decoder46<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type80> {
     let initial_segment = {
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
+        let tree_index = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            if (b == 255) {
+                let b = (lookahead.read_byte());
+                match b {
+                    225 => 1,
+
+                    224 => 0,
+                }
+            } else {
+                return None;
+            }
+        };
+        match tree_index {
+            0 => {
+                let inner = (Decoder48(scope, input))?;
+                (Type56::app0(inner))
+            }
+
+            1 => {
+                let inner = (Decoder49(scope, input))?;
+                (Type56::app1(inner))
+            }
+        }
     };
     let segments = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 255) {
+                    let b = (lookahead.read_byte());
+                    match b {
+                        219 => 0,
+
+                        196 => 0,
+
+                        204 => 0,
+
+                        221 => 0,
+
+                        224 => 0,
+
+                        225 => 0,
+
+                        226 => 0,
+
+                        227 => 0,
+
+                        228 => 0,
+
+                        229 => 0,
+
+                        230 => 0,
+
+                        231 => 0,
+
+                        232 => 0,
+
+                        233 => 0,
+
+                        234 => 0,
+
+                        235 => 0,
+
+                        236 => 0,
+
+                        237 => 0,
+
+                        238 => 0,
+
+                        239 => 0,
+
+                        254 => 0,
+
+                        192 => 1,
+
+                        193 => 1,
+
+                        194 => 1,
+
+                        195 => 1,
+
+                        197 => 1,
+
+                        198 => 1,
+
+                        199 => 1,
+
+                        201 => 1,
+
+                        202 => 1,
+
+                        203 => 1,
+
+                        205 => 1,
+
+                        206 => 1,
+
+                        207 => 1,
+                    }
+                } else {
+                    return None;
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder50(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let header = Decoder51(scope, input)?;
-    let scan = Decoder52(scope, input)?;
+    let header = { (Decoder51(scope, input))? };
+    let scan = { (Decoder52(scope, input))? };
     let dnl = {
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
+        let tree_index = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            if (b == 255) {
+                let b = (lookahead.read_byte());
+                match b {
+                    220 => 0,
+
+                    217 => 1,
+
+                    218 => 1,
+
+                    219 => 1,
+
+                    196 => 1,
+
+                    204 => 1,
+
+                    221 => 1,
+
+                    224 => 1,
+
+                    225 => 1,
+
+                    226 => 1,
+
+                    227 => 1,
+
+                    228 => 1,
+
+                    229 => 1,
+
+                    230 => 1,
+
+                    231 => 1,
+
+                    232 => 1,
+
+                    233 => 1,
+
+                    234 => 1,
+
+                    235 => 1,
+
+                    236 => 1,
+
+                    237 => 1,
+
+                    238 => 1,
+
+                    239 => 1,
+
+                    254 => 1,
+                }
+            } else {
+                return None;
+            }
+        };
+        match tree_index {
+            0 => {
+                let inner = (Decoder53(scope, input))?;
+                (Type79::some(inner))
+            }
+
+            1 => {
+                let inner = ();
+                (Type79::none(inner))
+            }
+        }
     };
     let scans = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 255) {
+                    let b = (lookahead.read_byte());
+                    match b {
+                        217 => 1,
+
+                        218 => 0,
+
+                        219 => 0,
+
+                        196 => 0,
+
+                        204 => 0,
+
+                        221 => 0,
+
+                        224 => 0,
+
+                        225 => 0,
+
+                        226 => 0,
+
+                        227 => 0,
+
+                        228 => 0,
+
+                        229 => 0,
+
+                        230 => 0,
+
+                        231 => 0,
+
+                        232 => 0,
+
+                        233 => 0,
+
+                        234 => 0,
+
+                        235 => 0,
+
+                        236 => 0,
+
+                        237 => 0,
+
+                        238 => 0,
+
+                        239 => 0,
+
+                        254 => 0,
+                    }
+                } else {
+                    return None;
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder54(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type55 {
+    (Some(Type80 {
         initial_segment,
         segments,
         header,
         scan,
         dnl,
         scans,
-    });
+    }))
 }
 
-fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder47<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 217 {
+        let b = (input.read_byte())?;
+        if (b == 217) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type87> {
+fn Decoder48<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 224) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type87 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type46 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type88> {
+fn Decoder49<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type55> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 225) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type88 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type55 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder50<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type66> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        if (b == 255) {
+            let b = (lookahead.read_byte());
+            match b {
+                233 => 13,
+
+                196 => 1,
+
+                235 => 15,
+
+                254 => 20,
+
+                221 => 3,
+
+                219 => 0,
+
+                237 => 17,
+
+                231 => 11,
+
+                230 => 10,
+
+                234 => 14,
+
+                238 => 18,
+
+                236 => 16,
+
+                224 => 4,
+
+                239 => 19,
+
+                232 => 12,
+
+                225 => 5,
+
+                227 => 7,
+
+                204 => 2,
+
+                229 => 9,
+
+                226 => 6,
+
+                228 => 8,
+            }
+        } else {
+            return None;
+        }
+    };
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder85(scope, input))?;
+            (Type66::dqt(inner))
+        }
+
+        1 => {
+            let inner = (Decoder86(scope, input))?;
+            (Type66::dht(inner))
+        }
+
+        2 => {
+            let inner = (Decoder87(scope, input))?;
+            (Type66::dac(inner))
+        }
+
+        3 => {
+            let inner = (Decoder88(scope, input))?;
+            (Type66::dri(inner))
+        }
+
+        4 => {
+            let inner = (Decoder48(scope, input))?;
+            (Type66::app0(inner))
+        }
+
+        5 => {
+            let inner = (Decoder49(scope, input))?;
+            (Type66::app1(inner))
+        }
+
+        6 => {
+            let inner = (Decoder89(scope, input))?;
+            (Type66::app2(inner))
+        }
+
+        7 => {
+            let inner = (Decoder90(scope, input))?;
+            (Type66::app3(inner))
+        }
+
+        8 => {
+            let inner = (Decoder91(scope, input))?;
+            (Type66::app4(inner))
+        }
+
+        9 => {
+            let inner = (Decoder92(scope, input))?;
+            (Type66::app5(inner))
+        }
+
+        10 => {
+            let inner = (Decoder93(scope, input))?;
+            (Type66::app6(inner))
+        }
+
+        11 => {
+            let inner = (Decoder94(scope, input))?;
+            (Type66::app7(inner))
+        }
+
+        12 => {
+            let inner = (Decoder95(scope, input))?;
+            (Type66::app8(inner))
+        }
+
+        13 => {
+            let inner = (Decoder96(scope, input))?;
+            (Type66::app9(inner))
+        }
+
+        14 => {
+            let inner = (Decoder97(scope, input))?;
+            (Type66::app10(inner))
+        }
+
+        15 => {
+            let inner = (Decoder98(scope, input))?;
+            (Type66::app11(inner))
+        }
+
+        16 => {
+            let inner = (Decoder99(scope, input))?;
+            (Type66::app12(inner))
+        }
+
+        17 => {
+            let inner = (Decoder100(scope, input))?;
+            (Type66::app13(inner))
+        }
+
+        18 => {
+            let inner = (Decoder101(scope, input))?;
+            (Type66::app14(inner))
+        }
+
+        19 => {
+            let inner = (Decoder102(scope, input))?;
+            (Type66::app15(inner))
+        }
+
+        20 => {
+            let inner = (Decoder103(scope, input))?;
+            (Type66::com(inner))
+        }
+    }))
 }
 
-fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type46> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder51<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type70> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        if (b == 255) {
+            let b = (lookahead.read_byte());
+            match b {
+                197 => 4,
+
+                203 => 9,
+
+                199 => 6,
+
+                193 => 1,
+
+                202 => 8,
+
+                206 => 11,
+
+                207 => 12,
+
+                201 => 7,
+
+                205 => 10,
+
+                194 => 2,
+
+                195 => 3,
+
+                192 => 0,
+
+                198 => 5,
+            }
+        } else {
+            return None;
+        }
+    };
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder70(scope, input))?;
+            (Type70::sof0(inner))
+        }
+
+        1 => {
+            let inner = (Decoder71(scope, input))?;
+            (Type70::sof1(inner))
+        }
+
+        2 => {
+            let inner = (Decoder72(scope, input))?;
+            (Type70::sof2(inner))
+        }
+
+        3 => {
+            let inner = (Decoder73(scope, input))?;
+            (Type70::sof3(inner))
+        }
+
+        4 => {
+            let inner = (Decoder74(scope, input))?;
+            (Type70::sof5(inner))
+        }
+
+        5 => {
+            let inner = (Decoder75(scope, input))?;
+            (Type70::sof6(inner))
+        }
+
+        6 => {
+            let inner = (Decoder76(scope, input))?;
+            (Type70::sof7(inner))
+        }
+
+        7 => {
+            let inner = (Decoder77(scope, input))?;
+            (Type70::sof9(inner))
+        }
+
+        8 => {
+            let inner = (Decoder78(scope, input))?;
+            (Type70::sof10(inner))
+        }
+
+        9 => {
+            let inner = (Decoder79(scope, input))?;
+            (Type70::sof11(inner))
+        }
+
+        10 => {
+            let inner = (Decoder80(scope, input))?;
+            (Type70::sof13(inner))
+        }
+
+        11 => {
+            let inner = (Decoder81(scope, input))?;
+            (Type70::sof14(inner))
+        }
+
+        12 => {
+            let inner = (Decoder82(scope, input))?;
+            (Type70::sof15(inner))
+        }
+    }))
 }
 
-fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
+fn Decoder52<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
     let segments = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 255) {
+                    let b = (lookahead.read_byte());
+                    match b {
+                        219 => 0,
+
+                        196 => 0,
+
+                        204 => 0,
+
+                        221 => 0,
+
+                        224 => 0,
+
+                        225 => 0,
+
+                        226 => 0,
+
+                        227 => 0,
+
+                        228 => 0,
+
+                        229 => 0,
+
+                        230 => 0,
+
+                        231 => 0,
+
+                        232 => 0,
+
+                        233 => 0,
+
+                        234 => 0,
+
+                        235 => 0,
+
+                        236 => 0,
+
+                        237 => 0,
+
+                        238 => 0,
+
+                        239 => 0,
+
+                        254 => 0,
+
+                        218 => 1,
+                    }
+                } else {
+                    return None;
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder50(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let sos = Decoder55(scope, input)?;
-    let data = Decoder69(scope, input)?;
-    return Some(Type52 {
+    let sos = { (Decoder55(scope, input))? };
+    let data = { (Decoder69(scope, input))? };
+    (Some(Type76 {
         segments,
         sos,
         data,
-    });
+    }))
 }
 
-fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type89> {
+fn Decoder53<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type78> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 220) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type89 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type78 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
+fn Decoder54<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
     let segments = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                if (b == 255) {
+                    let b = (lookahead.read_byte());
+                    match b {
+                        218 => 1,
+
+                        219 => 0,
+
+                        196 => 0,
+
+                        204 => 0,
+
+                        221 => 0,
+
+                        224 => 0,
+
+                        225 => 0,
+
+                        226 => 0,
+
+                        227 => 0,
+
+                        228 => 0,
+
+                        229 => 0,
+
+                        230 => 0,
+
+                        231 => 0,
+
+                        232 => 0,
+
+                        233 => 0,
+
+                        234 => 0,
+
+                        235 => 0,
+
+                        236 => 0,
+
+                        237 => 0,
+
+                        238 => 0,
+
+                        239 => 0,
+
+                        254 => 0,
+                    }
+                } else {
+                    return None;
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder50(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let sos = Decoder55(scope, input)?;
-    let data = Decoder56(scope, input)?;
-    return Some(Type52 {
+    let sos = { (Decoder55(scope, input))? };
+    let data = { (Decoder56(scope, input))? };
+    (Some(Type76 {
         segments,
         sos,
         data,
-    });
+    }))
 }
 
-fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type49> {
+fn Decoder55<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type73> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 218) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type49 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type73 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
+fn Decoder56<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type75> {
     let scan_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    255 => {
+                        let b = (lookahead.read_byte());
+                        match b {
+                            217 => 1,
+
+                            218 => 1,
+
+                            219 => 1,
+
+                            196 => 1,
+
+                            204 => 1,
+
+                            221 => 1,
+
+                            224 => 1,
+
+                            225 => 1,
+
+                            226 => 1,
+
+                            227 => 1,
+
+                            228 => 1,
+
+                            229 => 1,
+
+                            230 => 1,
+
+                            231 => 1,
+
+                            232 => 1,
+
+                            233 => 1,
+
+                            234 => 1,
+
+                            235 => 1,
+
+                            236 => 1,
+
+                            237 => 1,
+
+                            238 => 1,
+
+                            239 => 1,
+
+                            254 => 1,
+
+                            0 => 0,
+
+                            208 => 0,
+
+                            209 => 0,
+
+                            210 => 0,
+
+                            211 => 0,
+
+                            212 => 0,
+
+                            213 => 0,
+
+                            214 => 0,
+
+                            215 => 0,
+                        }
+                    }
+
+                    tmp if (tmp != 255) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let tree_index = {
+                        let lookahead = (input.clone());
+                        let b = (lookahead.read_byte());
+                        match b {
+                            255 => {
+                                let b = (lookahead.read_byte());
+                                match b {
+                                    214 => 7,
+
+                                    210 => 3,
+
+                                    211 => 4,
+
+                                    215 => 8,
+
+                                    212 => 5,
+
+                                    209 => 2,
+
+                                    213 => 6,
+
+                                    0 => 0,
+
+                                    208 => 1,
+                                }
+                            }
+
+                            tmp if (tmp != 255) => 0,
+                        }
+                    };
+                    match tree_index {
+                        0 => {
+                            let inner = (Decoder57(scope, input))?;
+                            (Type74::mcu(inner))
+                        }
+
+                        1 => {
+                            let inner = (Decoder58(scope, input))?;
+                            (Type74::rst0(inner))
+                        }
+
+                        2 => {
+                            let inner = (Decoder59(scope, input))?;
+                            (Type74::rst1(inner))
+                        }
+
+                        3 => {
+                            let inner = (Decoder60(scope, input))?;
+                            (Type74::rst2(inner))
+                        }
+
+                        4 => {
+                            let inner = (Decoder61(scope, input))?;
+                            (Type74::rst3(inner))
+                        }
+
+                        5 => {
+                            let inner = (Decoder62(scope, input))?;
+                            (Type74::rst4(inner))
+                        }
+
+                        6 => {
+                            let inner = (Decoder63(scope, input))?;
+                            (Type74::rst5(inner))
+                        }
+
+                        7 => {
+                            let inner = (Decoder64(scope, input))?;
+                            (Type74::rst6(inner))
+                        }
+
+                        8 => {
+                            let inner = (Decoder65(scope, input))?;
+                            (Type74::rst7(inner))
+                        }
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let scan_data_stream = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((scan_data.into_iter()).flat_map(
+            (|x| match x {
+                mcu(v) => {
+                    ([v].to_vec());
+                }
+
+                rst0(_) => {
+                    ([].to_vec());
+                }
+
+                rst1(_) => {
+                    ([].to_vec());
+                }
+
+                rst2(_) => {
+                    ([].to_vec());
+                }
+
+                rst3(_) => {
+                    ([].to_vec());
+                }
+
+                rst4(_) => {
+                    ([].to_vec());
+                }
+
+                rst5(_) => {
+                    ([].to_vec());
+                }
+
+                rst6(_) => {
+                    ([].to_vec());
+                }
+
+                rst7(_) => {
+                    ([].to_vec());
+                }
+            }),
+        ))
+        .collect())
     };
-    return Some(Type51 {
+    (Some(Type75 {
         scan_data,
         scan_data_stream,
-    });
+    }))
 }
 
 fn Decoder57<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        match b {
+            255 => 1,
+
+            tmp if (tmp != 255) => 0,
+        }
+    };
+    (Some(match tree_index {
+        0 => {
+            let b = (input.read_byte())?;
+            if (b != 255) {
+                b
+            } else {
+                return None;
+            }
+        }
+
+        1 => {
+            let inner = {
+                let field0 = {
+                    let b = (input.read_byte())?;
+                    if (b == 255) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                let field1 = {
+                    let b = (input.read_byte())?;
+                    if (b == 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (field0, field1)
+            };
+            ((|_| 255)(inner))
+        }
+    }))
 }
 
-fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder58<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 208 {
+        let b = (input.read_byte())?;
+        if (b == 208) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder59<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 209 {
+        let b = (input.read_byte())?;
+        if (b == 209) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder60<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 210 {
+        let b = (input.read_byte())?;
+        if (b == 210) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder61<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 211 {
+        let b = (input.read_byte())?;
+        if (b == 211) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder62<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 212 {
+        let b = (input.read_byte())?;
+        if (b == 212) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder63<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 213 {
+        let b = (input.read_byte())?;
+        if (b == 213) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder64<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 214 {
+        let b = (input.read_byte())?;
+        if (b == 214) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type28> {
+fn Decoder65<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
     let ff = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let marker = {
-        let b = input.read_byte()?;
-        if b == 215 {
+        let b = (input.read_byte())?;
+        if (b == 215) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type28 { ff, marker });
+    (Some(Type42 { ff, marker }))
 }
 
-fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type48> {
-    let num_image_components = Decoder16(scope, input)?;
+fn Decoder66<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type72> {
+    let num_image_components = { (Decoder16(scope, input))? };
     let image_components = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..num_image_components {
+            (accum.push((Decoder67(scope, input))?));
+        }
+        (Some(accum))
     };
-    let start_spectral_selection = Decoder16(scope, input)?;
-    let end_spectral_selection = Decoder16(scope, input)?;
-    let approximation_bit_position = Decoder16(scope, input)?;
-    return Some(Type48 {
+    let start_spectral_selection = { (Decoder16(scope, input))? };
+    let end_spectral_selection = { (Decoder16(scope, input))? };
+    let approximation_bit_position = { (Decoder16(scope, input))? };
+    (Some(Type72 {
         num_image_components,
         image_components,
         start_spectral_selection,
         end_spectral_selection,
         approximation_bit_position,
-    });
+    }))
 }
 
-fn Decoder67<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
-    let component_selector = Decoder16(scope, input)?;
-    let entropy_coding_table_ids = Decoder16(scope, input)?;
-    return Some(Type47 {
+fn Decoder67<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type71> {
+    let component_selector = { (Decoder16(scope, input))? };
+    let entropy_coding_table_ids = { (Decoder16(scope, input))? };
+    (Some(Type71 {
         component_selector,
         entropy_coding_table_ids,
-    });
+    }))
 }
 
-fn Decoder68<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type53> {
-    let num_lines = Decoder42(scope, input)?;
-    return Some(Type53 { num_lines });
+fn Decoder68<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type77> {
+    let num_lines = { (Decoder42(scope, input))? };
+    (Some(Type77 { num_lines }))
 }
 
-fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
+fn Decoder69<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type75> {
     let scan_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    255 => {
+                        let b = (lookahead.read_byte());
+                        match b {
+                            0 => 0,
+
+                            208 => 0,
+
+                            209 => 0,
+
+                            210 => 0,
+
+                            211 => 0,
+
+                            212 => 0,
+
+                            213 => 0,
+
+                            214 => 0,
+
+                            215 => 0,
+
+                            220 => 1,
+
+                            217 => 1,
+
+                            218 => 1,
+
+                            219 => 1,
+
+                            196 => 1,
+
+                            204 => 1,
+
+                            221 => 1,
+
+                            224 => 1,
+
+                            225 => 1,
+
+                            226 => 1,
+
+                            227 => 1,
+
+                            228 => 1,
+
+                            229 => 1,
+
+                            230 => 1,
+
+                            231 => 1,
+
+                            232 => 1,
+
+                            233 => 1,
+
+                            234 => 1,
+
+                            235 => 1,
+
+                            236 => 1,
+
+                            237 => 1,
+
+                            238 => 1,
+
+                            239 => 1,
+
+                            254 => 1,
+                        }
+                    }
+
+                    tmp if (tmp != 255) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let tree_index = {
+                        let lookahead = (input.clone());
+                        let b = (lookahead.read_byte());
+                        match b {
+                            255 => {
+                                let b = (lookahead.read_byte());
+                                match b {
+                                    214 => 7,
+
+                                    212 => 5,
+
+                                    210 => 3,
+
+                                    208 => 1,
+
+                                    215 => 8,
+
+                                    209 => 2,
+
+                                    0 => 0,
+
+                                    211 => 4,
+
+                                    213 => 6,
+                                }
+                            }
+
+                            tmp if (tmp != 255) => 0,
+                        }
+                    };
+                    match tree_index {
+                        0 => {
+                            let inner = (Decoder57(scope, input))?;
+                            (Type74::mcu(inner))
+                        }
+
+                        1 => {
+                            let inner = (Decoder58(scope, input))?;
+                            (Type74::rst0(inner))
+                        }
+
+                        2 => {
+                            let inner = (Decoder59(scope, input))?;
+                            (Type74::rst1(inner))
+                        }
+
+                        3 => {
+                            let inner = (Decoder60(scope, input))?;
+                            (Type74::rst2(inner))
+                        }
+
+                        4 => {
+                            let inner = (Decoder61(scope, input))?;
+                            (Type74::rst3(inner))
+                        }
+
+                        5 => {
+                            let inner = (Decoder62(scope, input))?;
+                            (Type74::rst4(inner))
+                        }
+
+                        6 => {
+                            let inner = (Decoder63(scope, input))?;
+                            (Type74::rst5(inner))
+                        }
+
+                        7 => {
+                            let inner = (Decoder64(scope, input))?;
+                            (Type74::rst6(inner))
+                        }
+
+                        8 => {
+                            let inner = (Decoder65(scope, input))?;
+                            (Type74::rst7(inner))
+                        }
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let scan_data_stream = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((scan_data.into_iter()).flat_map(
+            (|x| match x {
+                mcu(v) => {
+                    ([v].to_vec());
+                }
+
+                rst0(_) => {
+                    ([].to_vec());
+                }
+
+                rst1(_) => {
+                    ([].to_vec());
+                }
+
+                rst2(_) => {
+                    ([].to_vec());
+                }
+
+                rst3(_) => {
+                    ([].to_vec());
+                }
+
+                rst4(_) => {
+                    ([].to_vec());
+                }
+
+                rst5(_) => {
+                    ([].to_vec());
+                }
+
+                rst6(_) => {
+                    ([].to_vec());
+                }
+
+                rst7(_) => {
+                    ([].to_vec());
+                }
+            }),
+        ))
+        .collect())
     };
-    return Some(Type51 {
+    (Some(Type75 {
         scan_data,
         scan_data_stream,
-    });
+    }))
 }
 
-fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder70<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 192) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder71<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 193) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder72<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 194) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder73<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 195) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder74<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 197) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder75<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 198) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder76<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 199) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder77<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 201) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder78<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 202) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder79<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 203) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder80<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 205) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder81<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 206) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder82<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type90> {
+fn Decoder82<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type69> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 207) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type90 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type69 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type45> {
-    let sample_precision = Decoder16(scope, input)?;
-    let num_lines = Decoder42(scope, input)?;
-    let num_samples_per_line = Decoder42(scope, input)?;
-    let num_image_components = Decoder16(scope, input)?;
+fn Decoder83<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type68> {
+    let sample_precision = { (Decoder16(scope, input))? };
+    let num_lines = { (Decoder42(scope, input))? };
+    let num_samples_per_line = { (Decoder42(scope, input))? };
+    let num_image_components = { (Decoder16(scope, input))? };
     let image_components = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..num_image_components {
+            (accum.push((Decoder84(scope, input))?));
+        }
+        (Some(accum))
     };
-    return Some(Type45 {
+    (Some(Type68 {
         sample_precision,
         num_lines,
         num_samples_per_line,
         num_image_components,
         image_components,
-    });
+    }))
 }
 
-fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type44> {
-    let id = Decoder16(scope, input)?;
-    let sampling_factor = Decoder16(scope, input)?;
-    let quantization_table_id = Decoder16(scope, input)?;
-    return Some(Type44 {
+fn Decoder84<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type67> {
+    let id = { (Decoder16(scope, input))? };
+    let sampling_factor = { (Decoder16(scope, input))? };
+    let quantization_table_id = { (Decoder16(scope, input))? };
+    (Some(Type67 {
         id,
         sampling_factor,
         quantization_table_id,
-    });
+    }))
 }
 
-fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type91> {
+fn Decoder85<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type58> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 219) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type91 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type58 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type92> {
+fn Decoder86<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type60> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 196) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type92 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type60 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type93> {
+fn Decoder87<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type62> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 204) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type93 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type62 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type94> {
+fn Decoder88<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type64> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 221) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type94 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type64 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder89<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 226) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder90<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 227) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder91<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 228) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder92<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 229) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder93<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 230) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder94<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 231) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder95<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 232) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder96<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 233) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder97<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 234) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder98<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 235) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder99<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 236) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder100<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 237) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder101<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 238) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder102<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 239) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type95> {
+fn Decoder103<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type65> {
     let marker = {
-        let tmp = r#"invoke_decoder @ Record"#;
-        unimplemented!(r#"{}"#, tmp)
+        let ff = {
+            let b = (input.read_byte())?;
+            if (b == 255) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let marker = {
+            let b = (input.read_byte())?;
+            if (b == 254) {
+                b
+            } else {
+                return None;
+            }
+        };
+        Type42 { ff, marker }
     };
-    let length = Decoder42(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Slice"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type95 {
+    let length = { (Decoder42(scope, input))? };
+    let data = { (unimplemented!(r#"translate @ Decoder::Slice"#)) };
+    (Some(Type65 {
         marker,
         length,
         data,
-    });
+    }))
 }
 
-fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type42> {
-    let restart_interval = Decoder42(scope, input)?;
-    return Some(Type42 { restart_interval });
+fn Decoder104<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type63> {
+    let restart_interval = { (Decoder42(scope, input))? };
+    (Some(Type63 { restart_interval }))
 }
 
-fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type41> {
-    let class_table_id = Decoder16(scope, input)?;
-    let value = Decoder16(scope, input)?;
-    return Some(Type41 {
+fn Decoder105<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type61> {
+    let class_table_id = { (Decoder16(scope, input))? };
+    let value = { (Decoder16(scope, input))? };
+    (Some(Type61 {
         class_table_id,
         value,
-    });
+    }))
 }
 
-fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type40> {
-    let class_table_id = Decoder16(scope, input)?;
+fn Decoder106<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type59> {
+    let class_table_id = { (Decoder16(scope, input))? };
     let num_codes = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..16 {
+            (accum.push((Decoder16(scope, input))?));
+        }
+        (Some(accum))
     };
     let values = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                0
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder16(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type40 {
+    (Some(Type59 {
         class_table_id,
         num_codes,
         values,
-    });
+    }))
 }
 
-fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type39> {
-    let precision_table_id = Decoder16(scope, input)?;
+fn Decoder107<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type57> {
+    let precision_table_id = { (Decoder16(scope, input))? };
     let elements = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                0
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder16(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type39 {
+    (Some(Type57 {
         precision_table_id,
         elements,
-    });
+    }))
 }
 
-fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type37> {
-    let identifier = Decoder109(scope, input)?;
+fn Decoder108<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type54> {
+    let identifier = { (Decoder109(scope, input))? };
     let data = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match identifier.string {
+            [69, 120, 105, 102] => {
+                let inner = (Decoder110(scope, input))?;
+                (Type53::exif(inner))
+            }
+
+            [104, 116, 116, 112, 58, 47, 47, 110, 115, 46, 97, 100, 111, 98, 101, 46, 99, 111, 109, 47, 120, 97, 112, 47, 49, 46, 48, 47] =>
+            {
+                let inner = (Decoder111(scope, input))?;
+                (Type53::xmp(inner))
+            }
+
+            _ => {
+                let inner = {
+                    let mut accum = (Vec::new());
+                    while true {
+                        let matching_ix = {
+                            let lookahead = (input.clone());
+                            0
+                        };
+                        if (matching_ix == 0) {
+                            let next_elem = (Decoder16(scope, input))?;
+                            (accum.push(next_elem));
+                        } else {
+                            break;
+                        }
+                    }
+                    (Some(accum))
+                };
+                (Type53::other(inner))
+            }
+        }
     };
-    return Some(Type37 { identifier, data });
+    (Some(Type54 { identifier, data }))
 }
 
-fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+fn Decoder109<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
     let string = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let null = {
-        let b = input.read_byte()?;
-        if b == 0 {
+        let b = (input.read_byte())?;
+        if (b == 0) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type29 { string, null });
+    (Some(Type21 { string, null }))
 }
 
-fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type96> {
+fn Decoder110<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type52> {
     let padding = {
-        let b = input.read_byte()?;
-        if b == 0 {
+        let b = (input.read_byte())?;
+        if (b == 0) {
             b
         } else {
             return None;
         }
     };
-    let exif = Decoder112(scope, input)?;
-    return Some(Type96 { padding, exif });
+    let exif = { (Decoder112(scope, input))? };
+    (Some(Type52 { padding, exif }))
 }
 
-fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type97> {
+fn Decoder111<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type47> {
     let xmp = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                0
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder16(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    return Some(Type97 { xmp });
+    (Some(Type47 { xmp }))
 }
 
-fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type35> {
+fn Decoder112<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type51> {
     let byte_order = {
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
+        let tree_index = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            match b {
+                73 => 0,
+
+                77 => 1,
+            }
+        };
+        match tree_index {
+            0 => {
+                let field0 = {
+                    let b = (input.read_byte())?;
+                    if (b == 73) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                let field1 = {
+                    let b = (input.read_byte())?;
+                    if (b == 73) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type48::le((field0, field1)))
+            }
+
+            1 => {
+                let field0 = {
+                    let b = (input.read_byte())?;
+                    if (b == 77) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                let field1 = {
+                    let b = (input.read_byte())?;
+                    if (b == 77) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (Type48::be((field0, field1)))
+            }
+        }
     };
     let magic = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match byte_order {
+            le(_) => (Decoder113(scope, input))?,
+
+            be(_) => (Decoder42(scope, input))?,
+        }
     };
     let offset = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match byte_order {
+            le(_) => (Decoder23(scope, input))?,
+
+            be(_) => (Decoder32(scope, input))?,
+        }
     };
-    let ifd = {
-        let tmp = r#"invoke_decoder @ WithRelativeOffset"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type35 {
+    let ifd = { (unimplemented!(r#"translate @ Decoder::WithRelativeOffset"#)) };
+    (Some(Type51 {
         byte_order,
         magic,
         offset,
         ifd,
-    });
+    }))
 }
 
 fn Decoder113<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u16> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
-}
-
-fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type31> {
-    let identifier = Decoder115(scope, input)?;
-    let data = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+    let inner = {
+        let field0 = { (Decoder16(scope, input))? };
+        let field1 = { (Decoder16(scope, input))? };
+        (field0, field1)
     };
-    return Some(Type31 { identifier, data });
+    (Some(((|x| u16::from_le_bytes(x))(inner))))
 }
 
-fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+fn Decoder114<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type45> {
+    let identifier = { (Decoder115(scope, input))? };
+    let data = {
+        match identifier.string {
+            [74, 70, 73, 70] => {
+                let inner = (Decoder116(scope, input))?;
+                (Type44::jfif(inner))
+            }
+
+            _ => {
+                let inner = {
+                    let mut accum = (Vec::new());
+                    while true {
+                        let matching_ix = {
+                            let lookahead = (input.clone());
+                            0
+                        };
+                        if (matching_ix == 0) {
+                            let next_elem = (Decoder16(scope, input))?;
+                            (accum.push(next_elem));
+                        } else {
+                            break;
+                        }
+                    }
+                    (Some(accum))
+                };
+                (Type44::other(inner))
+            }
+        }
+    };
+    (Some(Type45 { identifier, data }))
+}
+
+fn Decoder115<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
     let string = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let null = {
-        let b = input.read_byte()?;
-        if b == 0 {
+        let b = (input.read_byte())?;
+        if (b == 0) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type29 { string, null });
+    (Some(Type21 { string, null }))
 }
 
-fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type98> {
-    let version_major = Decoder16(scope, input)?;
-    let version_minor = Decoder16(scope, input)?;
-    let density_units = Decoder16(scope, input)?;
-    let density_x = Decoder42(scope, input)?;
-    let density_y = Decoder42(scope, input)?;
-    let thumbnail_width = Decoder16(scope, input)?;
-    let thumbnail_height = Decoder16(scope, input)?;
+fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type43> {
+    let version_major = { (Decoder16(scope, input))? };
+    let version_minor = { (Decoder16(scope, input))? };
+    let density_units = { (Decoder16(scope, input))? };
+    let density_x = { (Decoder42(scope, input))? };
+    let density_y = { (Decoder42(scope, input))? };
+    let thumbnail_width = { (Decoder16(scope, input))? };
+    let thumbnail_height = { (Decoder16(scope, input))? };
     let thumbnail_pixels = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..thumbnail_height {
+            (accum.push({
+                let mut accum = (Vec::new());
+                for _ in 0..thumbnail_width {
+                    (accum.push((Decoder117(scope, input))?));
+                }
+                (Some(accum))
+            }));
+        }
+        (Some(accum))
     };
-    return Some(Type98 {
+    (Some(Type43 {
         version_major,
         version_minor,
         density_units,
@@ -2831,179 +5216,1109 @@ fn Decoder116<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         thumbnail_width,
         thumbnail_height,
         thumbnail_pixels,
-    });
+    }))
 }
 
 fn Decoder117<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
-    let r = Decoder16(scope, input)?;
-    let g = Decoder16(scope, input)?;
-    let b = Decoder16(scope, input)?;
-    return Some(Type2 { r, g, b });
+    let r = { (Decoder16(scope, input))? };
+    let g = { (Decoder16(scope, input))? };
+    let b = { (Decoder16(scope, input))? };
+    (Some(Type2 { r, g, b }))
 }
 
-fn Decoder118<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
+fn Decoder118<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type20> {
     let magic = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 31) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 139) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1)
     };
-    let method = Decoder16(scope, input)?;
-    let file_flags = Decoder16(scope, input)?;
-    let timestamp = Decoder23(scope, input)?;
-    let compression_flags = Decoder16(scope, input)?;
-    let os_id = Decoder16(scope, input)?;
-    return Some(Type13 {
+    let method = { (Decoder16(scope, input))? };
+    let file_flags = { (Decoder16(scope, input))? };
+    let timestamp = { (Decoder23(scope, input))? };
+    let compression_flags = { (Decoder16(scope, input))? };
+    let os_id = { (Decoder16(scope, input))? };
+    (Some(Type20 {
         magic,
         method,
         file_flags,
         timestamp,
         compression_flags,
         os_id,
-    });
+    }))
 }
 
-fn Decoder119<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
-    return Some(Decoder127(scope, input)?);
+fn Decoder119<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
+    (Some((Decoder127(scope, input))?))
 }
 
-fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type25> {
+fn Decoder120<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type39> {
     let blocks = {
-        let tmp = r#"invoke_decoder @ RepeatUntilLast"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let elem = (Decoder122(scope, input))?;
+            if (((|x| x.r#final == 1)())(&elem)) {
+                (accum.push(elem));
+                break;
+            } else {
+                (accum.push(elem));
+            }
+        }
+        (Some(accum))
     };
     let codes = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((blocks.into_iter()).flat_map(
+            (|x| match x.data {
+                uncompressed(y) => {
+                    y.codes_values;
+                }
+
+                fixed_huffman(y) => {
+                    y.codes_values;
+                }
+
+                dynamic_huffman(y) => {
+                    y.codes_values;
+                }
+            }),
+        ))
+        .collect())
     };
-    let inflate = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type25 {
+    let inflate = { (unimplemented!(r#"embed_expr is not implemented for Expr::Inflate"#)) };
+    (Some(Type39 {
         blocks,
         codes,
         inflate,
-    });
+    }))
 }
 
-fn Decoder121<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type26> {
-    let crc = Decoder23(scope, input)?;
-    let length = Decoder23(scope, input)?;
-    return Some(Type26 { crc, length });
+fn Decoder121<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type40> {
+    let crc = { (Decoder23(scope, input))? };
+    let length = { (Decoder23(scope, input))? };
+    (Some(Type40 { crc, length }))
 }
 
-fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type24> {
-    let r#final = Decoder123(scope, input)?;
+fn Decoder122<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type38> {
+    let r#final = { (Decoder123(scope, input))? };
     let r#type = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            (field0, field1)
+        };
+        ((|bits| bits.1 << 1 | bits.0)(inner))
     };
     let data = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match r#type {
+            0 => {
+                let inner = (Decoder124(scope, input))?;
+                (Type37::uncompressed(inner))
+            }
+
+            1 => {
+                let inner = (Decoder125(scope, input))?;
+                (Type37::fixed_huffman(inner))
+            }
+
+            2 => {
+                let inner = (Decoder126(scope, input))?;
+                (Type37::dynamic_huffman(inner))
+            }
+        }
     };
-    return Some(Type24 {
+    (Some(Type38 {
         r#final,
         r#type,
         data,
-    });
+    }))
 }
 
 fn Decoder123<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        b
-    });
+    let b = (input.read_byte())?;
+    (Some(b))
 }
 
-fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type99> {
+fn Decoder124<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type36> {
     let align = {
-        while input.offset() % 8 != 0 {
-            let _ = input.read_byte()?;
+        while (input.offset() % 8 != 0) {
+            let _ = (input.read_byte())?;
         }
         ()
     };
     let len = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            let field2 = { (Decoder123(scope, input))? };
+            let field3 = { (Decoder123(scope, input))? };
+            let field4 = { (Decoder123(scope, input))? };
+            let field5 = { (Decoder123(scope, input))? };
+            let field6 = { (Decoder123(scope, input))? };
+            let field7 = { (Decoder123(scope, input))? };
+            let field8 = { (Decoder123(scope, input))? };
+            let field9 = { (Decoder123(scope, input))? };
+            let field10 = { (Decoder123(scope, input))? };
+            let field11 = { (Decoder123(scope, input))? };
+            let field12 = { (Decoder123(scope, input))? };
+            let field13 = { (Decoder123(scope, input))? };
+            let field14 = { (Decoder123(scope, input))? };
+            let field15 = { (Decoder123(scope, input))? };
+            (
+                field0, field1, field2, field3, field4, field5, field6, field7, field8, field9,
+                field10, field11, field12, field13, field14, field15,
+            )
+        };
+        ((|bits| {
+            (bits.15 as u16) << 15
+                | (bits.14 as u16) << 14
+                | (bits.13 as u16) << 13
+                | (bits.12 as u16) << 12
+                | (bits.11 as u16) << 11
+                | (bits.10 as u16) << 10
+                | (bits.9 as u16) << 9
+                | (bits.8 as u16) << 8
+                | (bits.7 as u16) << 7
+                | (bits.6 as u16) << 6
+                | (bits.5 as u16) << 5
+                | (bits.4 as u16) << 4
+                | (bits.3 as u16) << 3
+                | (bits.2 as u16) << 2
+                | (bits.1 as u16) << 1
+                | (bits.0 as u16)
+        })(inner))
     };
     let nlen = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            let field2 = { (Decoder123(scope, input))? };
+            let field3 = { (Decoder123(scope, input))? };
+            let field4 = { (Decoder123(scope, input))? };
+            let field5 = { (Decoder123(scope, input))? };
+            let field6 = { (Decoder123(scope, input))? };
+            let field7 = { (Decoder123(scope, input))? };
+            let field8 = { (Decoder123(scope, input))? };
+            let field9 = { (Decoder123(scope, input))? };
+            let field10 = { (Decoder123(scope, input))? };
+            let field11 = { (Decoder123(scope, input))? };
+            let field12 = { (Decoder123(scope, input))? };
+            let field13 = { (Decoder123(scope, input))? };
+            let field14 = { (Decoder123(scope, input))? };
+            let field15 = { (Decoder123(scope, input))? };
+            (
+                field0, field1, field2, field3, field4, field5, field6, field7, field8, field9,
+                field10, field11, field12, field13, field14, field15,
+            )
+        };
+        ((|bits| {
+            (bits.15 as u16) << 15
+                | (bits.14 as u16) << 14
+                | (bits.13 as u16) << 13
+                | (bits.12 as u16) << 12
+                | (bits.11 as u16) << 11
+                | (bits.10 as u16) << 10
+                | (bits.9 as u16) << 9
+                | (bits.8 as u16) << 8
+                | (bits.7 as u16) << 7
+                | (bits.6 as u16) << 6
+                | (bits.5 as u16) << 5
+                | (bits.4 as u16) << 4
+                | (bits.3 as u16) << 3
+                | (bits.2 as u16) << 2
+                | (bits.1 as u16) << 1
+                | (bits.0 as u16)
+        })(inner))
     };
     let bytes = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..len {
+            (accum.push({
+                let inner = {
+                    let field0 = { (Decoder123(scope, input))? };
+                    let field1 = { (Decoder123(scope, input))? };
+                    let field2 = { (Decoder123(scope, input))? };
+                    let field3 = { (Decoder123(scope, input))? };
+                    let field4 = { (Decoder123(scope, input))? };
+                    let field5 = { (Decoder123(scope, input))? };
+                    let field6 = { (Decoder123(scope, input))? };
+                    let field7 = { (Decoder123(scope, input))? };
+                    (
+                        field0, field1, field2, field3, field4, field5, field6, field7,
+                    )
+                };
+                ((|bits| {
+                    bits.7 << 7
+                        | bits.6 << 6
+                        | bits.5 << 5
+                        | bits.4 << 4
+                        | bits.3 << 3
+                        | bits.2 << 2
+                        | bits.1 << 1
+                        | bits.0
+                })(inner))
+            }));
+        }
+        (Some(accum))
     };
-    let codes_values = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
-    return Some(Type99 {
+    let codes_values =
+        { (((bytes.into_iter()).flat_map((|x| [(literal(x))].to_vec()))).collect()) };
+    (Some(Type36 {
         align,
         len,
         nlen,
         bytes,
         codes_values,
-    });
+    }))
 }
 
-fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type100> {
-    let codes = {
-        let tmp = r#"invoke_decoder @ Dynamic"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
+fn Decoder125<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type34> {
+    let codes = { (unimplemented!(r#"translate @ Decoder::Dynamic"#)) };
     let codes_values = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((codes.into_iter()).flat_map(
+            (|x| match x.code {
+                256 => {
+                    ([].to_vec());
+                }
+
+                257 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                258 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                259 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                260 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                261 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                262 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                263 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                264 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                265 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                266 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                267 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                268 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                269 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                270 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                271 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                272 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                273 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                274 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                275 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                276 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                277 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                278 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                279 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                280 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                281 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                282 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                283 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                284 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                285 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                _ => {
+                    ([(literal((x.code as u8)))].to_vec());
+                }
+            }),
+        ))
+        .collect())
     };
-    return Some(Type100 {
+    (Some(Type34 {
         codes,
         codes_values,
-    });
+    }))
 }
 
-fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type101> {
+fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type30> {
     let hlit = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            let field2 = { (Decoder123(scope, input))? };
+            let field3 = { (Decoder123(scope, input))? };
+            let field4 = { (Decoder123(scope, input))? };
+            (field0, field1, field2, field3, field4)
+        };
+        ((|bits| bits.4 << 4 | bits.3 << 3 | bits.2 << 2 | bits.1 << 1 | bits.0)(inner))
     };
     let hdist = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            let field2 = { (Decoder123(scope, input))? };
+            let field3 = { (Decoder123(scope, input))? };
+            let field4 = { (Decoder123(scope, input))? };
+            (field0, field1, field2, field3, field4)
+        };
+        ((|bits| bits.4 << 4 | bits.3 << 3 | bits.2 << 2 | bits.1 << 1 | bits.0)(inner))
     };
     let hclen = {
-        let tmp = r#"invoke_decoder @ Map"#;
-        unimplemented!(r#"{}"#, tmp)
+        let inner = {
+            let field0 = { (Decoder123(scope, input))? };
+            let field1 = { (Decoder123(scope, input))? };
+            let field2 = { (Decoder123(scope, input))? };
+            let field3 = { (Decoder123(scope, input))? };
+            (field0, field1, field2, field3)
+        };
+        ((|bits| bits.3 << 3 | bits.2 << 2 | bits.1 << 1 | bits.0)(inner))
     };
     let code_length_alphabet_code_lengths = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..(hclen + 4) {
+            (accum.push({
+                let inner = {
+                    let field0 = { (Decoder123(scope, input))? };
+                    let field1 = { (Decoder123(scope, input))? };
+                    let field2 = { (Decoder123(scope, input))? };
+                    (field0, field1, field2)
+                };
+                ((|bits| bits.2 << 2 | bits.1 << 1 | bits.0)(inner))
+            }));
+        }
+        (Some(accum))
     };
-    let literal_length_distance_alphabet_code_lengths = {
-        let tmp = r#"invoke_decoder @ Dynamic"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
+    let literal_length_distance_alphabet_code_lengths =
+        { (unimplemented!(r#"translate @ Decoder::Dynamic"#)) };
     let literal_length_distance_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((literal_length_distance_alphabet_code_lengths.into_iter()).fold(
+            (none(())),
+            (|x| match (x.1.code as u8) {
+                16 => {
+                    (
+                        x.0,
+                        (Vec::from_iter(
+                            ((std::iter::repeat(match x.0 {
+                                some(y) => {
+                                    y;
+                                }
+                            }))
+                            .take((x.1.extra + 3))),
+                        )),
+                    );
+                }
+
+                17 => {
+                    (
+                        x.0,
+                        (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 3))))),
+                    );
+                }
+
+                18 => {
+                    (
+                        x.0,
+                        (Vec::from_iter(((std::iter::repeat(0)).take((x.1.extra + 11))))),
+                    );
+                }
+
+                v => {
+                    ((some(v)), ([v].to_vec()));
+                }
+            }),
+        ))
+        .collect())
     };
     let literal_length_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        {
+            let ix = 0;
+            literal_length_distance_alphabet_code_lengths_value[ix..(ix + (hlit as u16) + 257)]
+        }
     };
     let distance_alphabet_code_lengths_value = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        {
+            let ix = ((hlit as u16) + 257);
+            literal_length_distance_alphabet_code_lengths_value[ix..(ix + (hdist as u16) + 1)]
+        }
     };
-    let codes = {
-        let tmp = r#"invoke_decoder @ Dynamic"#;
-        unimplemented!(r#"{}"#, tmp)
-    };
+    let codes = { (unimplemented!(r#"translate @ Decoder::Dynamic"#)) };
     let codes_values = {
-        let tmp = r#"invoke_decoder @ Compute"#;
-        unimplemented!(r#"{}"#, tmp)
+        (((codes.into_iter()).flat_map(
+            (|x| match x.code {
+                256 => {
+                    ([].to_vec());
+                }
+
+                257 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                258 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                259 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                260 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                261 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                262 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                263 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                264 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                265 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                266 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                267 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                268 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                269 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                270 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                271 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                272 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                273 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                274 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                275 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                276 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                277 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                278 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                279 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                280 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                281 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                282 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                283 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                284 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                285 => {
+                    match x.extra {
+                        some(rec) => {
+                            ([reference {
+                                length: rec.length,
+                                distance: rec.distance_record.distance,
+                            }]
+                            .to_vec());
+                        }
+                    };
+                }
+
+                _ => {
+                    ([(literal((x.code as u8)))].to_vec());
+                }
+            }),
+        ))
+        .collect())
     };
-    return Some(Type101 {
+    (Some(Type30 {
         hlit,
         hdist,
         hclen,
@@ -3014,126 +6329,287 @@ fn Decoder126<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         distance_alphabet_code_lengths_value,
         codes,
         codes_values,
-    });
+    }))
 }
 
-fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type29> {
+fn Decoder127<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type21> {
     let string = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    0 => 1,
+
+                    tmp if (tmp != 0) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = {
+                    let b = (input.read_byte())?;
+                    if (b != 0) {
+                        b
+                    } else {
+                        return None;
+                    }
+                };
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
     let null = {
-        let b = input.read_byte()?;
-        if b == 0 {
+        let b = (input.read_byte())?;
+        if (b == 0) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type29 { string, null });
+    (Some(Type21 { string, null }))
 }
 
 fn Decoder128<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type0> {
     let signature = {
-        let tmp = r#"invoke_decoder @ Tuple"#;
-        unimplemented!(r#"{}"#, tmp)
+        let field0 = {
+            let b = (input.read_byte())?;
+            if (b == 71) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field1 = {
+            let b = (input.read_byte())?;
+            if (b == 73) {
+                b
+            } else {
+                return None;
+            }
+        };
+        let field2 = {
+            let b = (input.read_byte())?;
+            if (b == 70) {
+                b
+            } else {
+                return None;
+            }
+        };
+        (field0, field1, field2)
     };
     let version = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..3 {
+            (accum.push((Decoder20(scope, input))?));
+        }
+        (Some(accum))
     };
-    return Some(Type0 { signature, version });
+    (Some(Type0 { signature, version }))
 }
 
 fn Decoder129<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type4> {
-    let descriptor = Decoder145(scope, input)?;
+    let descriptor = { (Decoder145(scope, input))? };
     let global_color_table = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+        match (descriptor.flags & 128 != 0) {
+            true => {
+                let inner = {
+                    let mut accum = (Vec::new());
+                    for _ in 0..(2 << (descriptor.flags & 7)) {
+                        (accum.push((Decoder143(scope, input))?));
+                    }
+                    (Some(accum))
+                };
+                (Type3::yes(inner))
+            }
+
+            false => {
+                let inner = ();
+                (Type3::no(inner))
+            }
+        }
     };
-    return Some(Type4 {
+    (Some(Type4 {
         descriptor,
         global_color_table,
-    });
+    }))
 }
 
-fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type11> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder130<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type17> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        match b {
+            33 => {
+                let b = (lookahead.read_byte());
+                match b {
+                    249 => 0,
+
+                    1 => 0,
+
+                    255 => 1,
+
+                    254 => 1,
+                }
+            }
+
+            44 => 0,
+        }
+    };
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder132(scope, input))?;
+            (Type17::graphic_block(inner))
+        }
+
+        1 => {
+            let inner = (Decoder133(scope, input))?;
+            (Type17::special_purpose_block(inner))
+        }
+    }))
 }
 
-fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
+fn Decoder131<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type18> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 59 {
+        let b = (input.read_byte())?;
+        if (b == 59) {
             b
         } else {
             return None;
         }
     };
-    return Some(Type12 { separator });
+    (Some(Type18 { separator }))
 }
 
-fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type102> {
+fn Decoder132<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type13> {
     let graphic_control_extension = {
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
+        let tree_index = {
+            let lookahead = (input.clone());
+            let b = (lookahead.read_byte());
+            match b {
+                44 => 1,
+
+                33 => {
+                    let b = (lookahead.read_byte());
+                    match b {
+                        249 => 0,
+
+                        1 => 1,
+                    }
+                }
+            }
+        };
+        match tree_index {
+            0 => {
+                let inner = (Decoder138(scope, input))?;
+                (Type6::some(inner))
+            }
+
+            1 => {
+                let inner = ();
+                (Type6::none(inner))
+            }
+        }
     };
-    let graphic_rendering_block = Decoder139(scope, input)?;
-    return Some(Type102 {
+    let graphic_rendering_block = { (Decoder139(scope, input))? };
+    (Some(Type13 {
         graphic_control_extension,
         graphic_rendering_block,
-    });
+    }))
 }
 
-fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
+fn Decoder133<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type16> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        if (b == 33) {
+            let b = (lookahead.read_byte());
+            match b {
+                255 => 0,
+
+                254 => 1,
+            }
+        } else {
+            return None;
+        }
+    };
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder134(scope, input))?;
+            (Type16::application_extension(inner))
+        }
+
+        1 => {
+            let inner = (Decoder135(scope, input))?;
+            (Type16::comment_extension(inner))
+        }
+    }))
 }
 
-fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type103> {
+fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type14> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 33 {
+        let b = (input.read_byte())?;
+        if (b == 33) {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let b = input.read_byte()?;
-        if b == 255 {
+        let b = (input.read_byte())?;
+        if (b == 255) {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let b = input.read_byte()?;
-        if b == 11 {
+        let b = (input.read_byte())?;
+        if (b == 11) {
             b
         } else {
             return None;
         }
     };
     let identifier = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..8 {
+            (accum.push((Decoder16(scope, input))?));
+        }
+        (Some(accum))
     };
     let authentication_code = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..3 {
+            (accum.push((Decoder16(scope, input))?));
+        }
+        (Some(accum))
     };
     let application_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder136(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let terminator = Decoder137(scope, input)?;
-    return Some(Type103 {
+    let terminator = { (Decoder137(scope, input))? };
+    (Some(Type14 {
         separator,
         label,
         block_size,
@@ -3141,96 +6617,114 @@ fn Decoder134<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         authentication_code,
         application_data,
         terminator,
-    });
+    }))
 }
 
-fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type104> {
+fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type15> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 33 {
+        let b = (input.read_byte())?;
+        if (b == 33) {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let b = input.read_byte()?;
-        if b == 254 {
+        let b = (input.read_byte())?;
+        if (b == 254) {
             b
         } else {
             return None;
         }
     };
     let comment_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    0 => 1,
+
+                    tmp if (tmp != 0) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder136(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let terminator = Decoder137(scope, input)?;
-    return Some(Type104 {
+    let terminator = { (Decoder137(scope, input))? };
+    (Some(Type15 {
         separator,
         label,
         comment_data,
         terminator,
-    });
+    }))
 }
 
-fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
+fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
     let len_bytes = {
-        let b = input.read_byte()?;
-        if b != 0 {
+        let b = (input.read_byte())?;
+        if (b != 0) {
             b
         } else {
             return None;
         }
     };
     let data = {
-        let tmp = r#"invoke_decoder @ RepeatCount"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        for _ in 0..len_bytes {
+            (accum.push((Decoder16(scope, input))?));
+        }
+        (Some(accum))
     };
-    return Some(Type7 { len_bytes, data });
+    (Some(Type8 { len_bytes, data }))
 }
 
 fn Decoder137<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<u8> {
-    return Some({
-        let b = input.read_byte()?;
-        if b == 0 {
-            b
-        } else {
-            return None;
-        }
-    });
+    let b = (input.read_byte())?;
+    (Some(if (b == 0) {
+        b
+    } else {
+        return None;
+    }))
 }
 
-fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type105> {
+fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type5> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 33 {
+        let b = (input.read_byte())?;
+        if (b == 33) {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let b = input.read_byte()?;
-        if b == 249 {
+        let b = (input.read_byte())?;
+        if (b == 249) {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let b = input.read_byte()?;
-        if b == 4 {
+        let b = (input.read_byte())?;
+        if (b == 4) {
             b
         } else {
             return None;
         }
     };
-    let flags = Decoder16(scope, input)?;
-    let delay_time = Decoder113(scope, input)?;
-    let transparent_color_index = Decoder16(scope, input)?;
-    let terminator = Decoder137(scope, input)?;
-    return Some(Type105 {
+    let flags = { (Decoder16(scope, input))? };
+    let delay_time = { (Decoder113(scope, input))? };
+    let transparent_color_index = { (Decoder16(scope, input))? };
+    let terminator = { (Decoder137(scope, input))? };
+    (Some(Type5 {
         separator,
         label,
         block_size,
@@ -3238,69 +6732,117 @@ fn Decoder138<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         delay_time,
         transparent_color_index,
         terminator,
-    });
+    }))
 }
 
-fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
-    return Some({
-        let tmp = r#"invoke_decoder @ Branch"#;
-        unimplemented!(r#"{}"#, tmp)
-    });
-}
+fn Decoder139<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type12> {
+    let tree_index = {
+        let lookahead = (input.clone());
+        let b = (lookahead.read_byte());
+        match b {
+            44 => 0,
 
-fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type106> {
-    let descriptor = Decoder142(scope, input)?;
-    let local_color_table = {
-        let tmp = r#"invoke_decoder @ Match"#;
-        unimplemented!(r#"{}"#, tmp)
+            33 => 1,
+        }
     };
-    let data = Decoder144(scope, input)?;
-    return Some(Type106 {
+    (Some(match tree_index {
+        0 => {
+            let inner = (Decoder140(scope, input))?;
+            (Type12::table_based_image(inner))
+        }
+
+        1 => {
+            let inner = (Decoder141(scope, input))?;
+            (Type12::plain_text_extension(inner))
+        }
+    }))
+}
+
+fn Decoder140<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type10> {
+    let descriptor = { (Decoder142(scope, input))? };
+    let local_color_table = {
+        match (descriptor.flags & 128 != 0) {
+            true => {
+                let inner = {
+                    let mut accum = (Vec::new());
+                    for _ in 0..(2 << (descriptor.flags & 7)) {
+                        (accum.push((Decoder143(scope, input))?));
+                    }
+                    (Some(accum))
+                };
+                (Type3::yes(inner))
+            }
+
+            false => {
+                let inner = ();
+                (Type3::no(inner))
+            }
+        }
+    };
+    let data = { (Decoder144(scope, input))? };
+    (Some(Type10 {
         descriptor,
         local_color_table,
         data,
-    });
+    }))
 }
 
-fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type107> {
+fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type11> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 33 {
+        let b = (input.read_byte())?;
+        if (b == 33) {
             b
         } else {
             return None;
         }
     };
     let label = {
-        let b = input.read_byte()?;
-        if b == 1 {
+        let b = (input.read_byte())?;
+        if (b == 1) {
             b
         } else {
             return None;
         }
     };
     let block_size = {
-        let b = input.read_byte()?;
-        if b == 12 {
+        let b = (input.read_byte())?;
+        if (b == 12) {
             b
         } else {
             return None;
         }
     };
-    let text_grid_left_position = Decoder113(scope, input)?;
-    let text_grid_top_position = Decoder113(scope, input)?;
-    let text_grid_width = Decoder113(scope, input)?;
-    let text_grid_height = Decoder113(scope, input)?;
-    let character_cell_width = Decoder16(scope, input)?;
-    let character_cell_height = Decoder16(scope, input)?;
-    let text_foreground_color_index = Decoder16(scope, input)?;
-    let text_background_color_index = Decoder16(scope, input)?;
+    let text_grid_left_position = { (Decoder113(scope, input))? };
+    let text_grid_top_position = { (Decoder113(scope, input))? };
+    let text_grid_width = { (Decoder113(scope, input))? };
+    let text_grid_height = { (Decoder113(scope, input))? };
+    let character_cell_width = { (Decoder16(scope, input))? };
+    let character_cell_height = { (Decoder16(scope, input))? };
+    let text_foreground_color_index = { (Decoder16(scope, input))? };
+    let text_background_color_index = { (Decoder16(scope, input))? };
     let plain_text_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    tmp if (tmp != 0) => 0,
+
+                    0 => 1,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder136(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let terminator = Decoder137(scope, input)?;
-    return Some(Type107 {
+    let terminator = { (Decoder137(scope, input))? };
+    (Some(Type11 {
         separator,
         label,
         block_size,
@@ -3314,67 +6856,84 @@ fn Decoder141<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
         text_background_color_index,
         plain_text_data,
         terminator,
-    });
+    }))
 }
 
-fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type6> {
+fn Decoder142<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
     let separator = {
-        let b = input.read_byte()?;
-        if b == 44 {
+        let b = (input.read_byte())?;
+        if (b == 44) {
             b
         } else {
             return None;
         }
     };
-    let image_left_position = Decoder113(scope, input)?;
-    let image_top_position = Decoder113(scope, input)?;
-    let image_width = Decoder113(scope, input)?;
-    let image_height = Decoder113(scope, input)?;
-    let flags = Decoder16(scope, input)?;
-    return Some(Type6 {
+    let image_left_position = { (Decoder113(scope, input))? };
+    let image_top_position = { (Decoder113(scope, input))? };
+    let image_width = { (Decoder113(scope, input))? };
+    let image_height = { (Decoder113(scope, input))? };
+    let flags = { (Decoder16(scope, input))? };
+    (Some(Type7 {
         separator,
         image_left_position,
         image_top_position,
         image_width,
         image_height,
         flags,
-    });
+    }))
 }
 
 fn Decoder143<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type2> {
-    let r = Decoder16(scope, input)?;
-    let g = Decoder16(scope, input)?;
-    let b = Decoder16(scope, input)?;
-    return Some(Type2 { r, g, b });
+    let r = { (Decoder16(scope, input))? };
+    let g = { (Decoder16(scope, input))? };
+    let b = { (Decoder16(scope, input))? };
+    (Some(Type2 { r, g, b }))
 }
 
-fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type8> {
-    let lzw_min_code_size = Decoder16(scope, input)?;
+fn Decoder144<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type9> {
+    let lzw_min_code_size = { (Decoder16(scope, input))? };
     let image_data = {
-        let tmp = r#"invoke_decoder @ While"#;
-        unimplemented!(r#"{}"#, tmp)
+        let mut accum = (Vec::new());
+        while true {
+            let matching_ix = {
+                let lookahead = (input.clone());
+                let b = (lookahead.read_byte());
+                match b {
+                    0 => 1,
+
+                    tmp if (tmp != 0) => 0,
+                }
+            };
+            if (matching_ix == 0) {
+                let next_elem = (Decoder136(scope, input))?;
+                (accum.push(next_elem));
+            } else {
+                break;
+            }
+        }
+        (Some(accum))
     };
-    let terminator = Decoder137(scope, input)?;
-    return Some(Type8 {
+    let terminator = { (Decoder137(scope, input))? };
+    (Some(Type9 {
         lzw_min_code_size,
         image_data,
         terminator,
-    });
+    }))
 }
 
 fn Decoder145<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type1> {
-    let screen_width = Decoder113(scope, input)?;
-    let screen_height = Decoder113(scope, input)?;
-    let flags = Decoder16(scope, input)?;
-    let bg_color_index = Decoder16(scope, input)?;
-    let pixel_aspect_ratio = Decoder16(scope, input)?;
-    return Some(Type1 {
+    let screen_width = { (Decoder113(scope, input))? };
+    let screen_height = { (Decoder113(scope, input))? };
+    let flags = { (Decoder16(scope, input))? };
+    let bg_color_index = { (Decoder16(scope, input))? };
+    let pixel_aspect_ratio = { (Decoder16(scope, input))? };
+    (Some(Type1 {
         screen_width,
         screen_height,
         flags,
         bg_color_index,
         pixel_aspect_ratio,
-    });
+    }))
 }
 
 #[test]

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,39 +1,12 @@
 use doodle::prelude::*;
 
-struct Type28 {
-    ff: u8,
-    marker: u8,
-}
-
-struct Type1 {
-    screen_width: u16,
-    screen_height: u16,
-    flags: u8,
-    bg_color_index: u8,
-    pixel_aspect_ratio: u8,
-}
-
-enum Type9 {
-    table_based_image {
-        descriptor: Type6,
-        local_color_table: Type3,
-        data: Type8,
-    },
-    plain_text_extension {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        text_grid_left_position: u16,
-        text_grid_top_position: u16,
-        text_grid_width: u16,
-        text_grid_height: u16,
-        character_cell_width: u8,
-        character_cell_height: u8,
-        text_foreground_color_index: u8,
-        text_background_color_index: u8,
-        plain_text_data: Vec<Type7>,
-        terminator: u8,
-    },
+struct Type13 {
+    magic: (u8, u8),
+    method: u8,
+    file_flags: u8,
+    timestamp: u32,
+    compression_flags: u8,
+    os_id: u8,
 }
 
 struct Type89 {
@@ -42,138 +15,10 @@ struct Type89 {
     data: Type53,
 }
 
-struct Type42 {
-    restart_interval: u16,
-}
-
-struct Type91 {
+struct Type92 {
     marker: Type28,
     length: u16,
-    data: Type39,
-}
-
-struct Type77 {
-    header: Type0,
-    logical_screen: Type4,
-    blocks: Vec<Type11>,
-    trailer: Type12,
-}
-
-enum Type54 {
-    some {
-        marker: Type28,
-        length: u16,
-        data: Type53,
-    },
-    none(),
-}
-
-struct Type98 {
-    version_major: u8,
-    version_minor: u8,
-    density_units: u8,
-    density_x: u16,
-    density_y: u16,
-    thumbnail_width: u8,
-    thumbnail_height: u8,
-    thumbnail_pixels: Vec<Vec<Type2>>,
-}
-
-struct Type49 {
-    marker: Type28,
-    length: u16,
-    data: Type48,
-}
-
-struct Type82 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type58,
-    crc: u32,
-}
-
-enum Type5 {
-    some {
-        separator: u8,
-        label: u8,
-        block_size: u8,
-        flags: u8,
-        delay_time: u16,
-        transparent_color_index: u8,
-        terminator: u8,
-    },
-    none(),
-}
-
-enum Type3 {
-    no(),
-    yes(Vec<Type2>),
-}
-
-struct Type90 {
-    marker: Type28,
-    length: u16,
-    data: Type45,
-}
-
-struct Type48 {
-    num_image_components: u8,
-    image_components: Vec<Type47>,
-    start_spectral_selection: u8,
-    end_spectral_selection: u8,
-    approximation_bit_position: u8,
-}
-
-struct Type69 {
-    string: Vec<u8>,
-    __padding: Vec<u8>,
-}
-
-enum Type38 {
-    app0 {
-        marker: Type28,
-        length: u16,
-        data: Type31,
-    },
-    app1 {
-        marker: Type28,
-        length: u16,
-        data: Type37,
-    },
-}
-
-struct Type6 {
-    separator: u8,
-    image_left_position: u16,
-    image_top_position: u16,
-    image_width: u16,
-    image_height: u16,
-    flags: u8,
-}
-
-struct Type41 {
-    class_table_id: u8,
-    value: u8,
-}
-
-struct Type44 {
-    id: u8,
-    sampling_factor: u8,
-    quantization_table_id: u8,
-}
-
-enum Type58 {
-    color_type_3 { palette_index: u8 },
-    color_type_6 { red: u16, green: u16, blue: u16 },
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_4 { greyscale: u16 },
-    color_type_0 { greyscale: u16 },
-}
-
-struct Type81 {
-    contents: Vec<Type73>,
-    __padding: Vec<u8>,
-    __trailing: Vec<u8>,
+    data: Type40,
 }
 
 enum Type23 {
@@ -202,167 +47,45 @@ enum Type23 {
     },
 }
 
-struct Type40 {
-    class_table_id: u8,
-    num_codes: Vec<u8>,
-    values: Vec<u8>,
+struct Type44 {
+    id: u8,
+    sampling_factor: u8,
+    quantization_table_id: u8,
 }
 
-struct Type55 {
-    initial_segment: Type38,
-    segments: Vec<Type43>,
-    header: Type46,
-    scan: Type52,
-    dnl: Type54,
-    scans: Vec<Type52>,
+struct Type1 {
+    screen_width: u16,
+    screen_height: u16,
+    flags: u8,
+    bg_color_index: u8,
+    pixel_aspect_ratio: u8,
 }
 
-struct Type56 {
-    width: u32,
-    height: u32,
-    bit_depth: u8,
-    color_type: u8,
-    compression_method: u8,
-    filter_method: u8,
-    interlace_method: u8,
+struct Type81 {
+    contents: Vec<Type73>,
+    __padding: Vec<u8>,
+    __trailing: Vec<u8>,
 }
 
-struct Type71 {
-    string: Vec<u8>,
-    padding: Vec<u8>,
-}
-
-struct Type76 {
-    data: Type75,
-    end: (),
-}
-
-enum Type36 {
-    other(Vec<u8>),
-    xmp { xmp: Vec<u8> },
-    exif { padding: u8, exif: Type35 },
-}
-
-struct Type25 {
-    blocks: Vec<Type24>,
-    codes: Vec<Type19>,
-    inflate: Vec<u8>,
-}
-
-enum Type50 {
-    mcu(u8),
-    rst0 { ff: u8, marker: u8 },
-    rst1 { ff: u8, marker: u8 },
-    rst2 { ff: u8, marker: u8 },
-    rst3 { ff: u8, marker: u8 },
-    rst4 { ff: u8, marker: u8 },
-    rst5 { ff: u8, marker: u8 },
-    rst6 { ff: u8, marker: u8 },
-    rst7 { ff: u8, marker: u8 },
-}
-
-struct Type45 {
-    sample_precision: u8,
-    num_lines: u16,
-    num_samples_per_line: u16,
-    num_image_components: u8,
-    image_components: Vec<Type44>,
-}
-
-struct Type73 {
-    header: Type72,
-    file: Vec<u8>,
-    __padding: (),
-}
-
-struct Type80 {
-    tag: (u8, u8, u8, u8),
-    length: u32,
-    data: Type68,
-    pad: Type66,
-}
-
-struct Type99 {
-    align: (),
-    len: u16,
-    nlen: u16,
-    bytes: Vec<u8>,
-    codes_values: Vec<Type22>,
-}
-
-struct Type7 {
-    len_bytes: u8,
+struct Type95 {
+    marker: Type28,
+    length: u16,
     data: Vec<u8>,
 }
 
-enum Type19 {
-    literal(u8),
-    reference { length: u16, distance: u16 },
+enum Type17 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u16,
+        distance_record: Type16,
+    },
 }
 
 struct Type21 {
     code: u16,
     extra: Type20,
-}
-
-struct Type107 {
-    separator: u8,
-    label: u8,
-    block_size: u8,
-    text_grid_left_position: u16,
-    text_grid_top_position: u16,
-    text_grid_width: u16,
-    text_grid_height: u16,
-    character_cell_width: u8,
-    character_cell_height: u8,
-    text_foreground_color_index: u8,
-    text_background_color_index: u8,
-    plain_text_data: Vec<Type7>,
-    terminator: u8,
-}
-
-struct Type57 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type56,
-    crc: u32,
-}
-
-struct Type27 {
-    header: Type13,
-    fname: Type14,
-    data: Type25,
-    footer: Type26,
-}
-
-struct Type0 {
-    signature: (u8, u8, u8),
-    version: Vec<u8>,
-}
-
-struct Type53 {
-    num_lines: u16,
-}
-
-struct Type8 {
-    lzw_min_code_size: u8,
-    image_data: Vec<Type7>,
-    terminator: u8,
-}
-
-enum Type20 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u8,
-        distance_record: Type16,
-    },
-}
-
-struct Type47 {
-    component_selector: u8,
-    entropy_coding_table_ids: u8,
 }
 
 struct Type33 {
@@ -372,96 +95,23 @@ struct Type33 {
     offset_or_data: u32,
 }
 
-enum Type22 {
-    literal(u8),
-}
-
-struct Type60 {
-    year: u16,
-    month: u8,
-    day: u8,
-    hour: u8,
-    minute: u8,
-    second: u8,
-}
-
-enum Type63 {
-    bKGD {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type58,
-        crc: u32,
-    },
-    pHYs {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type59,
-        crc: u32,
-    },
-    PLTE {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Vec<Type2>,
-        crc: u32,
-    },
-    tIME {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type60,
-        crc: u32,
-    },
-    tRNS {
-        length: u32,
-        tag: (u8, u8, u8, u8),
-        data: Type62,
-        crc: u32,
-    },
-}
-
-enum Type30 {
-    other(Vec<u8>),
-    jfif {
-        version_major: u8,
-        version_minor: u8,
-        density_units: u8,
-        density_x: u16,
-        density_y: u16,
-        thumbnail_width: u8,
-        thumbnail_height: u8,
-        thumbnail_pixels: Vec<Vec<Type2>>,
-    },
-}
-
-struct Type65 {
+struct Type57 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: (),
+    data: Type56,
     crc: u32,
 }
 
-struct Type72 {
-    name: Type69,
-    mode: Type70,
-    uid: Type70,
-    gid: Type70,
-    size: u32,
-    mtime: Type70,
-    chksum: Type70,
-    typeflag: u8,
-    linkname: Type69,
-    magic: (u8, u8, u8, u8, u8, u8),
-    version: (u8, u8),
-    uname: Type71,
-    gname: Type71,
-    devmajor: Type70,
-    devminor: Type70,
-    prefix: Type69,
-    pad: Vec<u8>,
+struct Type87 {
+    marker: Type28,
+    length: u16,
+    data: Type31,
 }
 
-struct Type37 {
-    identifier: Type29,
-    data: Type36,
+struct Type70 {
+    string: Vec<u8>,
+    __nul_or_wsp: u8,
+    __padding: Vec<u8>,
 }
 
 enum Type75 {
@@ -499,151 +149,68 @@ enum Type75 {
     text(Type74),
 }
 
-struct Type13 {
-    magic: (u8, u8),
-    method: u8,
-    file_flags: u8,
-    timestamp: u32,
-    compression_flags: u8,
-    os_id: u8,
-}
-
-enum Type10 {
-    application_extension {
+enum Type9 {
+    table_based_image {
+        descriptor: Type6,
+        local_color_table: Type3,
+        data: Type8,
+    },
+    plain_text_extension {
         separator: u8,
         label: u8,
         block_size: u8,
-        identifier: Vec<u8>,
-        authentication_code: Vec<u8>,
-        application_data: Vec<Type7>,
-        terminator: u8,
-    },
-    comment_extension {
-        separator: u8,
-        label: u8,
-        comment_data: Vec<Type7>,
+        text_grid_left_position: u16,
+        text_grid_top_position: u16,
+        text_grid_width: u16,
+        text_grid_height: u16,
+        character_cell_width: u8,
+        character_cell_height: u8,
+        text_foreground_color_index: u8,
+        text_background_color_index: u8,
+        plain_text_data: Vec<Type7>,
         terminator: u8,
     },
 }
 
-struct Type85 {
-    length: u32,
+struct Type76 {
+    data: Type75,
+    end: (),
+}
+
+struct Type16 {
+    distance_extra_bits: u16,
+    distance: u16,
+}
+
+struct Type67 {
     tag: (u8, u8, u8, u8),
-    data: Type60,
-    crc: u32,
-}
-
-struct Type87 {
-    marker: Type28,
-    length: u16,
-    data: Type31,
-}
-
-struct Type93 {
-    marker: Type28,
-    length: u16,
-    data: Type41,
-}
-
-struct Type96 {
-    padding: u8,
-    exif: Type35,
-}
-
-struct Type95 {
-    marker: Type28,
-    length: u16,
+    length: u32,
     data: Vec<u8>,
+    pad: Type66,
 }
 
-struct Type101 {
-    hlit: u8,
-    hdist: u8,
-    hclen: u8,
-    code_length_alphabet_code_lengths: Vec<u8>,
-    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
-    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
-    literal_length_alphabet_code_lengths_value: Vec<u8>,
-    distance_alphabet_code_lengths_value: Vec<u8>,
-    codes: Vec<Type18>,
-    codes_values: Vec<Type19>,
-}
-
-enum Type14 {
-    no(),
-    yes { string: Vec<u8>, null: u8 },
-}
-
-struct Type29 {
-    string: Vec<u8>,
-    null: u8,
-}
-
-struct Type31 {
-    identifier: Type29,
-    data: Type30,
-}
-
-struct Type68 {
-    tag: (u8, u8, u8, u8),
-    chunks: Vec<Type67>,
-}
-
-struct Type83 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type59,
-    crc: u32,
-}
-
-struct Type52 {
-    segments: Vec<Type43>,
-    sos: Type49,
-    data: Type51,
-}
-
-enum Type32 {
-    le(u8, u8),
-    be(u8, u8),
-}
-
-struct Type103 {
+struct Type104 {
     separator: u8,
     label: u8,
-    block_size: u8,
-    identifier: Vec<u8>,
-    authentication_code: Vec<u8>,
-    application_data: Vec<Type7>,
+    comment_data: Vec<Type7>,
     terminator: u8,
 }
 
-enum Type62 {
-    color_type_3(Vec<Type61>),
-    color_type_2 { red: u16, green: u16, blue: u16 },
-    color_type_0 { greyscale: u16 },
+struct Type4 {
+    descriptor: Type1,
+    global_color_table: Type3,
 }
 
-struct Type61 {
-    palette_index: u8,
-}
-
-struct Type79 {
-    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
-    ihdr: Type57,
-    chunks: Vec<Type63>,
-    idat: Vec<Type64>,
-    more_chunks: Vec<Type63>,
-    iend: Type65,
-}
-
-enum Type74 {
-    ascii(Vec<u8>),
-    utf8(Vec<char>),
-}
-
-struct Type102 {
-    graphic_control_extension: Type5,
-    graphic_rendering_block: Type9,
+enum Type50 {
+    mcu(u8),
+    rst0 { ff: u8, marker: u8 },
+    rst1 { ff: u8, marker: u8 },
+    rst2 { ff: u8, marker: u8 },
+    rst3 { ff: u8, marker: u8 },
+    rst4 { ff: u8, marker: u8 },
+    rst5 { ff: u8, marker: u8 },
+    rst6 { ff: u8, marker: u8 },
+    rst7 { ff: u8, marker: u8 },
 }
 
 struct Type34 {
@@ -653,10 +220,34 @@ struct Type34 {
     next_ifd: Vec<u8>,
 }
 
-struct Type88 {
-    marker: Type28,
-    length: u16,
-    data: Type37,
+struct Type28 {
+    ff: u8,
+    marker: u8,
+}
+
+struct Type8 {
+    lzw_min_code_size: u8,
+    image_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type55 {
+    initial_segment: Type38,
+    segments: Vec<Type43>,
+    header: Type46,
+    scan: Type52,
+    dnl: Type54,
+    scans: Vec<Type52>,
+}
+
+enum Type14 {
+    no(),
+    yes { string: Vec<u8>, null: u8 },
+}
+
+struct Type47 {
+    component_selector: u8,
+    entropy_coding_table_ids: u8,
 }
 
 enum Type43 {
@@ -767,9 +358,142 @@ enum Type43 {
     },
 }
 
-struct Type51 {
-    scan_data: Vec<Type50>,
-    scan_data_stream: Vec<u8>,
+struct Type64 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Vec<u8>,
+    crc: u32,
+}
+
+struct Type40 {
+    class_table_id: u8,
+    num_codes: Vec<u8>,
+    values: Vec<u8>,
+}
+
+enum Type10 {
+    application_extension {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        identifier: Vec<u8>,
+        authentication_code: Vec<u8>,
+        application_data: Vec<Type7>,
+        terminator: u8,
+    },
+    comment_extension {
+        separator: u8,
+        label: u8,
+        comment_data: Vec<Type7>,
+        terminator: u8,
+    },
+}
+
+enum Type22 {
+    literal(u8),
+}
+
+struct Type12 {
+    separator: u8,
+}
+
+struct Type15 {
+    code: u16,
+    extra: u8,
+}
+
+struct Type18 {
+    code: u16,
+    extra: Type17,
+}
+
+struct Type25 {
+    blocks: Vec<Type24>,
+    codes: Vec<Type19>,
+    inflate: Vec<u8>,
+}
+
+struct Type26 {
+    crc: u32,
+    length: u32,
+}
+
+struct Type31 {
+    identifier: Type29,
+    data: Type30,
+}
+
+struct Type6 {
+    separator: u8,
+    image_left_position: u16,
+    image_top_position: u16,
+    image_width: u16,
+    image_height: u16,
+    flags: u8,
+}
+
+struct Type41 {
+    class_table_id: u8,
+    value: u8,
+}
+
+struct Type37 {
+    identifier: Type29,
+    data: Type36,
+}
+
+struct Type45 {
+    sample_precision: u8,
+    num_lines: u16,
+    num_samples_per_line: u16,
+    num_image_components: u8,
+    image_components: Vec<Type44>,
+}
+
+struct Type59 {
+    pixels_per_unit_x: u32,
+    pixels_per_unit_y: u32,
+    unit_specifier: u8,
+}
+
+struct Type68 {
+    tag: (u8, u8, u8, u8),
+    chunks: Vec<Type67>,
+}
+
+struct Type29 {
+    string: Vec<u8>,
+    null: u8,
+}
+
+struct Type69 {
+    string: Vec<u8>,
+    __padding: Vec<u8>,
+}
+
+struct Type0 {
+    signature: (u8, u8, u8),
+    version: Vec<u8>,
+}
+
+struct Type72 {
+    name: Type69,
+    mode: Type70,
+    uid: Type70,
+    gid: Type70,
+    size: u32,
+    mtime: Type70,
+    chksum: Type70,
+    typeflag: u8,
+    linkname: Type69,
+    magic: (u8, u8, u8, u8, u8, u8),
+    version: (u8, u8),
+    uname: Type71,
+    gname: Type71,
+    devmajor: Type70,
+    devminor: Type70,
+    prefix: Type69,
+    pad: Vec<u8>,
 }
 
 struct Type35 {
@@ -779,29 +503,18 @@ struct Type35 {
     ifd: Type34,
 }
 
-struct Type70 {
-    string: Vec<u8>,
-    __nul_or_wsp: u8,
-    __padding: Vec<u8>,
+struct Type24 {
+    r#final: u8,
+    r#type: u8,
+    data: Type23,
 }
 
-struct Type78 {
-    soi: Type28,
-    frame: Type55,
-    eoi: Type28,
-}
-
-struct Type84 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Vec<Type2>,
-    crc: u32,
-}
-
-struct Type2 {
-    r: u8,
-    g: u8,
-    b: u8,
+enum Type58 {
+    color_type_3 { palette_index: u8 },
+    color_type_6 { red: u16, green: u16, blue: u16 },
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_4 { greyscale: u16 },
+    color_type_0 { greyscale: u16 },
 }
 
 enum Type46 {
@@ -872,113 +585,70 @@ enum Type46 {
     },
 }
 
-struct Type104 {
-    separator: u8,
-    label: u8,
-    comment_data: Vec<Type7>,
-    terminator: u8,
+struct Type71 {
+    string: Vec<u8>,
+    padding: Vec<u8>,
 }
 
-enum Type11 {
-    graphic_block {
-        graphic_control_extension: Type5,
-        graphic_rendering_block: Type9,
-    },
-    special_purpose_block(Type10),
+struct Type52 {
+    segments: Vec<Type43>,
+    sos: Type49,
+    data: Type51,
 }
 
-struct Type94 {
-    marker: Type28,
-    length: u16,
-    data: Type42,
+struct Type51 {
+    scan_data: Vec<Type50>,
+    scan_data_stream: Vec<u8>,
 }
 
-struct Type106 {
-    descriptor: Type6,
-    local_color_table: Type3,
-    data: Type8,
+struct Type61 {
+    palette_index: u8,
 }
 
-struct Type4 {
-    descriptor: Type1,
-    global_color_table: Type3,
+struct Type73 {
+    header: Type72,
+    file: Vec<u8>,
+    __padding: (),
 }
 
-struct Type12 {
-    separator: u8,
+struct Type78 {
+    soi: Type28,
+    frame: Type55,
+    eoi: Type28,
 }
 
-struct Type18 {
-    code: u16,
-    extra: Type17,
-}
-
-struct Type67 {
+struct Type80 {
     tag: (u8, u8, u8, u8),
     length: u32,
-    data: Vec<u8>,
+    data: Type68,
     pad: Type66,
 }
 
-struct Type16 {
-    distance_extra_bits: u16,
-    distance: u16,
-}
-
-struct Type64 {
+struct Type84 {
     length: u32,
     tag: (u8, u8, u8, u8),
-    data: Vec<u8>,
+    data: Vec<Type2>,
     crc: u32,
 }
 
-enum Type17 {
-    none(),
-    some {
-        length_extra_bits: u8,
-        length: u16,
-        distance_code: u16,
-        distance_record: Type16,
-    },
-}
-
-struct Type92 {
+struct Type88 {
     marker: Type28,
     length: u16,
-    data: Type40,
+    data: Type37,
 }
 
-struct Type39 {
-    precision_table_id: u8,
-    elements: Vec<u8>,
+struct Type91 {
+    marker: Type28,
+    length: u16,
+    data: Type39,
 }
 
-struct Type24 {
-    r#final: u8,
-    r#type: u8,
-    data: Type23,
-}
-
-enum Type66 {
-    no(u8),
-    yes(),
-}
-
-struct Type86 {
-    length: u32,
-    tag: (u8, u8, u8, u8),
-    data: Type62,
-    crc: u32,
-}
-
-struct Type100 {
-    codes: Vec<Type21>,
-    codes_values: Vec<Type19>,
-}
-
-struct Type26 {
-    crc: u32,
-    length: u32,
+struct Type99 {
+    align: (),
+    len: u16,
+    nlen: u16,
+    bytes: Vec<u8>,
+    codes_values: Vec<Type22>,
 }
 
 struct Type105 {
@@ -991,19 +661,349 @@ struct Type105 {
     terminator: u8,
 }
 
+struct Type27 {
+    header: Type13,
+    fname: Type14,
+    data: Type25,
+    footer: Type26,
+}
+
+enum Type32 {
+    le(u8, u8),
+    be(u8, u8),
+}
+
+struct Type49 {
+    marker: Type28,
+    length: u16,
+    data: Type48,
+}
+
+struct Type107 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    text_grid_left_position: u16,
+    text_grid_top_position: u16,
+    text_grid_width: u16,
+    text_grid_height: u16,
+    character_cell_width: u8,
+    character_cell_height: u8,
+    text_foreground_color_index: u8,
+    text_background_color_index: u8,
+    plain_text_data: Vec<Type7>,
+    terminator: u8,
+}
+
+enum Type11 {
+    graphic_block {
+        graphic_control_extension: Type5,
+        graphic_rendering_block: Type9,
+    },
+    special_purpose_block(Type10),
+}
+
+struct Type39 {
+    precision_table_id: u8,
+    elements: Vec<u8>,
+}
+
+enum Type66 {
+    no(u8),
+    yes(),
+}
+
+struct Type83 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type59,
+    crc: u32,
+}
+
+struct Type56 {
+    width: u32,
+    height: u32,
+    bit_depth: u8,
+    color_type: u8,
+    compression_method: u8,
+    filter_method: u8,
+    interlace_method: u8,
+}
+
 struct Type97 {
     xmp: Vec<u8>,
 }
 
-struct Type15 {
-    code: u16,
-    extra: u8,
+enum Type3 {
+    no(),
+    yes(Vec<Type2>),
 }
 
-struct Type59 {
-    pixels_per_unit_x: u32,
-    pixels_per_unit_y: u32,
-    unit_specifier: u8,
+struct Type98 {
+    version_major: u8,
+    version_minor: u8,
+    density_units: u8,
+    density_x: u16,
+    density_y: u16,
+    thumbnail_width: u8,
+    thumbnail_height: u8,
+    thumbnail_pixels: Vec<Vec<Type2>>,
+}
+
+struct Type82 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type58,
+    crc: u32,
+}
+
+enum Type36 {
+    other(Vec<u8>),
+    xmp { xmp: Vec<u8> },
+    exif { padding: u8, exif: Type35 },
+}
+
+enum Type63 {
+    bKGD {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type58,
+        crc: u32,
+    },
+    pHYs {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type59,
+        crc: u32,
+    },
+    PLTE {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Vec<Type2>,
+        crc: u32,
+    },
+    tIME {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type60,
+        crc: u32,
+    },
+    tRNS {
+        length: u32,
+        tag: (u8, u8, u8, u8),
+        data: Type62,
+        crc: u32,
+    },
+}
+
+enum Type30 {
+    other(Vec<u8>),
+    jfif {
+        version_major: u8,
+        version_minor: u8,
+        density_units: u8,
+        density_x: u16,
+        density_y: u16,
+        thumbnail_width: u8,
+        thumbnail_height: u8,
+        thumbnail_pixels: Vec<Vec<Type2>>,
+    },
+}
+
+enum Type62 {
+    color_type_3(Vec<Type61>),
+    color_type_2 { red: u16, green: u16, blue: u16 },
+    color_type_0 { greyscale: u16 },
+}
+
+struct Type42 {
+    restart_interval: u16,
+}
+
+struct Type2 {
+    r: u8,
+    g: u8,
+    b: u8,
+}
+
+struct Type7 {
+    len_bytes: u8,
+    data: Vec<u8>,
+}
+
+enum Type19 {
+    literal(u8),
+    reference { length: u16, distance: u16 },
+}
+
+struct Type65 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: (),
+    crc: u32,
+}
+
+struct Type53 {
+    num_lines: u16,
+}
+
+enum Type74 {
+    ascii(Vec<u8>),
+    utf8(Vec<char>),
+}
+
+struct Type77 {
+    header: Type0,
+    logical_screen: Type4,
+    blocks: Vec<Type11>,
+    trailer: Type12,
+}
+
+struct Type60 {
+    year: u16,
+    month: u8,
+    day: u8,
+    hour: u8,
+    minute: u8,
+    second: u8,
+}
+
+struct Type79 {
+    signature: (u8, u8, u8, u8, u8, u8, u8, u8),
+    ihdr: Type57,
+    chunks: Vec<Type63>,
+    idat: Vec<Type64>,
+    more_chunks: Vec<Type63>,
+    iend: Type65,
+}
+
+struct Type86 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type62,
+    crc: u32,
+}
+
+struct Type90 {
+    marker: Type28,
+    length: u16,
+    data: Type45,
+}
+
+struct Type94 {
+    marker: Type28,
+    length: u16,
+    data: Type42,
+}
+
+struct Type96 {
+    padding: u8,
+    exif: Type35,
+}
+
+enum Type20 {
+    none(),
+    some {
+        length_extra_bits: u8,
+        length: u16,
+        distance_code: u8,
+        distance_record: Type16,
+    },
+}
+
+enum Type54 {
+    some {
+        marker: Type28,
+        length: u16,
+        data: Type53,
+    },
+    none(),
+}
+
+struct Type48 {
+    num_image_components: u8,
+    image_components: Vec<Type47>,
+    start_spectral_selection: u8,
+    end_spectral_selection: u8,
+    approximation_bit_position: u8,
+}
+
+struct Type100 {
+    codes: Vec<Type21>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type101 {
+    hlit: u8,
+    hdist: u8,
+    hclen: u8,
+    code_length_alphabet_code_lengths: Vec<u8>,
+    literal_length_distance_alphabet_code_lengths: Vec<Type15>,
+    literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
+    literal_length_alphabet_code_lengths_value: Vec<u8>,
+    distance_alphabet_code_lengths_value: Vec<u8>,
+    codes: Vec<Type18>,
+    codes_values: Vec<Type19>,
+}
+
+struct Type103 {
+    separator: u8,
+    label: u8,
+    block_size: u8,
+    identifier: Vec<u8>,
+    authentication_code: Vec<u8>,
+    application_data: Vec<Type7>,
+    terminator: u8,
+}
+
+struct Type102 {
+    graphic_control_extension: Type5,
+    graphic_rendering_block: Type9,
+}
+
+struct Type106 {
+    descriptor: Type6,
+    local_color_table: Type3,
+    data: Type8,
+}
+
+struct Type93 {
+    marker: Type28,
+    length: u16,
+    data: Type41,
+}
+
+enum Type5 {
+    some {
+        separator: u8,
+        label: u8,
+        block_size: u8,
+        flags: u8,
+        delay_time: u16,
+        transparent_color_index: u8,
+        terminator: u8,
+    },
+    none(),
+}
+
+struct Type85 {
+    length: u32,
+    tag: (u8, u8, u8, u8),
+    data: Type60,
+    crc: u32,
+}
+
+enum Type38 {
+    app0 {
+        marker: Type28,
+        length: u16,
+        data: Type31,
+    },
+    app1 {
+        marker: Type28,
+        length: u16,
+        data: Type37,
+    },
 }
 
 fn Decoder0<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type76> {
@@ -3177,14 +3177,7 @@ fn Decoder135<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Optio
 fn Decoder136<'input>(scope: &mut Scope, input: &mut ParseCtxt<'input>) -> Option<Type7> {
     let len_bytes = {
         let b = input.read_byte()?;
-        if ByteSet::from_bits([
-            18446744073709551614,
-            18446744073709551615,
-            18446744073709551615,
-            18446744073709551615,
-        ])
-        .contains(b)
-        {
+        if b != 0 {
             b
         } else {
             return None;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -325,6 +325,37 @@ fn embed_byteset(bs: &ByteSet) -> RustExpr {
     ])])
 }
 
+fn name_for_decoder(dec: &Decoder) -> &'static str {
+    match dec {
+        Decoder::Call(_, _) => "Call",
+        Decoder::Fail => "Fail",
+        Decoder::EndOfInput => "EndOfInput",
+        Decoder::Align(_) => "Align",
+        Decoder::Byte(_) => "Byte",
+        Decoder::Variant(_, _) => "Variant",
+        Decoder::Parallel(_) => "Parallel",
+        Decoder::Branch(_, _) => "Branch",
+        Decoder::Tuple(_) => "Tuple",
+        Decoder::Record(_) => "Record",
+        Decoder::While(_, _) => "While",
+        Decoder::Until(_, _) => "Until",
+        Decoder::RepeatCount(_, _) => "RepeatCount",
+        Decoder::RepeatUntilLast(_, _) => "RepeatUntilLast",
+        Decoder::RepeatUntilSeq(_, _) => "RepeatUntilSeq",
+        Decoder::Peek(_) => "Peek",
+        Decoder::PeekNot(_) => "PeekNot",
+        Decoder::Slice(_, _) => "Slice",
+        Decoder::Bits(_) => "Bits",
+        Decoder::WithRelativeOffset(_, _) => "WithRelativeOffset",
+        Decoder::Map(_, _) => "Map",
+        Decoder::Compute(_) => "Compute",
+        Decoder::Let(_, _, _) => "Let",
+        Decoder::Match(_, _) => "Match",
+        Decoder::Dynamic(_, _, _) => "Dynamic",
+        Decoder::Apply(_) => "Apply",
+    }
+}
+
 // FIXME - implement something that actually works
 fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
     match decoder {
@@ -401,10 +432,7 @@ fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
         other => {
             let let_tmp = RustStmt::assign(
                 "tmp",
-                RustExpr::str_lit(format!(
-                    "invoke_decoder @ {:?}",
-                    std::mem::discriminant(other)
-                )),
+                RustExpr::str_lit(format!("invoke_decoder @ {}", name_for_decoder(other))),
             );
             RustExpr::BlockScope(
                 vec![let_tmp],

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -217,7 +217,7 @@ impl Codegen {
                                         let cl_inner = self.translate(inner, Some(&RustType::AnonTuple(typs.clone())));
                                         CaseLogic::Derived(DerivedLogic::VariantOf(qname, Box::new(cl_inner)))
                                     }
-                                    Some(RustVariant::Record(_, fields)) => {
+                                    Some(RustVariant::Record(_, _fields)) => {
                                         // FIXME - this is much harder to implement as Records cannot be anonymous
                                         todo!("VariantOf @ RustVariant::Record")
                                     }
@@ -307,9 +307,11 @@ impl Codegen {
     }
 }
 
+#[allow(dead_code)]
 type RustBlock = (Vec<RustStmt>, Option<RustExpr>);
 
 #[derive(Clone, Copy)]
+#[allow(dead_code)]
 struct ProdCtxt<'a> {
     input_varname: &'a Label,
     scope_varname: &'a Label,
@@ -324,6 +326,7 @@ impl CaseLogic {
     ///
     /// Local bindings and control flow are allowed, as long as an explicit return
     /// or a concrete, consistently typed return value are used
+    #[allow(dead_code)]
     fn to_ast(&self, ctxt: ProdCtxt<'_>) -> RustBlock {
         match self {
             CaseLogic::Simple(s) => s.to_ast(ctxt),
@@ -759,7 +762,7 @@ impl OtherLogic {
 
 /// this production should be a RustExpr whose compiled type is usize, and whose
 /// runtime value is the index of the successful match relative to the input
-fn invoke_matchtree(tree: &MatchTree, ctxt: ProdCtxt<'_>) -> RustExpr {
+fn invoke_matchtree(_tree: &MatchTree, _ctxt: ProdCtxt<'_>) -> RustExpr {
     RustExpr::local("unimplemented!").call_with([RustExpr::str_lit("invoke_matchtree")])
 }
 
@@ -769,9 +772,9 @@ enum ParallelLogic {
     Alts(Vec<CaseLogic>),
 }
 impl ParallelLogic {
-    fn to_ast(&self, ctxt: ProdCtxt<'_>) -> RustBlock {
+    fn to_ast(&self, _ctxt: ProdCtxt<'_>) -> RustBlock {
         match self {
-            ParallelLogic::Alts(alts) => {
+            ParallelLogic::Alts(_alts) => {
                 // FIMXE - no proper model for Parallel parsing yet
                 (
                     Vec::new(),
@@ -802,10 +805,10 @@ enum DerivedLogic {
 }
 
 impl DerivedLogic {
-    fn to_ast(&self, ctxt: ProdCtxt<'_>) -> (Vec<RustStmt>, Option<RustExpr>) {
+    fn to_ast(&self, _ctxt: ProdCtxt<'_>) -> (Vec<RustStmt>, Option<RustExpr>) {
         match self {
             // FIXME - variants cannot be modelled as atomic operations within the current framework
-            DerivedLogic::VariantOf(vname, logic) => (
+            DerivedLogic::VariantOf(_vname, _logic) => (
                 Vec::new(),
                 Some(
                     RustExpr::local("unimplemented!")

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -190,7 +190,6 @@ impl Codegen {
         }
     }
 
-    #[allow(dead_code)]
     fn translate(&self, decoder: &Decoder, type_hint: Option<&RustType>) -> CaseLogic {
         match decoder {
             Decoder::Call(ix, args) => CaseLogic::Simple(SimpleLogic::Invoke(*ix, args.clone())),
@@ -547,7 +546,7 @@ fn embed_expr(expr: &Expr) -> RustExpr {
                     (
                         // FIXME - add actual type_hint when possible
                         MatchCaseLHS::Pattern(embed_pattern(pat, None)),
-                        vec![RustStmt::Expr(embed_expr(rhs))],
+                        vec![RustStmt::Return(false, embed_expr(rhs))],
                     )
                 })
                 .collect(),

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -880,7 +880,9 @@ fn embed_matchtree(tree: &MatchTree, ctxt: ProdCtxt<'_>) -> RustBlock {
 
         let bind = RustStmt::assign(
             "b",
-            RustExpr::local(ctxt.input_varname.clone()).call_method("read_byte"),
+            RustExpr::local(ctxt.input_varname.clone())
+                .call_method("read_byte")
+                .wrap_try(),
         );
 
         if tree.branches.len() == 1 {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -186,6 +186,7 @@ impl Codegen {
         }
     }
 
+    #[allow(dead_code)]
     fn translate(&self, decoder: &Decoder, type_hint: Option<&RustType>) -> CaseLogic {
         match decoder {
             Decoder::Call(ix, args) => CaseLogic::Simple(SimpleLogic::Invoke(*ix, args.clone())),
@@ -298,7 +299,7 @@ fn decoder_fn(ix: usize, t: &RustType, decoder: &Decoder) -> RustFn {
                 let ty = {
                     let mut params = RustParams::<RustLt, RustType>::new();
                     params.push_lifetime(RustLt::Parametric("'input".into()));
-                    RustType::verbatim("ReadCtxt", Some(params))
+                    RustType::Atom(AtomType::Comp(CompType::Borrow(None, Mut::Mutable, Box::new(RustType::verbatim("ParseCtxt", Some(params))))))
                 };
                 (name, ty)
             };
@@ -328,7 +329,7 @@ fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
             // it is harder to write, but much more efficient, to cut the buffer at the right place
             let cond = RustExpr::infix(
                 RustExpr::infix(
-                    RustExpr::local("input").field("offset"),
+                    RustExpr::local("input").call_method("offset"),
                     " % ",
                     RustExpr::NumericLit(*factor),
                 ),
@@ -337,14 +338,12 @@ fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
             );
             let body = {
                 let let_tmp = RustStmt::assign(
-                    "tmp",
+                    "_",
                     RustExpr::local(input_varname.clone())
                         .call_method("read_byte")
                         .wrap_try(),
                 );
-                let rebind =
-                    RustStmt::Reassign(input_varname.clone(), RustExpr::local("tmp").nth(1));
-                vec![let_tmp, rebind]
+                vec![let_tmp]
             };
             RustExpr::BlockScope(
                 vec![RustStmt::Control(RustControl::While(cond, body))],
@@ -357,43 +356,35 @@ fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
         ),
         Decoder::EndOfInput => {
             let call = RustExpr::local(input_varname.clone()).call_method("read_byte");
-            let bind = RustStmt::assign("tmp", call);
-            let cond = RustExpr::local("tmp").call_method("is_none");
+            let cond = call.call_method("is_none");
             let b_true = [
-                RustStmt::Reassign(input_varname.clone(), RustExpr::local("tmp").nth(1)),
                 RustStmt::Return(false, RustExpr::UNIT),
             ];
             let b_false = [RustStmt::Return(true, RustExpr::NONE)];
-            RustExpr::BlockScope(
-                vec![bind],
-                Box::new(RustExpr::Control(Box::new(RustControl::If(
+                RustExpr::Control(Box::new(RustControl::If(
                     cond,
                     b_true.to_vec(),
                     Some(b_false.to_vec()),
-                )))),
-            )
+                )))
         }
         Decoder::Byte(bs) => {
             // FIXME - we have multiple options to handle this, none of them simple
             let bs_let = RustStmt::assign("bs", embed_byteset(bs));
 
-            let call = RustExpr::local("input").call_method("read_byte").wrap_try();
-
-            let bind = RustStmt::assign("tmp", call);
-            let b_let = RustStmt::assign("b", RustExpr::local("tmp").nth(0));
+            let call = RustExpr::local(input_varname.clone()).call_method("read_byte").wrap_try();
+            let b_let = RustStmt::assign("b", call);
 
             let logic = {
                 let cond =
                     RustExpr::local("bs").call_method_with("contains", [RustExpr::local("b")]);
                 let b_true = vec![
-                    RustStmt::Reassign(input_varname.clone(), RustExpr::local("tmp").nth(1)),
                     RustStmt::Return(false, RustExpr::local("b")),
                 ];
                 let b_false = vec![RustStmt::Return(true, RustExpr::local("None"))];
                 RustExpr::Control(Box::new(RustControl::If(cond, b_true, Some(b_false))))
             };
 
-            RustExpr::BlockScope([bs_let, bind, b_let].to_vec(), Box::new(logic))
+            RustExpr::BlockScope([bs_let, b_let].to_vec(), Box::new(logic))
         }
         // FIXME - not sure what to do with _args ...
         Decoder::Call(ix_dec, _args) => {
@@ -402,12 +393,15 @@ fn invoke_decoder(decoder: &Decoder, input_varname: &Label) -> RustExpr {
                 RustExpr::local("scope"),
                 RustExpr::local(input_varname.clone()),
             ]);
-            let bind = RustStmt::assign("tmp", call.wrap_try());
-            let replace = RustStmt::Reassign(input_varname.clone(), RustExpr::local("tmp").nth(1));
-            let ret = RustExpr::local("tmp").nth(0);
-            RustExpr::BlockScope(vec![bind, replace], Box::new(ret))
+            call.wrap_try()
         }
-        _ => RustExpr::local("unimplemented!").call_with([RustExpr::str_lit("invoke_decoder")]),
+        Decoder::Tuple(elts) if elts.is_empty() => {
+            RustExpr::UNIT
+        }
+        other => {
+            let let_tmp = RustStmt::assign("tmp", RustExpr::str_lit(format!("invoke_decoder @ {:?}", std::mem::discriminant(other))));
+            RustExpr::BlockScope(vec![let_tmp], Box::new(RustExpr::local("unimplemented!").call_with([RustExpr::str_lit("{}"), RustExpr::local("tmp")])))
+        }
     }
 }
 
@@ -466,16 +460,8 @@ pub enum DerivedLogic {
 
 fn decoder_body(decoder: &Decoder, return_type: &RustType) -> Vec<rust_ast::RustStmt> {
     // FIXME - double-check this won't clash with any local assignments in Decoder expansion
-    let inp_varname: Label = "inp".into();
+    let inp_varname: Label = "input".into();
     let mut body = Vec::new();
-
-    let init = RustStmt::Let(
-        Mut::Mutable,
-        inp_varname.clone(),
-        None,
-        RustExpr::local("input"),
-    );
-    body.push(init);
 
     match decoder {
         Decoder::Tuple(elems) => {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1021,7 +1021,7 @@ impl RepeatLogic {
                     ))
                 };
                 stmts.push(ctrl);
-                (stmts, Some(RustExpr::some(RustExpr::local("accum"))))
+                (stmts, Some(RustExpr::local("accum")))
             }
             RepeatLogic::BreakOnMatch(btree, elt) => {
                 let mut stmts = Vec::new();
@@ -1058,7 +1058,7 @@ impl RepeatLogic {
                     ))
                 };
                 stmts.push(ctrl);
-                (stmts, Some(RustExpr::some(RustExpr::local("accum"))))
+                (stmts, Some(RustExpr::local("accum")))
             }
             RepeatLogic::ExactCount(expr_n, elt) => {
                 let mut stmts = Vec::new();
@@ -1081,7 +1081,7 @@ impl RepeatLogic {
                     body,
                 )));
 
-                (stmts, Some(RustExpr::some(RustExpr::local("accum"))))
+                (stmts, Some(RustExpr::local("accum")))
             }
             RepeatLogic::ConditionTerminal(tpred, elt) => {
                 let mut stmts = Vec::new();
@@ -1119,7 +1119,7 @@ impl RepeatLogic {
                     ))
                 };
                 stmts.push(ctrl);
-                (stmts, Some(RustExpr::some(RustExpr::local("accum"))))
+                (stmts, Some(RustExpr::local("accum")))
             }
             RepeatLogic::ConditionComplete(cpred, elt) => {
                 let mut stmts = Vec::new();
@@ -1149,7 +1149,7 @@ impl RepeatLogic {
                     ))
                 };
                 stmts.push(ctrl);
-                (stmts, Some(RustExpr::some(RustExpr::local("accum"))))
+                (stmts, Some(RustExpr::local("accum")))
             }
         }
     }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -580,18 +580,10 @@ fn embed_expr(expr: &Expr) -> RustExpr {
             Box::new(embed_expr(x)),
             PrimType::U32.into(),
         )),
-        Expr::U16Be(be_bytes) => {
-            RustExpr::scoped(["u16"], "from_be_bytes").call_with([embed_expr(be_bytes)])
-        }
-        Expr::U16Le(le_bytes) => {
-            RustExpr::scoped(["u16"], "from_le_bytes").call_with([embed_expr(le_bytes)])
-        }
-        Expr::U32Be(be_bytes) => {
-            RustExpr::scoped(["u32"], "from_be_bytes").call_with([embed_expr(be_bytes)])
-        }
-        Expr::U32Le(le_bytes) => {
-            RustExpr::scoped(["u32"], "from_le_bytes").call_with([embed_expr(le_bytes)])
-        }
+        Expr::U16Be(be_bytes) => RustExpr::local("u16be").call_with([embed_expr(be_bytes)]),
+        Expr::U16Le(le_bytes) => RustExpr::local("u16le").call_with([embed_expr(le_bytes)]),
+        Expr::U32Be(be_bytes) => RustExpr::local("u32be").call_with([embed_expr(be_bytes)]),
+        Expr::U32Le(le_bytes) => RustExpr::local("u32le").call_with([embed_expr(le_bytes)]),
         Expr::AsChar(codepoint) => RustExpr::scoped(["char"], "from_u32")
             .call_with([embed_expr(codepoint)])
             .call_method("unwrap"),

--- a/src/codegen/rust_ast.rs
+++ b/src/codegen/rust_ast.rs
@@ -746,6 +746,7 @@ pub(crate) enum RustExpr {
 
 #[derive(Debug, Clone)]
 pub(crate) enum RustOp {
+    // scaffolding to allow for flexible infix operations from operator tokens; should contain spaces already
     InfixOp(&'static str, Box<RustExpr>, Box<RustExpr>),
 }
 

--- a/src/codegen/rust_ast.rs
+++ b/src/codegen/rust_ast.rs
@@ -425,6 +425,16 @@ pub(crate) enum RustVariant {
     Record(Label, Vec<(Label, RustType)>),
 }
 
+impl RustVariant {
+    pub(crate) fn get_label(&self) -> &Label {
+        match self {
+            RustVariant::Unit(lab) | RustVariant::Tuple(lab, _) | RustVariant::Record(lab, _) => {
+                lab
+            }
+        }
+    }
+}
+
 impl ToFragment for RustVariant {
     fn to_fragment(&self) -> Fragment {
         match self {

--- a/src/codegen/rust_ast.rs
+++ b/src/codegen/rust_ast.rs
@@ -407,7 +407,7 @@ fn replace_bad(input: &str) -> String {
             ret.push('_');
             ret.push(c);
             dashed = false;
-        } else if is_valid(0, c) {
+        } else if is_valid(ret.len(), c) {
             ret.push(c);
             dashed = false;
         } else if !dashed {
@@ -828,9 +828,8 @@ impl ToFragment for RustExpr {
         match self {
             RustExpr::Entity(e) => e.to_fragment(),
             RustExpr::NumericLit(n) => Fragment::DisplayAtom(Rc::new(*n)),
-            RustExpr::StringLit(s) => s
-                .to_fragment()
-                .delimit(Fragment::Char('"'), Fragment::Char('"')),
+            RustExpr::StringLit(s) => Fragment::String(s.clone())
+                .delimit(Fragment::string("r#\""), Fragment::string("\"#")),
             RustExpr::ArrayLit(elts) => Fragment::seq(
                 elts.iter().map(RustExpr::to_fragment),
                 Some(Fragment::string(", ")),

--- a/src/codegen/rust_ast.rs
+++ b/src/codegen/rust_ast.rs
@@ -1096,7 +1096,7 @@ pub(crate) enum RustPattern {
     PrimLiteral(RustPrimLit),
     TupleLiteral(Vec<RustPattern>),
     ArrayLiteral(Vec<RustPattern>),
-    CatchAll(Option<Label>), // None <- `_`, Some("x") for `x`
+    CatchAll(Option<Label>),          // None <- `_`, Some("x") for `x`
     Variant(Label, Box<RustPattern>), // FIXME - need to attach enum scope
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod decoder;
 pub mod error;
 
 pub mod output;
+mod precedence;
 pub mod prelude;
 pub mod read;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1429,7 +1429,9 @@ impl<'a> MatchTreeLevel<'a> {
             Some(tree)
         } else if depth > 0 {
             let mut tree = Self::reject();
-            for (i, next) in nexts {
+            let mut tmp = Vec::from_iter(nexts.into_iter());
+            tmp.sort_by_key(|(ix, _)| *ix);
+            for (i, next) in tmp.into_iter() {
                 let subtree = MatchTreeStep::from_next(module, next);
                 tree = tree.merge_step(i, subtree).ok()?;
             }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{MultiScope, Scope, SingleScope, Value};
+use crate::precedence::{cond_paren, Precedence};
 use crate::Label;
 use crate::{DynFormat, Expr, Format, FormatModule};
 
@@ -923,42 +924,42 @@ impl<'module> MonoidalPrinter<'module> {
             Expr::AsU8(expr) => cond_paren(
                 self.compile_prefix("as-u8", None, expr),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::AsU16(expr) => cond_paren(
                 self.compile_prefix("as-u16", None, expr),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::AsU32(expr) => cond_paren(
                 self.compile_prefix("as-u32", None, expr),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::AsChar(expr) => cond_paren(
                 self.compile_prefix("as-char", None, expr),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::U16Be(bytes) => cond_paren(
                 self.compile_prefix("u16be", None, bytes),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::U16Le(bytes) => cond_paren(
                 self.compile_prefix("u16le", None, bytes),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::U32Be(bytes) => cond_paren(
                 self.compile_prefix("u32be", None, bytes),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::U32Le(bytes) => cond_paren(
                 self.compile_prefix("u32le", None, bytes),
                 prec,
-                Precedence::CAST,
+                Precedence::CAST_PREFIX,
             ),
             Expr::SeqLength(seq) => cond_paren(
                 self.compile_prefix("seq-length", None, seq),
@@ -1238,199 +1239,5 @@ impl<'module> MonoidalPrinter<'module> {
             Format::Record(fields) if fields.is_empty() => Fragment::String("{}".into()),
             Format::Record(_) => Fragment::String("{ ... }".into()),
         }
-    }
-}
-
-/// Operator Precedence classes
-///
-///
-#[derive(Copy, Clone, Debug, Default)]
-enum Precedence {
-    Atomic, // Highest precedence
-    Projection,
-    Prefix, // Highest natural precedence
-    ArithInfix(ArithLevel),
-    BitwiseInfix(BitwiseLevel),
-    Comparison(CompareLevel), // Unsound when chained
-    Calculus,                 // Arrow and Match
-    #[default]
-    Top,        // Entry level for neutral context
-}
-
-#[derive(Copy, Clone, Debug)]
-enum CompareLevel {
-    Comparison = 0, // Highest comparative precedence
-    Equality,
-}
-
-#[derive(Copy, Clone, Debug)]
-enum ArithLevel {
-    DivRem = 0, // Highest arithmetic precedence
-    Mul,
-    AddSub,
-}
-
-#[derive(Copy, Clone, Debug)]
-#[repr(u8)]
-enum BitwiseLevel {
-    Shift = 0, // Highest bitwise precedence
-    And = 1,
-    Or = 2,
-}
-
-/// Intransitive partial relation over operator subclasses
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
-enum Relation {
-    /// `.<`
-    Inferior,
-    /// `.=`
-    Congruent,
-    /// ``.>`
-    Superior,
-    /// ``><``
-    Disjoint,
-}
-
-trait IntransitiveOrd {
-    fn relate(&self, other: &Self) -> Relation;
-
-    fn inferior(&self, other: &Self) -> bool {
-        matches!(self.relate(other), Relation::Inferior)
-    }
-
-    fn superior(&self, other: &Self) -> bool {
-        matches!(self.relate(other), Relation::Superior)
-    }
-
-    fn congruent(&self, other: &Self) -> bool {
-        matches!(self.relate(other), Relation::Congruent)
-    }
-
-    fn disjoint(&self, other: &Self) -> bool {
-        matches!(self.relate(other), Relation::Disjoint)
-    }
-}
-
-impl IntransitiveOrd for CompareLevel {
-    fn relate(&self, other: &Self) -> Relation {
-        match (self, other) {
-            (Self::Comparison, Self::Comparison) | (Self::Equality, Self::Equality) => {
-                Relation::Congruent
-            }
-            (Self::Comparison, Self::Equality) => Relation::Disjoint,
-            (Self::Equality, Self::Comparison) => Relation::Disjoint,
-        }
-    }
-}
-
-impl IntransitiveOrd for ArithLevel {
-    fn relate(&self, other: &Self) -> Relation {
-        match (self, other) {
-            (Self::DivRem, Self::DivRem)
-            | (Self::Mul, Self::Mul)
-            | (Self::AddSub, Self::AddSub) => Relation::Congruent,
-            (Self::DivRem, Self::Mul) | (Self::Mul, Self::DivRem) => Relation::Disjoint,
-            (Self::AddSub, _) => Relation::Inferior,
-            (_, Self::AddSub) => Relation::Superior,
-        }
-    }
-}
-
-impl IntransitiveOrd for BitwiseLevel {
-    fn relate(&self, other: &Self) -> Relation {
-        match (self, other) {
-            (BitwiseLevel::Shift, BitwiseLevel::Shift) => Relation::Congruent,
-            (BitwiseLevel::Shift, _) => Relation::Superior,
-            (_, BitwiseLevel::Shift) => Relation::Inferior,
-            (BitwiseLevel::And, BitwiseLevel::And) => Relation::Congruent,
-            (BitwiseLevel::And, BitwiseLevel::Or) => Relation::Superior,
-            (BitwiseLevel::Or, BitwiseLevel::And) => Relation::Inferior,
-            (BitwiseLevel::Or, BitwiseLevel::Or) => Relation::Congruent,
-        }
-    }
-}
-
-/// Rules:
-///   x .= x
-///   Atomic .> Proj .> Prefix .> *Infix .> Comparison .> Calculus .> Top
-///   rel(x, y) = rel(ArithInfix(x), ArithInfix(y))
-///   rel(x, y) = rel(BitwiseInfix(x), BitwiseInfix(y))
-///   Bitwise(_) >< Arith(_)
-impl IntransitiveOrd for Precedence {
-    fn relate(&self, other: &Self) -> Relation {
-        match (self, other) {
-            // Trivial Congruences
-            (Self::Atomic, Self::Atomic) => Relation::Congruent,
-            (Self::Projection, Self::Projection) => Relation::Congruent,
-            (Self::Prefix, Self::Prefix) => Relation::Congruent,
-            (Self::Calculus, Self::Calculus) => Relation::Congruent,
-            (Self::Top, Self::Top) => Relation::Congruent,
-
-            // Descending relations
-            (Self::Atomic, _) => Relation::Superior,
-            (_, Self::Atomic) => Relation::Superior,
-            (Self::Projection, _) => Relation::Superior,
-            (_, Self::Projection) => Relation::Inferior,
-            (Self::Prefix, _) => Relation::Superior,
-            (_, Self::Prefix) => Relation::Inferior,
-
-            // Ascending relations
-            (Self::Top, _) => Relation::Inferior,
-            (_, Self::Top) => Relation::Superior,
-            (Self::Calculus, _) => Relation::Inferior,
-            (_, Self::Calculus) => Relation::Superior,
-
-            // Implications
-            (Self::ArithInfix(x), Self::ArithInfix(y)) => x.relate(y),
-            (Self::BitwiseInfix(x), Self::BitwiseInfix(y)) => x.relate(y),
-            (Self::Comparison(x), Self::Comparison(y)) => x.relate(y),
-
-            // Ascending relations (continued)
-            (Self::Comparison(_), _) => Relation::Inferior,
-            (_, Self::Comparison(_)) => Relation::Superior,
-
-            // Disjunctions
-            (Self::ArithInfix(_), Self::BitwiseInfix(_)) => Relation::Disjoint,
-            (Self::BitwiseInfix(_), Self::ArithInfix(_)) => Relation::Disjoint,
-        }
-    }
-}
-
-impl Precedence {
-    #![allow(dead_code)]
-    const TOP: Self = Precedence::Top;
-    const ARROW: Self = Precedence::Calculus;
-    const MATCH: Self = Precedence::Calculus;
-    const COMPARE: Self = Precedence::Comparison(CompareLevel::Comparison);
-    const EQUALITY: Self = Precedence::Comparison(CompareLevel::Equality);
-    const BITOR: Self = Precedence::BitwiseInfix(BitwiseLevel::Or);
-    const ADDSUB: Self = Precedence::ArithInfix(ArithLevel::AddSub);
-    const BITAND: Self = Precedence::BitwiseInfix(BitwiseLevel::And);
-    const DIVREM: Self = Precedence::ArithInfix(ArithLevel::DivRem);
-    const MUL: Self = Precedence::ArithInfix(ArithLevel::Mul);
-    const BITSHIFT: Self = Precedence::BitwiseInfix(BitwiseLevel::Shift);
-    const FUNAPP: Self = Precedence::Prefix;
-    const CAST: Self = Precedence::Prefix;
-    const PROJ: Self = Precedence::Projection;
-    const ATOM: Self = Precedence::Atomic;
-
-    const FORMAT_COMPOUND: Self = Self::Top;
-    const FORMAT_ATOM: Self = Self::Atomic;
-
-    fn bump_format(&self) -> Self {
-        match self {
-            Precedence::Top => Precedence::Atomic,
-            Precedence::Atomic => Precedence::Atomic,
-            _ => unreachable!("Unexpected non-format precedence level {self:?}"),
-        }
-    }
-}
-
-fn cond_paren(frag: Fragment, current: Precedence, cutoff: Precedence) -> Fragment {
-    match current.relate(&cutoff) {
-        Relation::Disjoint | Relation::Superior => {
-            Fragment::Char('(').cat(frag).cat(Fragment::Char(')'))
-        }
-        Relation::Congruent | Relation::Inferior => frag,
     }
 }

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -1,0 +1,196 @@
+use crate::output::Fragment;
+
+/// Operator Precedence classes
+///
+///
+#[derive(Copy, Clone, Debug, Default)]
+pub(crate) enum Precedence {
+    Atomic, // Highest precedence
+    Projection,
+    Prefix, // Highest natural precedence
+    ArithInfix(ArithLevel),
+    BitwiseInfix(BitwiseLevel),
+    Comparison(CompareLevel), // Unsound when chained
+    Calculus,                 // Arrow and Match
+    #[default]
+    Top,        // Entry level for neutral context
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum CompareLevel {
+    Comparison = 0, // Highest comparative precedence
+    Equality,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum ArithLevel {
+    DivRem = 0, // Highest arithmetic precedence
+    Mul,
+    AddSub,
+}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(u8)]
+pub(crate) enum BitwiseLevel {
+    Shift = 0, // Highest bitwise precedence
+    And = 1,
+    Or = 2,
+}
+
+/// Intransitive partial relation over operator subclasses
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum Relation {
+    /// `.<`
+    Inferior,
+    /// `.=`
+    Congruent,
+    /// `.>`
+    Superior,
+    /// `><`
+    Disjoint,
+}
+
+pub(crate) trait IntransitiveOrd {
+    fn relate(&self, other: &Self) -> Relation;
+
+    fn inferior(&self, other: &Self) -> bool {
+        matches!(self.relate(other), Relation::Inferior)
+    }
+
+    fn superior(&self, other: &Self) -> bool {
+        matches!(self.relate(other), Relation::Superior)
+    }
+
+    fn congruent(&self, other: &Self) -> bool {
+        matches!(self.relate(other), Relation::Congruent)
+    }
+
+    fn disjoint(&self, other: &Self) -> bool {
+        matches!(self.relate(other), Relation::Disjoint)
+    }
+}
+
+impl IntransitiveOrd for CompareLevel {
+    fn relate(&self, other: &Self) -> Relation {
+        match (self, other) {
+            (Self::Comparison, Self::Comparison) | (Self::Equality, Self::Equality) => {
+                Relation::Congruent
+            }
+            (Self::Comparison, Self::Equality) => Relation::Disjoint,
+            (Self::Equality, Self::Comparison) => Relation::Disjoint,
+        }
+    }
+}
+
+impl IntransitiveOrd for ArithLevel {
+    fn relate(&self, other: &Self) -> Relation {
+        match (self, other) {
+            (Self::DivRem, Self::DivRem)
+            | (Self::Mul, Self::Mul)
+            | (Self::AddSub, Self::AddSub) => Relation::Congruent,
+            (Self::DivRem, Self::Mul) | (Self::Mul, Self::DivRem) => Relation::Disjoint,
+            (Self::AddSub, _) => Relation::Inferior,
+            (_, Self::AddSub) => Relation::Superior,
+        }
+    }
+}
+
+impl IntransitiveOrd for BitwiseLevel {
+    fn relate(&self, other: &Self) -> Relation {
+        match (self, other) {
+            (BitwiseLevel::Shift, BitwiseLevel::Shift) => Relation::Congruent,
+            (BitwiseLevel::Shift, _) => Relation::Superior,
+            (_, BitwiseLevel::Shift) => Relation::Inferior,
+            (BitwiseLevel::And, BitwiseLevel::And) => Relation::Congruent,
+            (BitwiseLevel::And, BitwiseLevel::Or) => Relation::Superior,
+            (BitwiseLevel::Or, BitwiseLevel::And) => Relation::Inferior,
+            (BitwiseLevel::Or, BitwiseLevel::Or) => Relation::Congruent,
+        }
+    }
+}
+
+/// Rules:
+///   x .= x
+///   Atomic .> Proj .> Prefix .> *Infix .> Comparison .> Calculus .> Top
+///   rel(x, y) = rel(ArithInfix(x), ArithInfix(y))
+///   rel(x, y) = rel(BitwiseInfix(x), BitwiseInfix(y))
+///   Bitwise(_) >< Arith(_)
+impl IntransitiveOrd for Precedence {
+    fn relate(&self, other: &Self) -> Relation {
+        match (self, other) {
+            // Trivial Congruences
+            (Self::Atomic, Self::Atomic) => Relation::Congruent,
+            (Self::Projection, Self::Projection) => Relation::Congruent,
+            (Self::Prefix, Self::Prefix) => Relation::Congruent,
+            (Self::Calculus, Self::Calculus) => Relation::Congruent,
+            (Self::Top, Self::Top) => Relation::Congruent,
+
+            // Descending relations
+            (Self::Atomic, _) => Relation::Superior,
+            (_, Self::Atomic) => Relation::Superior,
+            (Self::Projection, _) => Relation::Superior,
+            (_, Self::Projection) => Relation::Inferior,
+            (Self::Prefix, _) => Relation::Superior,
+            (_, Self::Prefix) => Relation::Inferior,
+
+            // Ascending relations
+            (Self::Top, _) => Relation::Inferior,
+            (_, Self::Top) => Relation::Superior,
+            (Self::Calculus, _) => Relation::Inferior,
+            (_, Self::Calculus) => Relation::Superior,
+
+            // Implications
+            (Self::ArithInfix(x), Self::ArithInfix(y)) => x.relate(y),
+            (Self::BitwiseInfix(x), Self::BitwiseInfix(y)) => x.relate(y),
+            (Self::Comparison(x), Self::Comparison(y)) => x.relate(y),
+
+            // Ascending relations (continued)
+            (Self::Comparison(_), _) => Relation::Inferior,
+            (_, Self::Comparison(_)) => Relation::Superior,
+
+            // Disjunctions
+            (Self::ArithInfix(_), Self::BitwiseInfix(_)) => Relation::Disjoint,
+            (Self::BitwiseInfix(_), Self::ArithInfix(_)) => Relation::Disjoint,
+        }
+    }
+}
+
+impl Precedence {
+    #![allow(dead_code)]
+    pub(crate) const TOP: Self = Precedence::Top;
+    pub(crate) const ARROW: Self = Precedence::Calculus;
+    pub(crate) const MATCH: Self = Precedence::Calculus;
+    pub(crate) const COMPARE: Self = Precedence::Comparison(CompareLevel::Comparison);
+    pub(crate) const EQUALITY: Self = Precedence::Comparison(CompareLevel::Equality);
+    pub(crate) const BITOR: Self = Precedence::BitwiseInfix(BitwiseLevel::Or);
+    pub(crate) const ADDSUB: Self = Precedence::ArithInfix(ArithLevel::AddSub);
+    pub(crate) const BITAND: Self = Precedence::BitwiseInfix(BitwiseLevel::And);
+    pub(crate) const DIVREM: Self = Precedence::ArithInfix(ArithLevel::DivRem);
+    pub(crate) const MUL: Self = Precedence::ArithInfix(ArithLevel::Mul);
+    pub(crate) const BITSHIFT: Self = Precedence::BitwiseInfix(BitwiseLevel::Shift);
+    pub(crate) const FUNAPP: Self = Precedence::Prefix;
+    pub(crate) const CAST_INFIX: Self = Precedence::Calculus;
+    pub(crate) const CAST_PREFIX: Self = Precedence::Prefix;
+    pub(crate) const PROJ: Self = Precedence::Projection;
+    pub(crate) const ATOM: Self = Precedence::Atomic;
+
+    pub(crate) const FORMAT_COMPOUND: Self = Self::Top;
+    pub(crate) const FORMAT_ATOM: Self = Self::Atomic;
+
+    pub(crate) fn bump_format(&self) -> Self {
+        match self {
+            Precedence::Top => Precedence::Atomic,
+            Precedence::Atomic => Precedence::Atomic,
+            _ => unreachable!("Unexpected non-format precedence level {self:?}"),
+        }
+    }
+}
+
+pub(crate) fn cond_paren(frag: Fragment, current: Precedence, cutoff: Precedence) -> Fragment {
+    match current.relate(&cutoff) {
+        Relation::Disjoint | Relation::Superior => {
+            Fragment::Char('(').cat(frag).cat(Fragment::Char(')'))
+        }
+        Relation::Congruent | Relation::Inferior => frag,
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,24 @@
 pub use crate::byte_set::ByteSet;
 pub use crate::decoder::Scope;
 pub use crate::read::ReadCtxt;
+
+// FIXME - this model does not support split_at or backtracking to previous ReadCtxt states
+pub struct ParseCtxt<'a> {
+    input: ReadCtxt<'a>,
+}
+
+impl<'a> ParseCtxt<'a> {
+    pub fn new(bytes: &'a [u8]) -> ParseCtxt<'a> {
+        Self { input: ReadCtxt::new(bytes) }
+    }
+
+    pub const fn offset(&self) -> usize {
+        self.input.offset
+    }
+
+    pub fn read_byte(&mut self) -> Option<u8> {
+        let (ret, new_input) =  self.input.read_byte()?;
+        self.input = new_input;
+        Some(ret)
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -25,3 +25,19 @@ impl<'a> ParseCtxt<'a> {
         Some(ret)
     }
 }
+
+pub fn u16le(input: (u8, u8)) -> u16 {
+    u16::from_le_bytes([input.0, input.1])
+}
+
+pub fn u16be(input: (u8, u8)) -> u16 {
+    u16::from_be_bytes([input.0, input.1])
+}
+
+pub fn u32le(input: (u8, u8, u8, u8)) -> u32 {
+    u32::from_le_bytes([input.0, input.1, input.2, input.3])
+}
+
+pub fn u32be(input: (u8, u8, u8, u8)) -> u32 {
+    u32::from_be_bytes([input.0, input.1, input.2, input.3])
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -3,6 +3,7 @@ pub use crate::decoder::Scope;
 pub use crate::read::ReadCtxt;
 
 // FIXME - this model does not support split_at or backtracking to previous ReadCtxt states
+#[derive(Clone)]
 pub struct ParseCtxt<'a> {
     input: ReadCtxt<'a>,
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,7 +9,9 @@ pub struct ParseCtxt<'a> {
 
 impl<'a> ParseCtxt<'a> {
     pub fn new(bytes: &'a [u8]) -> ParseCtxt<'a> {
-        Self { input: ReadCtxt::new(bytes) }
+        Self {
+            input: ReadCtxt::new(bytes),
+        }
     }
 
     pub const fn offset(&self) -> usize {
@@ -17,7 +19,7 @@ impl<'a> ParseCtxt<'a> {
     }
 
     pub fn read_byte(&mut self) -> Option<u8> {
-        let (ret, new_input) =  self.input.read_byte()?;
+        let (ret, new_input) = self.input.read_byte()?;
         self.input = new_input;
         Some(ret)
     }


### PR DESCRIPTION
Introduces `ParseCtxt`, simple abstraction for threading an incrementally-consumed `ReadCtxt` through Decoders without forcing them to change return-value. This does not allow for backtracking or splitting, at least as implemented currently.

Fixes broken label sanitization rules, and suppresses them entirely for the contents of string literals.

Adds a manual test at the end of `sample_codegen.rs` to confirm that parsing can actually work.