### PR TITLE
Simplify Expr type by introducing Arith and IntRel enums.

### DIFF
--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,6 +1,6 @@
 use doodle::byte_set::ByteSet;
 use doodle::IntoLabel;
-use doodle::{Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
+use doodle::{Arith, Expr, Format, FormatModule, FormatRef, IntRel, Pattern, ValueType};
 
 pub fn var<Name: IntoLabel>(name: Name) -> Expr {
     Expr::Var(name.into())
@@ -134,15 +134,15 @@ pub fn record_proj(head: impl Into<Expr>, label: impl IntoLabel) -> Expr {
 }
 
 pub fn expr_eq(x: Expr, y: Expr) -> Expr {
-    Expr::Eq(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Eq, Box::new(x), Box::new(y))
 }
 
 pub fn expr_ne(x: Expr, y: Expr) -> Expr {
-    Expr::Ne(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Ne, Box::new(x), Box::new(y))
 }
 
 pub fn expr_gte(x: Expr, y: Expr) -> Expr {
-    Expr::Gte(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Gte, Box::new(x), Box::new(y))
 }
 
 pub fn as_u8(x: Expr) -> Expr {
@@ -162,27 +162,27 @@ pub fn as_char(x: Expr) -> Expr {
 }
 
 pub fn add(x: Expr, y: Expr) -> Expr {
-    Expr::Add(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::Add, Box::new(x), Box::new(y))
 }
 
 pub fn sub(x: Expr, y: Expr) -> Expr {
-    Expr::Sub(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::Sub, Box::new(x), Box::new(y))
 }
 
 pub fn rem(x: Expr, y: Expr) -> Expr {
-    Expr::Rem(Box::new(x), Box::new(y))
-}
-
-pub fn shl(value: Expr, places: Expr) -> Expr {
-    Expr::Shl(Box::new(value), Box::new(places))
+    Expr::Arith(Arith::Rem, Box::new(x), Box::new(y))
 }
 
 pub fn bit_or(x: Expr, y: Expr) -> Expr {
-    Expr::BitOr(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::BitOr, Box::new(x), Box::new(y))
 }
 
 pub fn bit_and(x: Expr, y: Expr) -> Expr {
-    Expr::BitAnd(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::BitAnd, Box::new(x), Box::new(y))
+}
+
+pub fn shl(value: Expr, places: Expr) -> Expr {
+    Expr::Arith(Arith::Shl, Box::new(value), Box::new(places))
 }
 
 pub fn seq_length(seq: Expr) -> Expr {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{MultiScope, Scope, SingleScope, Value};
 use crate::Label;
-use crate::{DynFormat, Expr, Format, FormatModule};
+use crate::{Arith, DynFormat, Expr, Format, FormatModule, IntRel};
 
 use super::{Fragment, FragmentBuilder, Symbol};
 
@@ -845,80 +845,80 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::ARROW,
             ),
-            Expr::BitAnd(lhs, rhs) => cond_paren(
-                self.compile_binop(" & ", lhs, rhs, Precedence::BITAND, Precedence::BITAND),
-                prec,
-                Precedence::BITAND,
-            ),
-            Expr::BitOr(lhs, rhs) => cond_paren(
-                self.compile_binop(" | ", lhs, rhs, Precedence::BITOR, Precedence::BITOR),
-                prec,
-                Precedence::BITOR,
-            ),
-            Expr::Eq(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Eq, lhs, rhs) => cond_paren(
                 self.compile_binop(" == ", lhs, rhs, Precedence::EQUALITY, Precedence::EQUALITY),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Ne(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Ne, lhs, rhs) => cond_paren(
                 self.compile_binop(" != ", lhs, rhs, Precedence::EQUALITY, Precedence::EQUALITY),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Lt(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Lt, lhs, rhs) => cond_paren(
                 self.compile_binop(" < ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Gt(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Gt, lhs, rhs) => cond_paren(
                 self.compile_binop(" > ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Lte(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Lte, lhs, rhs) => cond_paren(
                 self.compile_binop(" <= ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Gte(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Gte, lhs, rhs) => cond_paren(
                 self.compile_binop(" >= ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Add(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Add, lhs, rhs) => cond_paren(
                 self.compile_binop(" + ", lhs, rhs, Precedence::ADDSUB, Precedence::ADDSUB),
                 prec,
                 Precedence::ADDSUB,
             ),
-            Expr::Sub(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Sub, lhs, rhs) => cond_paren(
                 self.compile_binop(" - ", lhs, rhs, Precedence::ADDSUB, Precedence::ADDSUB),
                 prec,
                 Precedence::ADDSUB,
             ),
-            Expr::Shl(lhs, rhs) => cond_paren(
-                self.compile_binop(" << ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
-                prec,
-                Precedence::BITSHIFT,
-            ),
-            Expr::Shr(lhs, rhs) => cond_paren(
-                self.compile_binop(" >> ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
-                prec,
-                Precedence::BITSHIFT,
-            ),
-            Expr::Mul(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Mul, lhs, rhs) => cond_paren(
                 self.compile_binop(" * ", lhs, rhs, Precedence::MUL, Precedence::MUL),
                 prec,
                 Precedence::MUL,
             ),
-            Expr::Div(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Div, lhs, rhs) => cond_paren(
                 self.compile_binop(" / ", lhs, rhs, Precedence::DIVREM, Precedence::DIVREM),
                 prec,
                 Precedence::DIVREM,
             ),
-            Expr::Rem(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Rem, lhs, rhs) => cond_paren(
                 self.compile_binop(" % ", lhs, rhs, Precedence::DIVREM, Precedence::DIVREM),
                 prec,
                 Precedence::DIVREM,
+            ),
+            Expr::Arith(Arith::BitAnd, lhs, rhs) => cond_paren(
+                self.compile_binop(" & ", lhs, rhs, Precedence::BITAND, Precedence::BITAND),
+                prec,
+                Precedence::BITAND,
+            ),
+            Expr::Arith(Arith::BitOr, lhs, rhs) => cond_paren(
+                self.compile_binop(" | ", lhs, rhs, Precedence::BITOR, Precedence::BITOR),
+                prec,
+                Precedence::BITOR,
+            ),
+            Expr::Arith(Arith::Shl, lhs, rhs) => cond_paren(
+                self.compile_binop(" << ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
+                prec,
+                Precedence::BITSHIFT,
+            ),
+            Expr::Arith(Arith::Shr, lhs, rhs) => cond_paren(
+                self.compile_binop(" >> ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
+                prec,
+                Precedence::BITSHIFT,
             ),
             Expr::AsU8(expr) => cond_paren(
                 self.compile_prefix("as-u8", None, expr),


### PR DESCRIPTION
The main reason to coalesce all the relational and arithmetic expressions is that they all have the same type, so it avoids some tedious code duplication when experimenting with different approaches to type checking.