### PR TITLE
Change Format::UnionNondet to be consistent with Union.

### DIFF
--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -32,14 +32,14 @@ pub fn main(module: &mut FormatModule) -> FormatRef {
         record([
             (
                 "data",
-                Format::UnionNondet(vec![
-                    ("gif".into(), gif.call()),
-                    ("gzip".into(), gzip.call()),
-                    ("jpeg".into(), jpeg.call()),
-                    ("png".into(), png.call()),
-                    ("riff".into(), riff.call()),
-                    ("tar".into(), tar.call()),
-                    ("text".into(), text.call()),
+                union_nondet(vec![
+                    ("gif", gif.call()),
+                    ("gzip", gzip.call()),
+                    ("jpeg", jpeg.call()),
+                    ("png", png.call()),
+                    ("riff", riff.call()),
+                    ("tar", tar.call()),
+                    ("text", text.call()),
                 ]),
             ),
             ("end", Format::EndOfInput),

--- a/src/bin/doodle/format/base.rs
+++ b/src/bin/doodle/format/base.rs
@@ -52,6 +52,14 @@ pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
     Format::Union(branches.into_iter().collect())
 }
 
+pub fn union_nondet<Name: IntoLabel>(branches: impl IntoIterator<Item = (Name, Format)>) -> Format {
+    Format::UnionNondet(
+        (branches.into_iter())
+            .map(|(label, format)| Format::Variant(label.into(), Box::new(format)))
+            .collect(),
+    )
+}
+
 pub fn record<Name: IntoLabel>(fields: impl IntoIterator<Item = (Name, Format)>) -> Format {
     Format::Record(
         (fields.into_iter())

--- a/src/bin/doodle/format/text.rs
+++ b/src/bin/doodle/format/text.rs
@@ -125,10 +125,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
 
     module.define_format(
         "text.string",
-        Format::UnionNondet(vec![
-            ("ascii".into(), ascii_str.call()),
-            ("utf8".into(), utf8_str.call()),
-        ]),
+        union_nondet(vec![("ascii", ascii_str.call()), ("utf8", utf8_str.call())]),
     )
 }
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -590,9 +590,9 @@ impl<'a> Compiler<'a> {
             }
             Format::UnionNondet(branches) => {
                 let mut ds = Vec::with_capacity(branches.len());
-                for (label, f) in branches {
+                for f in branches {
                     let d = self.compile_format(f, next.clone())?;
-                    ds.push(Decoder::Variant(label.clone(), Box::new(d)));
+                    ds.push(d);
                 }
                 Ok(Decoder::Parallel(ds))
             }

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -130,14 +130,7 @@ fn check_covered(
             check_covered(module, path, format)?;
             path.pop();
         }
-        Format::UnionNondet(branches) => {
-            for (label, format) in branches {
-                path.push(label.clone());
-                check_covered(module, path, format)?;
-                path.pop();
-            }
-        }
-        Format::Union(branches) => {
+        Format::Union(branches) | Format::UnionNondet(branches) => {
             for format in branches {
                 check_covered(module, path, format)?;
             }
@@ -219,20 +212,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 }
                 _ => panic!("expected variant, found {value:?}"),
             },
-            Format::UnionNondet(branches) => match value {
-                Value::Branch(index, value) => {
-                    let (label, format) = &branches[*index];
-                    match value.as_ref() {
-                        Value::Variant(label2, value) => {
-                            assert_eq!(label, label2);
-                            self.write_flat(scope, value, format)
-                        }
-                        _ => panic!("expected variant, found {value:?}"),
-                    }
-                }
-                _ => panic!("expected branch, found {value:?}"),
-            },
-            Format::Union(branches) => match value {
+            Format::Union(branches) | Format::UnionNondet(branches) => match value {
                 Value::Branch(index, value) => {
                     let format = &branches[*index];
                     self.write_flat(scope, value, format)

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -147,19 +147,9 @@ impl<'module> MonoidalPrinter<'module> {
                 }
             }
             Value::Branch(n, value) => match format.map(|f| self.unwrap_itemvars(f)) {
-                Some(Format::Union(branches)) => {
+                Some(Format::Union(branches)) | Some(Format::UnionNondet(branches)) => {
                     let format = &branches[*n];
                     self.is_atomic_value(value, Some(format))
-                }
-                Some(Format::UnionNondet(branches)) => {
-                    let (label, format) = &branches[*n];
-                    match value.as_ref() {
-                        Value::Variant(label2, value) => {
-                            assert_eq!(label, label2);
-                            self.is_atomic_value(value, Some(format))
-                        }
-                        _ => panic!("expected variant value"),
-                    }
                 }
                 Some(Format::Match(_head, branches)) => {
                     let (_pattern, format) = &branches[*n];
@@ -238,20 +228,7 @@ impl<'module> MonoidalPrinter<'module> {
                 }
                 _ => panic!("expected variant, found {value:?}"),
             },
-            Format::UnionNondet(branches) => match value {
-                Value::Branch(index, value) => {
-                    let (label, format) = &branches[*index];
-                    match value.as_ref() {
-                        Value::Variant(label2, value) => {
-                            assert_eq!(label, label2);
-                            self.compile_variant(scope, label, value, Some(format))
-                        }
-                        _ => panic!("expected variant, found {value:?}"),
-                    }
-                }
-                _ => panic!("expected branch, found {value:?}"),
-            },
-            Format::Union(branches) => match value {
+            Format::Union(branches) | Format::UnionNondet(branches) => match value {
                 Value::Branch(n, value) => {
                     let format = &branches[*n];
                     self.compile_decoded_value(scope, value, format)


### PR DESCRIPTION
This change shifts the variant label syntax sugar to a helper function, which simplifies the core format language.