### PR TITLE
Improve Bounds type and add Pattern::Int(Bounds)

### DIFF
--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -1,6 +1,6 @@
 use doodle::byte_set::ByteSet;
 use doodle::IntoLabel;
-use doodle::{Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
+use doodle::{Arith, Expr, Format, FormatModule, FormatRef, IntRel, Pattern, ValueType};
 
 pub fn var<Name: IntoLabel>(name: Name) -> Expr {
     Expr::Var(name.into())
@@ -134,15 +134,15 @@ pub fn record_proj(head: impl Into<Expr>, label: impl IntoLabel) -> Expr {
 }
 
 pub fn expr_eq(x: Expr, y: Expr) -> Expr {
-    Expr::Eq(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Eq, Box::new(x), Box::new(y))
 }
 
 pub fn expr_ne(x: Expr, y: Expr) -> Expr {
-    Expr::Ne(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Ne, Box::new(x), Box::new(y))
 }
 
 pub fn expr_gte(x: Expr, y: Expr) -> Expr {
-    Expr::Gte(Box::new(x), Box::new(y))
+    Expr::IntRel(IntRel::Gte, Box::new(x), Box::new(y))
 }
 
 pub fn as_u8(x: Expr) -> Expr {
@@ -162,27 +162,27 @@ pub fn as_char(x: Expr) -> Expr {
 }
 
 pub fn add(x: Expr, y: Expr) -> Expr {
-    Expr::Add(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::Add, Box::new(x), Box::new(y))
 }
 
 pub fn sub(x: Expr, y: Expr) -> Expr {
-    Expr::Sub(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::Sub, Box::new(x), Box::new(y))
 }
 
 pub fn rem(x: Expr, y: Expr) -> Expr {
-    Expr::Rem(Box::new(x), Box::new(y))
-}
-
-pub fn shl(value: Expr, places: Expr) -> Expr {
-    Expr::Shl(Box::new(value), Box::new(places))
+    Expr::Arith(Arith::Rem, Box::new(x), Box::new(y))
 }
 
 pub fn bit_or(x: Expr, y: Expr) -> Expr {
-    Expr::BitOr(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::BitOr, Box::new(x), Box::new(y))
 }
 
 pub fn bit_and(x: Expr, y: Expr) -> Expr {
-    Expr::BitAnd(Box::new(x), Box::new(y))
+    Expr::Arith(Arith::BitAnd, Box::new(x), Box::new(y))
+}
+
+pub fn shl(value: Expr, places: Expr) -> Expr {
+    Expr::Arith(Arith::Shl, Box::new(value), Box::new(places))
 }
 
 pub fn seq_length(seq: Expr) -> Expr {

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -1,3 +1,4 @@
+use doodle::bounds::Bounds;
 use doodle::{DynFormat, Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
 
 use crate::format::base::*;
@@ -387,6 +388,13 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         expr_match(
                             record_proj(var("x"), "code"),
                             vec![
+                                (
+                                    Pattern::Int(Bounds::new(0, Some(255))),
+                                    Expr::Seq(vec![variant(
+                                        "literal",
+                                        as_u8(record_proj(var("x"), "code")),
+                                    )]),
+                                ),
                                 (Pattern::U16(256), Expr::Seq(vec![])),
                                 (Pattern::U16(257), reference_record()),
                                 (Pattern::U16(258), reference_record()),
@@ -417,13 +425,6 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (Pattern::U16(283), reference_record()),
                                 (Pattern::U16(284), reference_record()),
                                 (Pattern::U16(285), reference_record()),
-                                (
-                                    Pattern::Wildcard,
-                                    Expr::Seq(vec![variant(
-                                        "literal",
-                                        as_u8(record_proj(var("x"), "code")),
-                                    )]),
-                                ),
                             ],
                         ),
                     ),
@@ -756,6 +757,13 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         expr_match(
                             record_proj(var("x"), "code"),
                             vec![
+                                (
+                                    Pattern::Int(Bounds::new(0, Some(255))),
+                                    Expr::Seq(vec![variant(
+                                        "literal",
+                                        as_u8(record_proj(var("x"), "code")),
+                                    )]),
+                                ),
                                 (Pattern::U16(256), Expr::Seq(vec![])),
                                 (Pattern::U16(257), reference_record()),
                                 (Pattern::U16(258), reference_record()),
@@ -786,13 +794,6 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (Pattern::U16(283), reference_record()),
                                 (Pattern::U16(284), reference_record()),
                                 (Pattern::U16(285), reference_record()),
-                                (
-                                    Pattern::Wildcard,
-                                    Expr::Seq(vec![variant(
-                                        "literal",
-                                        as_u8(record_proj(var("x"), "code")),
-                                    )]),
-                                ),
                             ],
                         ),
                     ),

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -389,7 +389,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             record_proj(var("x"), "code"),
                             vec![
                                 (
-                                    Pattern::Int(Bounds::new(0, Some(255))),
+                                    Pattern::Int(Bounds::new(0, 255)),
                                     Expr::Seq(vec![variant(
                                         "literal",
                                         as_u8(record_proj(var("x"), "code")),
@@ -758,7 +758,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             record_proj(var("x"), "code"),
                             vec![
                                 (
-                                    Pattern::Int(Bounds::new(0, Some(255))),
+                                    Pattern::Int(Bounds::new(0, 255)),
                                     Expr::Seq(vec![variant(
                                         "literal",
                                         as_u8(record_proj(var("x"), "code")),

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -3,13 +3,21 @@ use std::ops::{Add, Mul};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
-    pub min: usize,
-    pub max: Option<usize>,
+    min: usize,
+    max: Option<usize>,
 }
 
 impl Bounds {
     pub fn new(min: usize, max: Option<usize>) -> Bounds {
         Bounds { min, max }
+    }
+
+    pub fn min(&self) -> usize {
+        self.min
+    }
+
+    pub fn max(&self) -> Option<usize> {
+        self.max
     }
 
     pub fn exact(n: usize) -> Bounds {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::ops::{Add, Div, Mul, Shl, Sub};
+use std::ops::{Add, Div, Mul, Shl, Shr, Sub};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
@@ -133,6 +133,23 @@ impl Shl<Bounds> for Bounds {
                 .unwrap(),
             max: match (self.max, rhs.max) {
                 (Some(m1), Some(m2)) => Some(m1.checked_shl(u32::try_from(m2).unwrap()).unwrap()),
+                _ => None,
+            },
+        }
+    }
+}
+
+impl Shr<Bounds> for Bounds {
+    type Output = Self;
+
+    fn shr(self, rhs: Bounds) -> Bounds {
+        Bounds {
+            min: match rhs.max {
+                Some(m2) => self.min.checked_shr(u32::try_from(m2).unwrap()).unwrap(),
+                None => 0,
+            },
+            max: match self.max {
+                Some(m1) => Some(m1.checked_shr(u32::try_from(rhs.min).unwrap()).unwrap()),
                 _ => None,
             },
         }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,6 +1,7 @@
+use serde::Serialize;
 use std::ops::{Add, Mul};
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
     pub min: usize,
     pub max: Option<usize>,
@@ -23,6 +24,14 @@ impl Bounds {
             Some(n) if n == self.min => Some(n),
             _ => None,
         }
+    }
+
+    pub fn contains(&self, n: usize) -> bool {
+        n >= self.min
+            && match self.max {
+                Some(m) => n <= m,
+                _ => true,
+            }
     }
 
     pub fn union(lhs: Bounds, rhs: Bounds) -> Bounds {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use std::ops::{Add, BitAnd, BitOr, Div, Mul, Shl, Shr, Sub};
 
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
     min: usize,
     max: Option<usize>,
@@ -213,4 +213,177 @@ fn mask(x: usize) -> usize {
     } else {
         0
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn any_bounds() -> impl Strategy<Value = Bounds> {
+        Strategy::prop_union(
+            any::<u8>().prop_map(|n| Bounds::exact(n as usize)).boxed(),
+            any::<(u8, u8)>()
+                .prop_map(|(min, length)| {
+                    Bounds::new(min as usize, (min as usize) + (length as usize))
+                })
+                .boxed(),
+        )
+        .or(any::<u8>()
+            .prop_map(|n| Bounds::unbounded(n as usize))
+            .boxed())
+    }
+
+    proptest! {
+        #[test]
+        fn test_add(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x + y).contains(a + b));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_sub(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x - y).contains(a.saturating_sub(b)));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_mul(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x * y).contains(a * b));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_div(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize + 1;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x / y).contains(a / b));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_bitor(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x | y).contains(a | b));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_bitand(a in any::<u8>(), b in any::<u8>(), x in any_bounds(), y in any_bounds()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                !x.contains(a) ||
+                !y.contains(b) ||
+                (x & y).contains(a & b));
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_add_exact(a in any::<u8>(), b in any::<u8>()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                (Bounds::exact(a) + Bounds::exact(b)).is_exact().unwrap() == a + b)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_sub_exact(a in any::<u8>(), b in any::<u8>()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                (Bounds::exact(a) - Bounds::exact(b)).is_exact().unwrap() == a.saturating_sub(b))
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_mul_exact(a in any::<u8>(), b in any::<u8>()) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                (Bounds::exact(a) * Bounds::exact(b)).is_exact().unwrap() == a * b)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_div_exact(a in any::<u8>(), b in any::<u8>()) {
+            let a = a as usize;
+            let b = b as usize + 1;
+            prop_assert!(
+                (Bounds::exact(a) / Bounds::exact(b)).is_exact().unwrap() == a / b)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_shl_exact(a in any::<u8>(), b in 0..8) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                (Bounds::exact(a) << Bounds::exact(b)).is_exact().unwrap() == a << b)
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn test_shr_exact(a in any::<u8>(), b in 0..8) {
+            let a = a as usize;
+            let b = b as usize;
+            prop_assert!(
+                (Bounds::exact(a) >> Bounds::exact(b)).is_exact().unwrap() == a >> b)
+        }
+    }
+    /*
+        proptest! {
+            #[test]
+            fn test_bitor_exact(a in any::<u8>(), b in any::<u8>()) {
+                let a = a as usize;
+                let b = b as usize;
+                prop_assert!(
+                    (Bounds::exact(a) | Bounds::exact(b)).is_exact().unwrap() == a | b)
+            }
+        }
+
+        proptest! {
+            #[test]
+            fn test_bitand_exact(a in any::<u8>(), b in any::<u8>()) {
+                let a = a as usize;
+                let b = b as usize;
+                prop_assert!(
+                    (Bounds::exact(a) & Bounds::exact(b)).is_exact().unwrap() == a & b)
+            }
+        }
+    */
 }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::ops::{Add, Mul};
+use std::ops::{Add, Mul, Sub};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
@@ -69,6 +69,23 @@ impl Add for Bounds {
             max: match (self.max, rhs.max) {
                 (Some(m1), Some(m2)) => Some(m1.checked_add(m2).unwrap()),
                 _ => None,
+            },
+        }
+    }
+}
+
+impl Sub for Bounds {
+    type Output = Self;
+
+    fn sub(self, rhs: Bounds) -> Bounds {
+        Bounds {
+            min: match rhs.max {
+                Some(m2) => self.min.saturating_sub(m2),
+                None => 0,
+            },
+            max: match self.max {
+                Some(m1) => Some(m1.saturating_sub(rhs.min)),
+                None => None,
             },
         }
     }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::ops::{Add, Mul, Sub};
+use std::ops::{Add, Div, Mul, Sub};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
@@ -99,6 +99,23 @@ impl Mul<Bounds> for Bounds {
             min: self.min.checked_mul(rhs.min).unwrap(),
             max: match (self.max, rhs.max) {
                 (Some(m1), Some(m2)) => Some(m1.checked_mul(m2).unwrap()),
+                _ => None,
+            },
+        }
+    }
+}
+
+impl Div<Bounds> for Bounds {
+    type Output = Self;
+
+    fn div(self, rhs: Bounds) -> Bounds {
+        Bounds {
+            min: match rhs.max {
+                Some(m2) => self.min.checked_div(m2).unwrap(),
+                None => 0,
+            },
+            max: match self.max {
+                Some(m1) => Some(m1 / usize::max(rhs.min, 1)),
                 _ => None,
             },
         }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -65,9 +65,9 @@ impl Add for Bounds {
 
     fn add(self, rhs: Bounds) -> Bounds {
         Bounds {
-            min: self.min + rhs.min,
+            min: self.min.checked_add(rhs.min).unwrap(),
             max: match (self.max, rhs.max) {
-                (Some(m1), Some(m2)) => Some(m1 + m2),
+                (Some(m1), Some(m2)) => Some(m1.checked_add(m2).unwrap()),
                 _ => None,
             },
         }
@@ -79,9 +79,9 @@ impl Mul<Bounds> for Bounds {
 
     fn mul(self, rhs: Bounds) -> Bounds {
         Bounds {
-            min: self.min * rhs.min,
+            min: self.min.checked_mul(rhs.min).unwrap(),
             max: match (self.max, rhs.max) {
-                (Some(m1), Some(m2)) => Some(m1 * m2),
+                (Some(m1), Some(m2)) => Some(m1.checked_mul(m2).unwrap()),
                 _ => None,
             },
         }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,5 +1,5 @@
 use serde::Serialize;
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, Div, Mul, Shl, Sub};
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
@@ -116,6 +116,23 @@ impl Div<Bounds> for Bounds {
             },
             max: match self.max {
                 Some(m1) => Some(m1 / usize::max(rhs.min, 1)),
+                _ => None,
+            },
+        }
+    }
+}
+
+impl Shl<Bounds> for Bounds {
+    type Output = Self;
+
+    fn shl(self, rhs: Bounds) -> Bounds {
+        Bounds {
+            min: self
+                .min
+                .checked_shl(u32::try_from(rhs.min).unwrap())
+                .unwrap(),
+            max: match (self.max, rhs.max) {
+                (Some(m1), Some(m2)) => Some(m1.checked_shl(u32::try_from(m2).unwrap()).unwrap()),
                 _ => None,
             },
         }

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -8,8 +8,26 @@ pub struct Bounds {
 }
 
 impl Bounds {
-    pub fn new(min: usize, max: Option<usize>) -> Bounds {
-        Bounds { min, max }
+    pub const fn new(min: usize, max: usize) -> Bounds {
+        Bounds {
+            min,
+            max: Some(max),
+        }
+    }
+
+    pub const fn exact(n: usize) -> Bounds {
+        Bounds {
+            min: n,
+            max: Some(n),
+        }
+    }
+
+    pub const fn unbounded(min: usize) -> Bounds {
+        Bounds { min, max: None }
+    }
+
+    pub const fn unknown() -> Bounds {
+        Bounds::unbounded(0)
     }
 
     pub fn min(&self) -> usize {
@@ -18,13 +36,6 @@ impl Bounds {
 
     pub fn max(&self) -> Option<usize> {
         self.max
-    }
-
-    pub fn exact(n: usize) -> Bounds {
-        Bounds {
-            min: n,
-            max: Some(n),
-        }
     }
 
     pub fn is_exact(&self) -> Option<usize> {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -668,7 +668,7 @@ impl<'a> Compiler<'a> {
             }
             Format::PeekNot(a) => {
                 const MAX_LOOKAHEAD: usize = 1024;
-                match a.match_bounds(self.module).max {
+                match a.match_bounds(self.module).max() {
                     None => return Err("PeekNot cannot require unbounded lookahead".to_string()),
                     Some(n) if n > MAX_LOOKAHEAD => {
                         return Err(format!(

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -119,6 +119,9 @@ impl Value {
             (Pattern::U8(i0), Value::U8(i1)) => i0 == i1,
             (Pattern::U16(i0), Value::U16(i1)) => i0 == i1,
             (Pattern::U32(i0), Value::U32(i1)) => i0 == i1,
+            (Pattern::Int(bounds), Value::U8(n)) => bounds.contains(usize::from(*n)),
+            (Pattern::Int(bounds), Value::U16(n)) => bounds.contains(usize::from(*n)),
+            (Pattern::Int(bounds), Value::U32(n)) => bounds.contains(usize::try_from(*n).unwrap()),
             (Pattern::Char(c0), Value::Char(c1)) => c0 == c1,
             (Pattern::Tuple(ps), Value::Tuple(vs)) | (Pattern::Seq(ps), Value::Seq(vs))
                 if ps.len() == vs.len() =>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,7 +479,13 @@ impl Expr {
             Expr::U16(n) => Bounds::exact(usize::from(*n)),
             Expr::U32(n) => Bounds::exact(*n as usize),
             Expr::Arith(Arith::Add, a, b) => a.bounds() + b.bounds(),
+            Expr::Arith(Arith::Sub, a, b) => a.bounds() - b.bounds(),
             Expr::Arith(Arith::Mul, a, b) => a.bounds() * b.bounds(),
+            Expr::Arith(Arith::Div, a, b) => a.bounds() / b.bounds(),
+            Expr::Arith(Arith::BitOr, a, b) => a.bounds() | b.bounds(),
+            Expr::Arith(Arith::BitAnd, a, b) => a.bounds() & b.bounds(),
+            Expr::Arith(Arith::Shl, a, b) => a.bounds() << b.bounds(),
+            Expr::Arith(Arith::Shr, a, b) => a.bounds() >> b.bounds(),
             _ => Bounds::new(0, None),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -486,7 +486,7 @@ impl Expr {
             Expr::Arith(Arith::BitAnd, a, b) => a.bounds() & b.bounds(),
             Expr::Arith(Arith::Shl, a, b) => a.bounds() << b.bounds(),
             Expr::Arith(Arith::Shr, a, b) => a.bounds() >> b.bounds(),
-            _ => Bounds::new(0, None),
+            _ => Bounds::unknown(),
         }
     }
 }
@@ -621,7 +621,7 @@ impl Format {
             Format::ItemVar(level, _args) => module.get_format(*level).match_bounds(module),
             Format::Fail => Bounds::exact(0),
             Format::EndOfInput => Bounds::exact(0),
-            Format::Align(n) => Bounds::new(0, Some(n - 1)),
+            Format::Align(n) => Bounds::new(0, n - 1),
             Format::Byte(_) => Bounds::exact(1),
             Format::Variant(_label, f) => f.match_bounds(module),
             Format::UnionNondet(branches) => branches
@@ -644,11 +644,11 @@ impl Format {
                 .map(|(_, f)| f.match_bounds(module))
                 .reduce(Bounds::add)
                 .unwrap_or(Bounds::exact(0)),
-            Format::Repeat(_) => Bounds::new(0, None),
-            Format::Repeat1(f) => f.match_bounds(module) * Bounds::new(1, None),
+            Format::Repeat(_) => Bounds::unknown(),
+            Format::Repeat1(f) => f.match_bounds(module) * Bounds::unbounded(1),
             Format::RepeatCount(expr, f) => f.match_bounds(module) * expr.bounds(),
-            Format::RepeatUntilLast(_, f) => f.match_bounds(module) * Bounds::new(1, None),
-            Format::RepeatUntilSeq(_, _f) => Bounds::new(0, None),
+            Format::RepeatUntilLast(_, f) => f.match_bounds(module) * Bounds::unbounded(1),
+            Format::RepeatUntilSeq(_, _f) => Bounds::unknown(),
             Format::Peek(_) => Bounds::exact(0),
             Format::PeekNot(_) => Bounds::exact(0),
             Format::Slice(expr, _) => expr.bounds(),
@@ -663,7 +663,7 @@ impl Format {
                 .reduce(Bounds::union)
                 .unwrap(),
             Format::Dynamic(_name, _dynformat, f) => f.match_bounds(module),
-            Format::Apply(_) => Bounds::new(1, None),
+            Format::Apply(_) => Bounds::unbounded(1),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -663,7 +663,7 @@ impl Format {
 
     /// Returns `true` if the format could match the empty byte string
     fn is_nullable(&self, module: &FormatModule) -> bool {
-        self.match_bounds(module).min == 0
+        self.match_bounds(module).min() == 0
     }
 
     /// True if the compilation of this format depends on the format that follows it
@@ -1261,7 +1261,7 @@ impl<'a> MatchTreeStep<'a> {
                 if let Some(n) = bounds.is_exact() {
                     Self::from_repeat_count(module, n, a, next.clone())
                 } else {
-                    Self::from_repeat_count(module, bounds.min, a, Rc::new(Next::Empty))
+                    Self::from_repeat_count(module, bounds.min(), a, Rc::new(Next::Empty))
                 }
             }
             Format::RepeatUntilLast(_expr, _a) => {
@@ -1286,7 +1286,7 @@ impl<'a> MatchTreeStep<'a> {
                 if let Some(n) = bounds.is_exact() {
                     Self::from_slice(module, n, inside, next)
                 } else {
-                    Self::from_slice(module, bounds.min, inside, Rc::new(Next::Empty))
+                    Self::from_slice(module, bounds.min(), inside, Rc::new(Next::Empty))
                 }
             }
             Format::Bits(_a) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ pub enum Pattern {
     U8(u8),
     U16(u16),
     U32(u32),
+    Int(Bounds),
     Char(char),
     Tuple(Vec<Pattern>),
     Variant(Label, Box<Pattern>),
@@ -67,6 +68,9 @@ impl Pattern {
             (Pattern::U8(_i0), ValueType::U8) => {}
             (Pattern::U16(_i0), ValueType::U16) => {}
             (Pattern::U32(_i0), ValueType::U32) => {}
+            (Pattern::Int(_), ValueType::U8) => {}
+            (Pattern::Int(_), ValueType::U16) => {}
+            (Pattern::Int(_), ValueType::U32) => {}
             (Pattern::Tuple(ps), ValueType::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope(scope, t);

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -2,7 +2,7 @@ use std::{borrow::Cow, fmt, io, ops::Deref, rc::Rc};
 
 use crate::decoder::{MultiScope, Scope, SingleScope, Value};
 use crate::Label;
-use crate::{DynFormat, Expr, Format, FormatModule};
+use crate::{Arith, DynFormat, Expr, Format, FormatModule, IntRel};
 
 use super::{Fragment, FragmentBuilder, Symbol};
 
@@ -845,80 +845,80 @@ impl<'module> MonoidalPrinter<'module> {
                 prec,
                 Precedence::ARROW,
             ),
-            Expr::BitAnd(lhs, rhs) => cond_paren(
-                self.compile_binop(" & ", lhs, rhs, Precedence::BITAND, Precedence::BITAND),
-                prec,
-                Precedence::BITAND,
-            ),
-            Expr::BitOr(lhs, rhs) => cond_paren(
-                self.compile_binop(" | ", lhs, rhs, Precedence::BITOR, Precedence::BITOR),
-                prec,
-                Precedence::BITOR,
-            ),
-            Expr::Eq(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Eq, lhs, rhs) => cond_paren(
                 self.compile_binop(" == ", lhs, rhs, Precedence::EQUALITY, Precedence::EQUALITY),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Ne(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Ne, lhs, rhs) => cond_paren(
                 self.compile_binop(" != ", lhs, rhs, Precedence::EQUALITY, Precedence::EQUALITY),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Lt(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Lt, lhs, rhs) => cond_paren(
                 self.compile_binop(" < ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Gt(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Gt, lhs, rhs) => cond_paren(
                 self.compile_binop(" > ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Lte(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Lte, lhs, rhs) => cond_paren(
                 self.compile_binop(" <= ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Gte(lhs, rhs) => cond_paren(
+            Expr::IntRel(IntRel::Gte, lhs, rhs) => cond_paren(
                 self.compile_binop(" >= ", lhs, rhs, Precedence::COMPARE, Precedence::COMPARE),
                 prec,
                 Precedence::COMPARE,
             ),
-            Expr::Add(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Add, lhs, rhs) => cond_paren(
                 self.compile_binop(" + ", lhs, rhs, Precedence::ADDSUB, Precedence::ADDSUB),
                 prec,
                 Precedence::ADDSUB,
             ),
-            Expr::Sub(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Sub, lhs, rhs) => cond_paren(
                 self.compile_binop(" - ", lhs, rhs, Precedence::ADDSUB, Precedence::ADDSUB),
                 prec,
                 Precedence::ADDSUB,
             ),
-            Expr::Shl(lhs, rhs) => cond_paren(
-                self.compile_binop(" << ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
-                prec,
-                Precedence::BITSHIFT,
-            ),
-            Expr::Shr(lhs, rhs) => cond_paren(
-                self.compile_binop(" >> ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
-                prec,
-                Precedence::BITSHIFT,
-            ),
-            Expr::Mul(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Mul, lhs, rhs) => cond_paren(
                 self.compile_binop(" * ", lhs, rhs, Precedence::MUL, Precedence::MUL),
                 prec,
                 Precedence::MUL,
             ),
-            Expr::Div(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Div, lhs, rhs) => cond_paren(
                 self.compile_binop(" / ", lhs, rhs, Precedence::DIVREM, Precedence::DIVREM),
                 prec,
                 Precedence::DIVREM,
             ),
-            Expr::Rem(lhs, rhs) => cond_paren(
+            Expr::Arith(Arith::Rem, lhs, rhs) => cond_paren(
                 self.compile_binop(" % ", lhs, rhs, Precedence::DIVREM, Precedence::DIVREM),
                 prec,
                 Precedence::DIVREM,
+            ),
+            Expr::Arith(Arith::BitAnd, lhs, rhs) => cond_paren(
+                self.compile_binop(" & ", lhs, rhs, Precedence::BITAND, Precedence::BITAND),
+                prec,
+                Precedence::BITAND,
+            ),
+            Expr::Arith(Arith::BitOr, lhs, rhs) => cond_paren(
+                self.compile_binop(" | ", lhs, rhs, Precedence::BITOR, Precedence::BITOR),
+                prec,
+                Precedence::BITOR,
+            ),
+            Expr::Arith(Arith::Shl, lhs, rhs) => cond_paren(
+                self.compile_binop(" << ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
+                prec,
+                Precedence::BITSHIFT,
+            ),
+            Expr::Arith(Arith::Shr, lhs, rhs) => cond_paren(
+                self.compile_binop(" >> ", lhs, rhs, Precedence::BITSHIFT, Precedence::BITSHIFT),
+                prec,
+                Precedence::BITSHIFT,
             ),
             Expr::AsU8(expr) => cond_paren(
                 self.compile_prefix("as-u8", None, expr),


### PR DESCRIPTION
This extends the Bounds type with more operators and adds proptests, although it's my first time trying proptest so it might need some review.

I've also added Pattern::Int(Bounds), which is a convenient shorthand and a step towards more general treatment of integer types.