### PR TITLE
Compile each format into only one decoder by taking the union of nexts.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -793,6 +793,10 @@ impl FormatModule {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
     pub fn define_format(&mut self, name: impl IntoLabel, format: Format) -> FormatRef {
         self.define_format_args(name, vec![], format)
     }


### PR DESCRIPTION
The compilation of a format that ends with a union or a repeat will depend on the format that follows it, as this may influence the match tree used for lookahead, so initially we compiled each format into multiple decoders, one for each possible "next".

This pull request compiles each format to a single decoder instead, taking the union of all the "nexts". I think this is sound: if it's valid for F to be followed by A and valid for F to be followed by B then it should be valid for F to be followed by (A|B).

It's nice to create exactly one decoder per format however this still requires "whole program analysis" in the sense that a format cannot be compiled independently of how it is used, as you would hope a function or module could be.

Also the code feels slightly fragile given the way it has some subtle invariants on the decoder indices, that could probably be improved a little.