### PR TITLE
Move base module into library crate

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -1,6 +1,6 @@
-use doodle::byte_set::ByteSet;
-use doodle::IntoLabel;
-use doodle::{Arith, Expr, Format, FormatModule, FormatRef, IntRel, Pattern, ValueType};
+use crate::byte_set::ByteSet;
+use crate::IntoLabel;
+use crate::{Arith, Expr, Format, FormatModule, FormatRef, IntRel, Pattern, ValueType};
 
 pub fn var<Name: IntoLabel>(name: Name) -> Expr {
     Expr::Var(name.into())

--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -1,8 +1,5 @@
+use doodle::base::*;
 use doodle::{Format, FormatModule, FormatRef};
-
-use crate::format::base::*;
-
-mod base;
 
 mod deflate;
 mod gif;
@@ -16,7 +13,7 @@ mod text;
 mod tiff;
 
 pub fn main(module: &mut FormatModule) -> FormatRef {
-    let base = base::main(module);
+    let base = doodle::base::main(module);
 
     let deflate = deflate::main(module, &base);
     let tiff = tiff::main(module, &base);
@@ -60,7 +57,7 @@ mod test {
     #[test]
     fn with_relative_offset_format() -> Result<(), ParseError> {
         let mut module = FormatModule::new();
-        let base = base::main(&mut module);
+        let base = doodle::base::main(&mut module);
 
         let mask_bytes = {
             let mut tmp = ByteSet::new();

--- a/src/bin/doodle/format/deflate.rs
+++ b/src/bin/doodle/format/deflate.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{DynFormat, Expr, Format, FormatModule, FormatRef, Pattern, ValueType};
-
-use crate::format::base::*;
 
 fn tuple_proj(x: Expr, i: usize) -> Expr {
     Expr::TupleProj(Box::new(x), i)

--- a/src/bin/doodle/format/gif.rs
+++ b/src/bin/doodle/format/gif.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef};
-
-use crate::format::base::*;
 
 /// Graphics Interchange Format (GIF)
 ///

--- a/src/bin/doodle/format/gzip.rs
+++ b/src/bin/doodle/format/gzip.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef};
-
-use crate::format::base::*;
 
 /// gzip
 pub fn main(module: &mut FormatModule, deflate: FormatRef, base: &BaseModule) -> FormatRef {

--- a/src/bin/doodle/format/jpeg.rs
+++ b/src/bin/doodle/format/jpeg.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
-
-use crate::format::base::*;
 
 /// JPEG File Interchange Format
 ///

--- a/src/bin/doodle/format/mpeg4.rs
+++ b/src/bin/doodle/format/mpeg4.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
-
-use crate::format::base::*;
 
 fn tag_pattern(tag: [char; 4]) -> Pattern {
     Pattern::Tuple(vec![

--- a/src/bin/doodle/format/png.rs
+++ b/src/bin/doodle/format/png.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Format, FormatModule, FormatRef, Pattern};
-
-use crate::format::base::*;
 
 pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     let chunk = |tag: Format, data: Format| {

--- a/src/bin/doodle/format/riff.rs
+++ b/src/bin/doodle/format/riff.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef};
-
-use crate::format::base::*;
 
 pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     fn is_even(num: Expr) -> Expr {

--- a/src/bin/doodle/format/tar.rs
+++ b/src/bin/doodle/format/tar.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{byte_set::ByteSet, Expr, Format, FormatModule, FormatRef};
-
-use crate::format::base::*;
 
 const BLOCK_SIZE: u32 = 512;
 

--- a/src/bin/doodle/format/text.rs
+++ b/src/bin/doodle/format/text.rs
@@ -1,7 +1,6 @@
 use crate::format::BaseModule;
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
-
-use super::base::*;
 
 // mask table for bitwise and in order to drop N bits, for N = 0 ..= 5
 // We technically don't need a mask to drop 0, but it keeps the other indices intuitively correct

--- a/src/bin/doodle/format/tiff.rs
+++ b/src/bin/doodle/format/tiff.rs
@@ -1,6 +1,5 @@
+use doodle::base::*;
 use doodle::{Expr, Format, FormatModule, FormatRef, Pattern};
-
-use crate::format::base::*;
 
 /// TIFF Image file header
 ///

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -629,13 +629,11 @@ impl<'a> Compiler<'a> {
                 Ok(Decoder::Variant(label.clone(), Box::new(d)))
             }
             Format::Union(branches) => {
-                let mut fs = Vec::with_capacity(branches.len());
                 let mut ds = Vec::with_capacity(branches.len());
                 for f in branches {
                     ds.push(self.compile_format(f, next.clone())?);
-                    fs.push(f.clone());
                 }
-                if let Some(tree) = MatchTree::build(self.module, &fs, next) {
+                if let Some(tree) = MatchTree::build(self.module, branches, next) {
                     Ok(Decoder::Branch(tree, ds))
                 } else {
                     Err(format!("cannot build match tree for {:?}", format))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ use crate::bounds::Bounds;
 use crate::byte_set::ByteSet;
 use crate::read::ReadCtxt;
 
+pub mod base;
 pub mod bounds;
 pub mod byte_set;
 pub mod codegen;


### PR DESCRIPTION
This allows convenience functions to be used in tests.