### PR TITLE
Static analysis for selective elision of vacuous expressions, promotion of hard-coded strings to productive elements of associated model-structures

### DIFF
--- a/codegen_tests.rs
+++ b/codegen_tests.rs
@@ -4,14 +4,14 @@ use super::*;
 
 type TestResult<T = ()> = Result<T, Box<dyn Send + Sync + std::error::Error>>;
 
-// Stablization aliases to avoid hard-coding shifting numbers as formats are enriched with more possibilities
+// Stabilization aliases to avoid hard-coding shifting numbers as formats are enriched with more possibilities
 type Top = Type204;
 type TarBlock = Type202;
 type PngData = Type193;
 type JpegData = Type80;
 
 #[test]
-fn test_pngsig_decoder() {
+fn test_png_signature_decoder() {
     // PNG signature
     let input = b"\x89PNG\r\n\x1A\n";
     let mut parser = Parser::new(input);
@@ -23,8 +23,8 @@ fn test_pngsig_decoder() {
 fn test_decoder_gif() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.gif"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::gif(dat) => println!("{:?}", dat),
         other => unreachable!("expected gif, found {other:?}"),
     }
@@ -33,11 +33,11 @@ fn test_decoder_gif() -> TestResult {
 
 mod gzip {
     use super::*;
-    fn test_decoder_gzip(testfile: &str) -> TestResult {
-        let buffer = std::fs::read(std::path::Path::new(testfile))?;
+    fn test_decoder_gzip(test_file: &str) -> TestResult {
+        let buffer = std::fs::read(std::path::Path::new(test_file))?;
         let mut input = Parser::new(&buffer);
-        let oput = Decoder1(&mut input)?.data;
-        match oput {
+        let parsed_data = Decoder1(&mut input)?.data;
+        match parsed_data {
             Top::gzip(dat) => println!("{:?}", &dat[0].header),
             other => unreachable!("expected gzip, found {other:?}"),
         }
@@ -72,11 +72,11 @@ mod gzip {
 
 mod jpeg {
     use super::*;
-    fn test_decoder_jpeg(testfile: &str) -> TestResult {
-        let buffer = std::fs::read(std::path::Path::new(testfile))?;
+    fn test_decoder_jpeg(test_file: &str) -> TestResult {
+        let buffer = std::fs::read(std::path::Path::new(test_file))?;
         let mut input = Parser::new(&buffer);
-        let oput = Decoder1(&mut input)?.data;
-        match oput {
+        let parsed_data = Decoder1(&mut input)?.data;
+        match parsed_data {
             Top::jpeg(dat) => println!("{:?}", dat.frame.header),
             other => unreachable!("expected jpeg, found {other:?}"),
         }
@@ -98,8 +98,8 @@ mod jpeg {
 fn test_decoder_peano() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.peano"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::peano(x) => println!("PEANO: {x:#?}"),
         other => unreachable!("expected peano, found {other:?}"),
     }
@@ -110,8 +110,8 @@ fn test_decoder_peano() -> TestResult {
 fn test_decoder_mpeg4() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.mp4"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::mpeg4(dat) => println!("{:?}", dat),
         other => unreachable!("expected mpeg4, found {other:?}"),
     }
@@ -122,8 +122,8 @@ fn test_decoder_mpeg4() -> TestResult {
 fn test_decoder_png() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.png"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::png(dat) => println!("{:?}", dat),
         other => unreachable!("expected png, found {other:?}"),
     }
@@ -134,8 +134,8 @@ fn test_decoder_png() -> TestResult {
 fn test_decoder_riff() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.webp"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::riff(dat) => println!("{:?}", dat),
         other => unreachable!("expected riff, found {other:?}"),
     }
@@ -146,8 +146,8 @@ fn test_decoder_riff() -> TestResult {
 fn test_decoder_tar() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.tar"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder14(&mut input)?;
-    match oput {
+    let parsed_data = Decoder14(&mut input)?;
+    match parsed_data {
         TarBlock {
             header,
             file,
@@ -164,8 +164,8 @@ fn test_decoder_tar() -> TestResult {
 fn test_decoder_text_ascii() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.txt"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::text(chars) => {
             assert_eq!(
                 chars,
@@ -181,8 +181,8 @@ fn test_decoder_text_ascii() -> TestResult {
 fn test_decoder_text_utf8() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("test.utf8"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::text(chars) => {
             assert_eq!(
                 chars,
@@ -198,8 +198,8 @@ fn test_decoder_text_utf8() -> TestResult {
 fn test_decoder_text_mixed() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new("mixed.utf8"))?;
     let mut input = Parser::new(&buffer);
-    let oput = Decoder1(&mut input)?.data;
-    match oput {
+    let parsed_data = Decoder1(&mut input)?.data;
+    match parsed_data {
         Top::text(chars) => {
             assert_eq!(
                 chars,
@@ -224,8 +224,8 @@ mod test_files {
     fn print_png_breadcrumb(png_data: PngData) {
         let sig_hex = mk_sig_hex(png_data.signature);
         println!(
-            "SIG ({}) | IHDR (len: {} | h {}px * w {}px)",
-            sig_hex, png_data.ihdr.length, png_data.ihdr.data.height, png_data.ihdr.data.width,
+            "SIG ({}) | IHDR (h {}px * w {}px)",
+            sig_hex, png_data.ihdr.data.height, png_data.ihdr.data.width,
         );
     }
 
@@ -246,7 +246,7 @@ mod test_files {
                         density_y,
                         ..
                     }) => {
-                        // 0 = unitless, 1 = ppi, 2 = ppcm
+                        // 0 = density ratio w/o units, 1 = pixels per inch, 2 = pixels per cm
                         let density = match density_units {
                             0 => format!("{}:{}", density_x, density_y),
                             1 => format!("{}x{} ppi", density_x, density_y),
@@ -299,6 +299,7 @@ mod test_files {
             match () {
                 _ if name.contains("broken.png") => {
                     assert!(check_png(format!("test-images/{}", name).as_str()).is_err());
+                    println!("Broken PNG (expected)");
                 }
                 _ if name.ends_with(".png") => {
                     check_png(format!("test-images/{}", name).as_str())?;

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1,6 +1,9 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(dead_code)]
+
+mod codegen_tests;
+
 use doodle::prelude::*;
 
 #[derive(Debug, Clone)]
@@ -22829,5 +22832,3 @@ return Err(ParseError::ExcludedBranch(8001216093308031977u64));
     };
     PResult::Ok(((|x: (Vec<u8>, u8)| PResult::Ok((x.clone().0.len()) as u32))(inner))?)
 }
-
-mod codegen_tests;

--- a/sample_codegen.rs
+++ b/sample_codegen.rs
@@ -1839,7 +1839,7 @@ fn Decoder2<'input>(_input: &mut Parser<'input>) -> Result<Vec<u32>, ParseError>
                 break;
             }
         } else {
-            let next_elem = (Decoder181(_input))?;
+            let next_elem = (Decoder182(_input))?;
             accum.push(next_elem);
         }
     }
@@ -1847,8 +1847,8 @@ fn Decoder2<'input>(_input: &mut Parser<'input>) -> Result<Vec<u32>, ParseError>
 }
 
 fn Decoder3<'input>(_input: &mut Parser<'input>) -> Result<Type19, ParseError> {
-    let header = ((|| PResult::Ok((Decoder163(_input))?))())?;
-    let logical_screen = ((|| PResult::Ok((Decoder164(_input))?))())?;
+    let header = ((|| PResult::Ok((Decoder164(_input))?))())?;
+    let logical_screen = ((|| PResult::Ok((Decoder165(_input))?))())?;
     let blocks = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -1873,7 +1873,7 @@ fn Decoder3<'input>(_input: &mut Parser<'input>) -> Result<Type19, ParseError> {
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder165(_input))?;
+                    let next_elem = (Decoder166(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -1882,7 +1882,7 @@ fn Decoder3<'input>(_input: &mut Parser<'input>) -> Result<Type19, ParseError> {
             accum
         })
     })())?;
-    let trailer = ((|| PResult::Ok((Decoder166(_input))?))())?;
+    let trailer = ((|| PResult::Ok((Decoder167(_input))?))())?;
     PResult::Ok(Type19 {
         header,
         logical_screen,
@@ -1911,29 +1911,26 @@ fn Decoder4<'input>(_input: &mut Parser<'input>) -> Result<Vec<Type40>, ParseErr
             }
         } else {
             let next_elem = {
-                let header = ((|| PResult::Ok((Decoder151(_input))?))())?;
+                let header = ((|| PResult::Ok((Decoder152(_input))?))())?;
                 let fname = ((|| {
                     PResult::Ok(match header.clone().file_flags & 8u8 != 0u8 {
                         true => {
-                            let inner = (Decoder152(_input))?;
+                            let inner = (Decoder153(_input))?;
                             Type22::yes(inner)
                         }
 
-                        false => {
-                            let _ = ();
-                            Type22::no
-                        }
+                        false => Type22::no,
                     })
                 })())?;
                 let data = ((|| {
                     PResult::Ok({
                         _input.enter_bits_mode()?;
-                        let ret = ((|| PResult::Ok((Decoder153(_input))?))())?;
+                        let ret = ((|| PResult::Ok((Decoder154(_input))?))())?;
                         let _bits_read = _input.escape_bits_mode()?;
                         ret
                     })
                 })())?;
-                let footer = ((|| PResult::Ok((Decoder154(_input))?))())?;
+                let footer = ((|| PResult::Ok((Decoder155(_input))?))())?;
                 Type40 {
                     header,
                     fname,
@@ -1948,9 +1945,9 @@ fn Decoder4<'input>(_input: &mut Parser<'input>) -> Result<Vec<Type40>, ParseErr
 }
 
 fn Decoder5<'input>(_input: &mut Parser<'input>) -> Result<Type80, ParseError> {
-    let soi = ((|| PResult::Ok((Decoder78(_input))?))())?;
-    let frame = ((|| PResult::Ok((Decoder79(_input))?))())?;
-    let eoi = ((|| PResult::Ok((Decoder80(_input))?))())?;
+    let soi = ((|| PResult::Ok((Decoder79(_input))?))())?;
+    let frame = ((|| PResult::Ok((Decoder80(_input))?))())?;
+    let eoi = ((|| PResult::Ok((Decoder81(_input))?))())?;
     PResult::Ok(Type80 { soi, frame, eoi })
 }
 
@@ -1969,7 +1966,7 @@ fn Decoder6<'input>(_input: &mut Parser<'input>) -> Result<Type163, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder57(_input))?;
+                    let next_elem = (Decoder58(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -2217,10 +2214,7 @@ fn Decoder8<'input>(_input: &mut Parser<'input>) -> Result<Type197, ParseError> 
     })())?;
     let pad = ((|| {
         PResult::Ok(match length % 2u32 == 0u32 {
-            true => {
-                let _ = ();
-                Type194::yes
-            }
+            true => Type194::yes,
 
             false => {
                 let inner = {
@@ -4075,10 +4069,7 @@ fn Decoder26<'input>(_input: &mut Parser<'input>) -> Result<Type195, ParseError>
     })())?;
     let pad = ((|| {
         PResult::Ok(match length % 2u32 == 0u32 {
-            true => {
-                let _ = ();
-                Type194::yes
-            }
+            true => Type194::yes,
 
             false => {
                 let inner = {
@@ -4191,12 +4182,12 @@ fn Decoder27<'input>(
 
 fn Decoder28<'input>(_input: &mut Parser<'input>) -> Result<Type165, ParseError> {
     let length = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let tag = ((|| PResult::Ok((Decoder55(_input))?))())?;
+    let tag = ((|| PResult::Ok((Decoder56(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = length as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder56(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder57(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -4552,7 +4543,7 @@ fn Decoder37<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
                 PResult::Ok(match ihdr.clone().data.color_type {
                     0 => {
                         let inner = {
-                            let greyscale = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let greyscale = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type167 { greyscale }
                         };
                         Type170::color_type_0(inner)
@@ -4560,7 +4551,7 @@ fn Decoder37<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
 
                     4 => {
                         let inner = {
-                            let greyscale = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let greyscale = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type167 { greyscale }
                         };
                         Type170::color_type_4(inner)
@@ -4568,9 +4559,9 @@ fn Decoder37<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
 
                     2 => {
                         let inner = {
-                            let red = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let green = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let blue = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let red = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let green = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let blue = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type168 { red, green, blue }
                         };
                         Type170::color_type_2(inner)
@@ -4578,9 +4569,9 @@ fn Decoder37<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
 
                     6 => {
                         let inner = {
-                            let red = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let green = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let blue = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let red = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let green = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let blue = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type168 { red, green, blue }
                         };
                         Type170::color_type_6(inner)
@@ -4756,7 +4747,7 @@ fn Decoder39<'input>(_input: &mut Parser<'input>) -> Result<Type177, ParseError>
                     let profile_name = ((|| {
                         PResult::Ok({
                             let inner = {
-                                let field0 = ((|| PResult::Ok((Decoder54(_input))?))())?;
+                                let field0 = ((|| PResult::Ok((Decoder55(_input))?))())?;
                                 let field1 = ((|| {
                                     PResult::Ok({
                                         let b = _input.read_byte()?;
@@ -4784,29 +4775,7 @@ fn Decoder39<'input>(_input: &mut Parser<'input>) -> Result<Type177, ParseError>
                             }
                         })
                     })())?;
-                    let compressed_profile = ((|| {
-                        PResult::Ok({
-                            let mut accum = Vec::new();
-                            while _input.remaining() > 0 {
-                                let matching_ix = {
-                                    _input.open_peek_context();
-                                    _input.read_byte()?;
-                                    {
-                                        let ret = 0;
-                                        _input.close_peek_context()?;
-                                        ret
-                                    }
-                                };
-                                if matching_ix == 0 {
-                                    let next_elem = (Decoder16(_input))?;
-                                    accum.push(next_elem);
-                                } else {
-                                    break;
-                                }
-                            }
-                            accum
-                        })
-                    })())?;
+                    let compressed_profile = ((|| PResult::Ok((Decoder49(_input))?))())?;
                     Type176 {
                         profile_name,
                         compression_method,
@@ -4883,7 +4852,7 @@ fn Decoder40<'input>(_input: &mut Parser<'input>) -> Result<Type179, ParseError>
                     let keyword = ((|| {
                         PResult::Ok({
                             let inner = {
-                                let field0 = ((|| PResult::Ok((Decoder51(_input))?))())?;
+                                let field0 = ((|| PResult::Ok((Decoder52(_input))?))())?;
                                 let field1 = ((|| {
                                     PResult::Ok({
                                         let b = _input.read_byte()?;
@@ -4921,11 +4890,13 @@ fn Decoder40<'input>(_input: &mut Parser<'input>) -> Result<Type179, ParseError>
                             }
                         })
                     })())?;
-                    let language_tag = ((|| PResult::Ok((Decoder52(_input))?))())?;
-                    let translated_keyword = ((|| PResult::Ok((Decoder53(_input))?))())?;
+                    let language_tag = ((|| PResult::Ok((Decoder53(_input))?))())?;
+                    let translated_keyword = ((|| PResult::Ok((Decoder54(_input))?))())?;
                     let text = ((|| {
-                        PResult::Ok({
-                            let inner = {
+                        PResult::Ok(match compression_flag == 1u8 {
+                            true => (Decoder49(_input))?,
+
+                            false => {
                                 let mut accum = Vec::new();
                                 while _input.remaining() > 0 {
                                     let matching_ix = {
@@ -4945,20 +4916,7 @@ fn Decoder40<'input>(_input: &mut Parser<'input>) -> Result<Type179, ParseError>
                                     }
                                 }
                                 accum
-                            };
-                            ((|x: Vec<u8>| {
-                                PResult::Ok(match compression_flag {
-                                    0 => x,
-
-                                    1 => x,
-
-                                    _ => {
-                                        return Err(ParseError::ExcludedBranch(
-                                            2777544122374969611u64,
-                                        ));
-                                    }
-                                })
-                            })(inner))?
+                            }
                         })
                     })())?;
                     Type178 {
@@ -5282,7 +5240,7 @@ fn Decoder44<'input>(_input: &mut Parser<'input>) -> Result<Type183, ParseError>
                     let keyword = ((|| {
                         PResult::Ok({
                             let inner = {
-                                let field0 = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                                let field0 = ((|| PResult::Ok((Decoder51(_input))?))())?;
                                 let field1 = ((|| {
                                     PResult::Ok({
                                         let b = _input.read_byte()?;
@@ -5392,7 +5350,7 @@ fn Decoder45<'input>(_input: &mut Parser<'input>) -> Result<Type185, ParseError>
             _input.start_slice(sz)?;
             let ret = ((|| {
                 PResult::Ok({
-                    let year = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                    let year = ((|| PResult::Ok((Decoder50(_input))?))())?;
                     let month = ((|| PResult::Ok((Decoder16(_input))?))())?;
                     let day = ((|| PResult::Ok((Decoder16(_input))?))())?;
                     let hour = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -5476,7 +5434,7 @@ fn Decoder46<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
                 PResult::Ok(match ihdr.clone().data.color_type {
                     0 => {
                         let inner = {
-                            let greyscale = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let greyscale = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type167 { greyscale }
                         };
                         Type186::color_type_0(inner)
@@ -5484,9 +5442,9 @@ fn Decoder46<'input>(_input: &mut Parser<'input>, ihdr: Type165) -> Result<Type1
 
                     2 => {
                         let inner = {
-                            let red = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let green = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let blue = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let red = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let green = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let blue = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type168 { red, green, blue }
                         };
                         Type186::color_type_2(inner)
@@ -5625,32 +5583,7 @@ fn Decoder47<'input>(_input: &mut Parser<'input>) -> Result<Type189, ParseError>
                             }
                         })
                     })())?;
-                    let compressed_text = ((|| {
-                        PResult::Ok({
-                            let inner = {
-                                let mut accum = Vec::new();
-                                while _input.remaining() > 0 {
-                                    let matching_ix = {
-                                        _input.open_peek_context();
-                                        _input.read_byte()?;
-                                        {
-                                            let ret = 0;
-                                            _input.close_peek_context()?;
-                                            ret
-                                        }
-                                    };
-                                    if matching_ix == 0 {
-                                        let next_elem = (Decoder16(_input))?;
-                                        accum.push(next_elem);
-                                    } else {
-                                        break;
-                                    }
-                                }
-                                accum
-                            };
-                            ((|x: Vec<u8>| PResult::Ok(x))(inner))?
-                        })
-                    })())?;
+                    let compressed_text = ((|| PResult::Ok((Decoder49(_input))?))())?;
                     Type188 {
                         keyword,
                         compression_method,
@@ -6777,1119 +6710,35 @@ return Err(ParseError::ExcludedBranch(7279863718715306056u64));
     PResult::Ok(accum)
 }
 
-fn Decoder49<'input>(_input: &mut Parser<'input>) -> Result<u16, ParseError> {
+fn Decoder49<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
+    let mut accum = Vec::new();
+    while _input.remaining() > 0 {
+        let matching_ix = {
+            _input.open_peek_context();
+            _input.read_byte()?;
+            {
+                let ret = 0;
+                _input.close_peek_context()?;
+                ret
+            }
+        };
+        if matching_ix == 0 {
+            let next_elem = (Decoder16(_input))?;
+            accum.push(next_elem);
+        } else {
+            break;
+        }
+    }
+    PResult::Ok(accum)
+}
+
+fn Decoder50<'input>(_input: &mut Parser<'input>) -> Result<u16, ParseError> {
     let inner = {
         let field0 = ((|| PResult::Ok((Decoder16(_input))?))())?;
         let field1 = ((|| PResult::Ok((Decoder16(_input))?))())?;
         (field0, field1)
     };
     PResult::Ok(((|x: (u8, u8)| PResult::Ok(u16be(x)))(inner))?)
-}
-
-fn Decoder50<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
-    let mut accum = Vec::new();
-    while _input.remaining() > 0 {
-        let matching_ix = {
-            _input.open_peek_context();
-            let b = _input.read_byte()?;
-            {
-                let ret = match b {
-                    0u8 => 0,
-
-                    tmp if ((ByteSet::from_bits([
-                        18446744069414584320,
-                        9223372036854775807,
-                        18446744065119617024,
-                        18446744073709551615,
-                    ]))
-                    .contains(tmp)) =>
-                    {
-                        let b = _input.read_byte()?;
-                        match b {
-                            0u8 => 1,
-
-                            tmp if ((ByteSet::from_bits([
-                                18446744069414584320,
-                                9223372036854775807,
-                                18446744065119617024,
-                                18446744073709551615,
-                            ]))
-                            .contains(tmp)) =>
-                            {
-                                let b = _input.read_byte()?;
-                                match b {
-                                    0u8 => 2,
-
-                                    tmp if ((ByteSet::from_bits([
-                                        18446744069414584320,
-                                        9223372036854775807,
-                                        18446744065119617024,
-                                        18446744073709551615,
-                                    ]))
-                                    .contains(tmp)) =>
-                                    {
-                                        let b = _input.read_byte()?;
-                                        match b {
-                                            0u8 => 3,
-
-                                            tmp if ((ByteSet::from_bits([
-                                                18446744069414584320,
-                                                9223372036854775807,
-                                                18446744065119617024,
-                                                18446744073709551615,
-                                            ]))
-                                            .contains(tmp)) =>
-                                            {
-                                                let b = _input.read_byte()?;
-                                                match b {
-                                                    0u8 => 4,
-
-                                                    tmp if ((ByteSet::from_bits([
-                                                        18446744069414584320,
-                                                        9223372036854775807,
-                                                        18446744065119617024,
-                                                        18446744073709551615,
-                                                    ]))
-                                                    .contains(tmp)) =>
-                                                    {
-                                                        let b = _input.read_byte()?;
-                                                        match b {
-                                                            0u8 => 5,
-
-                                                            tmp if ((ByteSet::from_bits([
-                                                                18446744069414584320,
-                                                                9223372036854775807,
-                                                                18446744065119617024,
-                                                                18446744073709551615,
-                                                            ]))
-                                                            .contains(tmp)) =>
-                                                            {
-                                                                let b = _input.read_byte()?;
-                                                                match b {
-0u8 => {
-6
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-7
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-8
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-9
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-10
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-11
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-12
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-13
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-14
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-15
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-16
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-17
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-18
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-19
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-20
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-21
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-22
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-23
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-24
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-25
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-26
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-27
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-28
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-29
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-30
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-31
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-32
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-33
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-34
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-35
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-36
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-37
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-38
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-39
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-40
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-41
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-42
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-43
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-44
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-45
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-46
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-47
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-48
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-49
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-50
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-51
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-52
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-53
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-54
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-55
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-56
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-57
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-58
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-59
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-60
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-61
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-62
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-63
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-64
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-65
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-66
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-67
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-68
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-69
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-70
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-71
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-72
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-73
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-74
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-75
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-76
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-77
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-let b = _input.read_byte()?;
-match b {
-0u8 => {
-78
-},
-
-tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
-79
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1156600997808834721u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(686893874203959698u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5647302839925181930u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12596085444683110489u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(698004606122880289u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17484571581640965095u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6540530436842500333u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1885078274385301600u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2760313249059646380u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6864494491173992330u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12031893906322850579u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3325605041662679663u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18127647179293822299u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1757426024726163624u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(178440331724964330u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7701642596783457452u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5889869058337734004u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(448960124419894112u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17968063285163593108u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6658979120527716197u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14070492394437254859u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12094341563934969777u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14447745632705856537u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2878199988418950426u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9981078220607407536u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13979884363466418441u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14697219789812534349u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1922183737469204535u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4564459967526826259u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6295454573086855551u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8829268174072585826u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17289562280941389130u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15187733903820788036u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8945233277383628939u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17055677057026365051u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2711657847979741650u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7960086128827310454u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17243432721042925232u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2492433356894874420u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2412963531573765251u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13615115093049678240u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12861038934173916684u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15290638577266507314u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13771803105164343178u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8440227624652964490u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11749686089473367822u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14128049364035057882u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5772944606843372240u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12877845223200621278u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18429737009659339382u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5056695690378482781u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18175410941244882664u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14689827387576631959u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13752824778747682586u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15099715940097679920u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7570592576744298472u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9011326107999450601u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18413916726623917222u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11077716068559322830u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16761545731695489821u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1796681571676370638u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12634645130304766428u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10851594797972925398u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2877758930083196789u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4021154774029150054u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4872726929046804051u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13578407048997150968u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14985643526348759689u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13195439938299117823u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14643378569655829231u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16890725544144972486u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5759023799041458604u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7279863718715306056u64));
-}
-}
-                                                            }
-
-                                                            _ => {
-                                                                return Err(
-                                                                    ParseError::ExcludedBranch(
-                                                                        1929389086973805060u64,
-                                                                    ),
-                                                                );
-                                                            }
-                                                        }
-                                                    }
-
-                                                    _ => {
-                                                        return Err(ParseError::ExcludedBranch(
-                                                            16960558233825067461u64,
-                                                        ));
-                                                    }
-                                                }
-                                            }
-
-                                            _ => {
-                                                return Err(ParseError::ExcludedBranch(
-                                                    18079708419564968323u64,
-                                                ));
-                                            }
-                                        }
-                                    }
-
-                                    _ => {
-                                        return Err(ParseError::ExcludedBranch(
-                                            13745914803581094198u64,
-                                        ));
-                                    }
-                                }
-                            }
-
-                            _ => {
-                                return Err(ParseError::ExcludedBranch(6362830467043337482u64));
-                            }
-                        }
-                    }
-
-                    _ => {
-                        return Err(ParseError::ExcludedBranch(5206670497493022146u64));
-                    }
-                };
-                _input.close_peek_context()?;
-                ret
-            }
-        };
-        if (repeat_between_finished(
-            matching_ix == 0,
-            accum.len() >= (1u32 as usize),
-            accum.len() == (79u32 as usize),
-        ))? {
-            break;
-        } else {
-            let next_elem = {
-                let b = _input.read_byte()?;
-                if (ByteSet::from_bits([
-                    18446744069414584320,
-                    9223372036854775807,
-                    18446744065119617024,
-                    18446744073709551615,
-                ]))
-                .contains(b)
-                {
-                    b
-                } else {
-                    return Err(ParseError::ExcludedBranch(15306540504651776134u64));
-                }
-            };
-            accum.push(next_elem);
-        }
-    }
-    PResult::Ok(accum)
 }
 
 fn Decoder51<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
@@ -8998,111 +7847,7 @@ return Err(ParseError::ExcludedBranch(7279863718715306056u64));
     PResult::Ok(accum)
 }
 
-fn Decoder52<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
-    let string = ((|| {
-        PResult::Ok({
-            let mut accum = Vec::new();
-            while _input.remaining() > 0 {
-                let matching_ix = {
-                    _input.open_peek_context();
-                    let b = _input.read_byte()?;
-                    {
-                        let ret = match b {
-                            tmp if (tmp != 0) => 0,
-
-                            0u8 => 1,
-
-                            _ => {
-                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
-                            }
-                        };
-                        _input.close_peek_context()?;
-                        ret
-                    }
-                };
-                if matching_ix == 0 {
-                    let next_elem = {
-                        let b = _input.read_byte()?;
-                        if b != 0 {
-                            b
-                        } else {
-                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
-                        }
-                    };
-                    accum.push(next_elem);
-                } else {
-                    break;
-                }
-            }
-            accum
-        })
-    })())?;
-    let null = ((|| {
-        PResult::Ok({
-            let b = _input.read_byte()?;
-            if b == 0 {
-                b
-            } else {
-                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
-            }
-        })
-    })())?;
-    PResult::Ok(Type21 { string, null })
-}
-
-fn Decoder53<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
-    let string = ((|| {
-        PResult::Ok({
-            let mut accum = Vec::new();
-            while _input.remaining() > 0 {
-                let matching_ix = {
-                    _input.open_peek_context();
-                    let b = _input.read_byte()?;
-                    {
-                        let ret = match b {
-                            tmp if (tmp != 0) => 0,
-
-                            0u8 => 1,
-
-                            _ => {
-                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
-                            }
-                        };
-                        _input.close_peek_context()?;
-                        ret
-                    }
-                };
-                if matching_ix == 0 {
-                    let next_elem = {
-                        let b = _input.read_byte()?;
-                        if b != 0 {
-                            b
-                        } else {
-                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
-                        }
-                    };
-                    accum.push(next_elem);
-                } else {
-                    break;
-                }
-            }
-            accum
-        })
-    })())?;
-    let null = ((|| {
-        PResult::Ok({
-            let b = _input.read_byte()?;
-            if b == 0 {
-                b
-            } else {
-                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
-            }
-        })
-    })())?;
-    PResult::Ok(Type21 { string, null })
-}
-
-fn Decoder54<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
+fn Decoder52<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
     let mut accum = Vec::new();
     while _input.remaining() > 0 {
         let matching_ix = {
@@ -10208,7 +8953,1217 @@ return Err(ParseError::ExcludedBranch(7279863718715306056u64));
     PResult::Ok(accum)
 }
 
-fn Decoder55<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), ParseError> {
+fn Decoder53<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+    let string = ((|| {
+        PResult::Ok({
+            let mut accum = Vec::new();
+            while _input.remaining() > 0 {
+                let matching_ix = {
+                    _input.open_peek_context();
+                    let b = _input.read_byte()?;
+                    {
+                        let ret = match b {
+                            tmp if (tmp != 0) => 0,
+
+                            0u8 => 1,
+
+                            _ => {
+                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
+                            }
+                        };
+                        _input.close_peek_context()?;
+                        ret
+                    }
+                };
+                if matching_ix == 0 {
+                    let next_elem = {
+                        let b = _input.read_byte()?;
+                        if b != 0 {
+                            b
+                        } else {
+                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
+                        }
+                    };
+                    accum.push(next_elem);
+                } else {
+                    break;
+                }
+            }
+            accum
+        })
+    })())?;
+    let null = ((|| {
+        PResult::Ok({
+            let b = _input.read_byte()?;
+            if b == 0 {
+                b
+            } else {
+                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
+            }
+        })
+    })())?;
+    PResult::Ok(Type21 { string, null })
+}
+
+fn Decoder54<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+    let string = ((|| {
+        PResult::Ok({
+            let mut accum = Vec::new();
+            while _input.remaining() > 0 {
+                let matching_ix = {
+                    _input.open_peek_context();
+                    let b = _input.read_byte()?;
+                    {
+                        let ret = match b {
+                            tmp if (tmp != 0) => 0,
+
+                            0u8 => 1,
+
+                            _ => {
+                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
+                            }
+                        };
+                        _input.close_peek_context()?;
+                        ret
+                    }
+                };
+                if matching_ix == 0 {
+                    let next_elem = {
+                        let b = _input.read_byte()?;
+                        if b != 0 {
+                            b
+                        } else {
+                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
+                        }
+                    };
+                    accum.push(next_elem);
+                } else {
+                    break;
+                }
+            }
+            accum
+        })
+    })())?;
+    let null = ((|| {
+        PResult::Ok({
+            let b = _input.read_byte()?;
+            if b == 0 {
+                b
+            } else {
+                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
+            }
+        })
+    })())?;
+    PResult::Ok(Type21 { string, null })
+}
+
+fn Decoder55<'input>(_input: &mut Parser<'input>) -> Result<Vec<u8>, ParseError> {
+    let mut accum = Vec::new();
+    while _input.remaining() > 0 {
+        let matching_ix = {
+            _input.open_peek_context();
+            let b = _input.read_byte()?;
+            {
+                let ret = match b {
+                    0u8 => 0,
+
+                    tmp if ((ByteSet::from_bits([
+                        18446744069414584320,
+                        9223372036854775807,
+                        18446744065119617024,
+                        18446744073709551615,
+                    ]))
+                    .contains(tmp)) =>
+                    {
+                        let b = _input.read_byte()?;
+                        match b {
+                            0u8 => 1,
+
+                            tmp if ((ByteSet::from_bits([
+                                18446744069414584320,
+                                9223372036854775807,
+                                18446744065119617024,
+                                18446744073709551615,
+                            ]))
+                            .contains(tmp)) =>
+                            {
+                                let b = _input.read_byte()?;
+                                match b {
+                                    0u8 => 2,
+
+                                    tmp if ((ByteSet::from_bits([
+                                        18446744069414584320,
+                                        9223372036854775807,
+                                        18446744065119617024,
+                                        18446744073709551615,
+                                    ]))
+                                    .contains(tmp)) =>
+                                    {
+                                        let b = _input.read_byte()?;
+                                        match b {
+                                            0u8 => 3,
+
+                                            tmp if ((ByteSet::from_bits([
+                                                18446744069414584320,
+                                                9223372036854775807,
+                                                18446744065119617024,
+                                                18446744073709551615,
+                                            ]))
+                                            .contains(tmp)) =>
+                                            {
+                                                let b = _input.read_byte()?;
+                                                match b {
+                                                    0u8 => 4,
+
+                                                    tmp if ((ByteSet::from_bits([
+                                                        18446744069414584320,
+                                                        9223372036854775807,
+                                                        18446744065119617024,
+                                                        18446744073709551615,
+                                                    ]))
+                                                    .contains(tmp)) =>
+                                                    {
+                                                        let b = _input.read_byte()?;
+                                                        match b {
+                                                            0u8 => 5,
+
+                                                            tmp if ((ByteSet::from_bits([
+                                                                18446744069414584320,
+                                                                9223372036854775807,
+                                                                18446744065119617024,
+                                                                18446744073709551615,
+                                                            ]))
+                                                            .contains(tmp)) =>
+                                                            {
+                                                                let b = _input.read_byte()?;
+                                                                match b {
+0u8 => {
+6
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+7
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+8
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+9
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+10
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+11
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+12
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+13
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+14
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+15
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+16
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+17
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+18
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+19
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+20
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+21
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+22
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+23
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+24
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+25
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+26
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+27
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+28
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+29
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+30
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+31
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+32
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+33
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+34
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+35
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+36
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+37
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+38
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+39
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+40
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+41
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+42
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+43
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+44
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+45
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+46
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+47
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+48
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+49
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+50
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+51
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+52
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+53
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+54
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+55
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+56
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+57
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+58
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+59
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+60
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+61
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+62
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+63
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+64
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+65
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+66
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+67
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+68
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+69
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+70
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+71
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+72
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+73
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+74
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+75
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+76
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+77
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+let b = _input.read_byte()?;
+match b {
+0u8 => {
+78
+},
+
+tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(tmp)) => {
+79
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1156600997808834721u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(686893874203959698u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5647302839925181930u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12596085444683110489u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(698004606122880289u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17484571581640965095u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6540530436842500333u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1885078274385301600u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2760313249059646380u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6864494491173992330u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12031893906322850579u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3325605041662679663u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18127647179293822299u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1757426024726163624u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(178440331724964330u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7701642596783457452u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5889869058337734004u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(448960124419894112u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17968063285163593108u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6658979120527716197u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14070492394437254859u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12094341563934969777u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14447745632705856537u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2878199988418950426u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9981078220607407536u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13979884363466418441u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14697219789812534349u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1922183737469204535u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4564459967526826259u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6295454573086855551u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8829268174072585826u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17289562280941389130u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15187733903820788036u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8945233277383628939u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17055677057026365051u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2711657847979741650u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7960086128827310454u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17243432721042925232u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2492433356894874420u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2412963531573765251u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13615115093049678240u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12861038934173916684u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15290638577266507314u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13771803105164343178u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8440227624652964490u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11749686089473367822u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14128049364035057882u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5772944606843372240u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12877845223200621278u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18429737009659339382u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5056695690378482781u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18175410941244882664u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14689827387576631959u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13752824778747682586u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15099715940097679920u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7570592576744298472u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9011326107999450601u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18413916726623917222u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11077716068559322830u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16761545731695489821u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1796681571676370638u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12634645130304766428u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(10851594797972925398u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2877758930083196789u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4021154774029150054u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4872726929046804051u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13578407048997150968u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14985643526348759689u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13195439938299117823u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14643378569655829231u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16890725544144972486u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5759023799041458604u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7279863718715306056u64));
+}
+}
+                                                            }
+
+                                                            _ => {
+                                                                return Err(
+                                                                    ParseError::ExcludedBranch(
+                                                                        1929389086973805060u64,
+                                                                    ),
+                                                                );
+                                                            }
+                                                        }
+                                                    }
+
+                                                    _ => {
+                                                        return Err(ParseError::ExcludedBranch(
+                                                            16960558233825067461u64,
+                                                        ));
+                                                    }
+                                                }
+                                            }
+
+                                            _ => {
+                                                return Err(ParseError::ExcludedBranch(
+                                                    18079708419564968323u64,
+                                                ));
+                                            }
+                                        }
+                                    }
+
+                                    _ => {
+                                        return Err(ParseError::ExcludedBranch(
+                                            13745914803581094198u64,
+                                        ));
+                                    }
+                                }
+                            }
+
+                            _ => {
+                                return Err(ParseError::ExcludedBranch(6362830467043337482u64));
+                            }
+                        }
+                    }
+
+                    _ => {
+                        return Err(ParseError::ExcludedBranch(5206670497493022146u64));
+                    }
+                };
+                _input.close_peek_context()?;
+                ret
+            }
+        };
+        if (repeat_between_finished(
+            matching_ix == 0,
+            accum.len() >= (1u32 as usize),
+            accum.len() == (79u32 as usize),
+        ))? {
+            break;
+        } else {
+            let next_elem = {
+                let b = _input.read_byte()?;
+                if (ByteSet::from_bits([
+                    18446744069414584320,
+                    9223372036854775807,
+                    18446744065119617024,
+                    18446744073709551615,
+                ]))
+                .contains(b)
+                {
+                    b
+                } else {
+                    return Err(ParseError::ExcludedBranch(15306540504651776134u64));
+                }
+            };
+            accum.push(next_elem);
+        }
+    }
+    PResult::Ok(accum)
+}
+
+fn Decoder56<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), ParseError> {
     let field0 = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -10252,7 +10207,7 @@ fn Decoder55<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), Pa
     PResult::Ok((field0, field1, field2, field3))
 }
 
-fn Decoder56<'input>(_input: &mut Parser<'input>) -> Result<Type164, ParseError> {
+fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type164, ParseError> {
     let width = ((|| PResult::Ok((Decoder32(_input))?))())?;
     let height = ((|| PResult::Ok((Decoder32(_input))?))())?;
     let bit_depth = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -10271,15 +10226,15 @@ fn Decoder56<'input>(_input: &mut Parser<'input>) -> Result<Type164, ParseError>
     })
 }
 
-fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError> {
+fn Decoder58<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -10294,7 +10249,7 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
                 PResult::Ok(match r#type {
                     (102, 116, 121, 112) => {
                         let inner = {
-                            let major_brand = ((|| PResult::Ok((Decoder58(_input))?))())?;
+                            let major_brand = ((|| PResult::Ok((Decoder59(_input))?))())?;
                             let minor_version = ((|| PResult::Ok((Decoder32(_input))?))())?;
                             let compatible_brands = ((|| {
                                 PResult::Ok({
@@ -10310,7 +10265,7 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
                                             }
                                         };
                                         if matching_ix == 0 {
-                                            let next_elem = (Decoder58(_input))?;
+                                            let next_elem = (Decoder59(_input))?;
                                             accum.push(next_elem);
                                         } else {
                                             break;
@@ -10328,15 +10283,9 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
                         Type161::ftyp(inner)
                     }
 
-                    (102, 114, 101, 101) => {
-                        let _ = ();
-                        Type161::free
-                    }
+                    (102, 114, 101, 101) => Type161::free,
 
-                    (109, 100, 97, 116) => {
-                        let _ = ();
-                        Type161::mdat
-                    }
+                    (109, 100, 97, 116) => Type161::mdat,
 
                     (109, 101, 116, 97) => {
                         let field0 = ((|| PResult::Ok((Decoder32(_input))?))())?;
@@ -10354,7 +10303,7 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
                                         }
                                     };
                                     if matching_ix == 0 {
-                                        let next_elem = (Decoder60(_input))?;
+                                        let next_elem = (Decoder61(_input))?;
                                         accum.push(next_elem);
                                     } else {
                                         break;
@@ -10380,7 +10329,7 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder61(_input))?;
+                                    let next_elem = (Decoder62(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -10429,7 +10378,7 @@ fn Decoder57<'input>(_input: &mut Parser<'input>) -> Result<Type162, ParseError>
     })
 }
 
-fn Decoder58<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), ParseError> {
+fn Decoder59<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), ParseError> {
     let field0 = ((|| PResult::Ok((Decoder20(_input))?))())?;
     let field1 = ((|| PResult::Ok((Decoder20(_input))?))())?;
     let field2 = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -10437,7 +10386,7 @@ fn Decoder58<'input>(_input: &mut Parser<'input>) -> Result<(u8, u8, u8, u8), Pa
     PResult::Ok((field0, field1, field2, field3))
 }
 
-fn Decoder59<'input>(_input: &mut Parser<'input>) -> Result<u64, ParseError> {
+fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<u64, ParseError> {
     let inner = {
         let field0 = ((|| PResult::Ok((Decoder16(_input))?))())?;
         let field1 = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -10454,15 +10403,15 @@ fn Decoder59<'input>(_input: &mut Parser<'input>) -> Result<u64, ParseError> {
     PResult::Ok(((|x: (u8, u8, u8, u8, u8, u8, u8, u8)| PResult::Ok(u64be(x)))(inner))?)
 }
 
-fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError> {
+fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -10489,7 +10438,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder68(_input))?;
+                                    let next_elem = (Decoder69(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -10512,7 +10461,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                 })
                             })())?;
                             let predefined = ((|| PResult::Ok((Decoder32(_input))?))())?;
-                            let handler_type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+                            let handler_type = ((|| PResult::Ok((Decoder59(_input))?))())?;
                             let reserved = ((|| {
                                 PResult::Ok({
                                     let field0 = ((|| PResult::Ok((Decoder32(_input))?))())?;
@@ -10521,7 +10470,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                     (field0, field1, field2)
                                 })
                             })())?;
-                            let name = ((|| PResult::Ok((Decoder66(_input))?))())?;
+                            let name = ((|| PResult::Ok((Decoder67(_input))?))())?;
                             Type86 {
                                 version,
                                 flags,
@@ -10548,7 +10497,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                             let item_ID = ((|| {
                                 PResult::Ok(match version == 0u8 {
                                     true => {
-                                        let inner = (Decoder49(_input))?;
+                                        let inner = (Decoder50(_input))?;
                                         Type112::yes(inner)
                                     }
 
@@ -10581,7 +10530,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                             let entry_count = ((|| {
                                 PResult::Ok(match version == 0u8 {
                                     true => {
-                                        let inner = (Decoder49(_input))?;
+                                        let inner = (Decoder50(_input))?;
                                         ((|x: u16| PResult::Ok(x as u32))(inner))?
                                     }
 
@@ -10592,7 +10541,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                 PResult::Ok({
                                     let mut accum = Vec::new();
                                     for _ in 0..entry_count {
-                                        accum.push((Decoder70(_input))?);
+                                        accum.push((Decoder71(_input))?);
                                     }
                                     accum
                                 })
@@ -10640,7 +10589,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                                         })(
                                                         ))?;
                                                         let r#type = ((|| {
-                                                            PResult::Ok((Decoder58(_input))?)
+                                                            PResult::Ok((Decoder59(_input))?)
                                                         })(
                                                         ))?;
                                                         let size = ((|| {
@@ -10649,7 +10598,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
 
                                                                 1 => {
                                                                     let inner =
-                                                                        (Decoder59(_input))?;
+                                                                        (Decoder60(_input))?;
                                                                     ((|x: u64| {
                                                                         PResult::Ok(x - 16u64)
                                                                     })(
@@ -10670,7 +10619,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                                                         let from_item_ID =
                                                                             ((|| {
                                                                                 PResult::Ok(
-                                                                                    (Decoder49(
+                                                                                    (Decoder50(
                                                                                         _input,
                                                                                     ))?,
                                                                                 )
@@ -10679,7 +10628,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                                                         let reference_count =
                                                                             ((|| {
                                                                                 PResult::Ok(
-                                                                                    (Decoder49(
+                                                                                    (Decoder50(
                                                                                         _input,
                                                                                     ))?,
                                                                                 )
@@ -10691,7 +10640,7 @@ fn Decoder60<'input>(_input: &mut Parser<'input>) -> Result<Type115, ParseError>
                                                                                     let mut accum =
                                                                                         Vec::new();
                                                                                     for _ in 0..reference_count {
-accum.push((Decoder49(_input))?);
+accum.push((Decoder50(_input))?);
 }
                                                                                     accum
                                                                                 })
@@ -10747,7 +10696,7 @@ accum.push((Decoder49(_input))?);
                                                         })(
                                                         ))?;
                                                         let r#type = ((|| {
-                                                            PResult::Ok((Decoder58(_input))?)
+                                                            PResult::Ok((Decoder59(_input))?)
                                                         })(
                                                         ))?;
                                                         let size = ((|| {
@@ -10756,7 +10705,7 @@ accum.push((Decoder49(_input))?);
 
                                                                 1 => {
                                                                     let inner =
-                                                                        (Decoder59(_input))?;
+                                                                        (Decoder60(_input))?;
                                                                     ((|x: u64| {
                                                                         PResult::Ok(x - 16u64)
                                                                     })(
@@ -10786,7 +10735,7 @@ accum.push((Decoder49(_input))?);
                                                                         let reference_count =
                                                                             ((|| {
                                                                                 PResult::Ok(
-                                                                                    (Decoder49(
+                                                                                    (Decoder50(
                                                                                         _input,
                                                                                     ))?,
                                                                                 )
@@ -10879,7 +10828,7 @@ accum.push((Decoder32(_input))?);
                             let item_count = ((|| {
                                 PResult::Ok(match version < 2u8 {
                                     true => {
-                                        let inner = (Decoder49(_input))?;
+                                        let inner = (Decoder50(_input))?;
                                         ((|x: u16| PResult::Ok(x as u32))(inner))?
                                     }
 
@@ -10893,7 +10842,7 @@ accum.push((Decoder32(_input))?);
                                         accum.push({
 let item_ID = ((|| PResult::Ok(match version < 2u8 {
 true => {
-let inner = (Decoder49(_input))?;
+let inner = (Decoder50(_input))?;
 ((|x: u16| PResult::Ok(x as u32))(inner))?
 },
 
@@ -10903,16 +10852,15 @@ false => {
 }))())?;
 let construction_method = ((|| PResult::Ok(match version > 0u8 {
 true => {
-let inner = (Decoder49(_input))?;
+let inner = (Decoder50(_input))?;
 Type97::yes(inner)
 },
 
 false => {
-let _ = ();
 Type97::no
 }
 }))())?;
-let data_reference_index = ((|| PResult::Ok((Decoder49(_input))?))())?;
+let data_reference_index = ((|| PResult::Ok((Decoder50(_input))?))())?;
 let base_offset = ((|| PResult::Ok(match base_offset_size {
 0 => {
 0u64
@@ -10924,14 +10872,14 @@ let inner = (Decoder32(_input))?;
 },
 
 8 => {
-(Decoder59(_input))?
+(Decoder60(_input))?
 },
 
 _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let extent_count = ((|| PResult::Ok((Decoder49(_input))?))())?;
+let extent_count = ((|| PResult::Ok((Decoder50(_input))?))())?;
 let extents = ((|| PResult::Ok({
 let mut accum = Vec::new();
 for _ in 0..extent_count {
@@ -10947,7 +10895,7 @@ let inner = (Decoder32(_input))?;
 },
 
 8 => {
-(Decoder59(_input))?
+(Decoder60(_input))?
 },
 
 _other => {
@@ -10965,7 +10913,7 @@ let inner = (Decoder32(_input))?;
 },
 
 8 => {
-(Decoder59(_input))?
+(Decoder60(_input))?
 },
 
 _other => {
@@ -10983,7 +10931,7 @@ let inner = (Decoder32(_input))?;
 },
 
 8 => {
-(Decoder59(_input))?
+(Decoder60(_input))?
 },
 
 _other => {
@@ -11031,7 +10979,7 @@ Type99 { item_ID, construction_method, data_reference_index, base_offset, extent
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder71(_input))?;
+                                    let next_elem = (Decoder72(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11105,15 +11053,15 @@ Type99 { item_ID, construction_method, data_reference_index, base_offset, extent
     })
 }
 
-fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError> {
+fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11162,13 +11110,13 @@ fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError>
                                     1 => {
                                         let inner = {
                                             let creation_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let modification_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let timescale =
                                                 ((|| PResult::Ok((Decoder32(_input))?))())?;
                                             let duration =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             Type117 {
                                                 creation_time,
                                                 modification_time,
@@ -11187,8 +11135,8 @@ fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError>
                                 })
                             })())?;
                             let rate = ((|| PResult::Ok((Decoder32(_input))?))())?;
-                            let volume = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let reserved1 = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let volume = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let reserved1 = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             let reserved2 = ((|| {
                                 PResult::Ok({
                                     let field0 = ((|| PResult::Ok((Decoder32(_input))?))())?;
@@ -11245,7 +11193,7 @@ fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder62(_input))?;
+                                    let next_elem = (Decoder63(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11270,7 +11218,7 @@ fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder63(_input))?;
+                                    let next_elem = (Decoder64(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11319,15 +11267,15 @@ fn Decoder61<'input>(_input: &mut Parser<'input>) -> Result<Type160, ParseError>
     })
 }
 
-fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError> {
+fn Decoder63<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11379,15 +11327,15 @@ fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError>
                                     1 => {
                                         let inner = {
                                             let creation_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let modification_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let track_ID =
                                                 ((|| PResult::Ok((Decoder32(_input))?))())?;
                                             let reserved =
                                                 ((|| PResult::Ok((Decoder32(_input))?))())?;
                                             let duration =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             Type152 {
                                                 creation_time,
                                                 modification_time,
@@ -11413,10 +11361,10 @@ fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError>
                                     (field0, field1)
                                 })
                             })())?;
-                            let layer = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let alternate_group = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let volume = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let reserved1 = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let layer = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let alternate_group = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let volume = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let reserved1 = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             let matrix = ((|| {
                                 PResult::Ok({
                                     let mut accum = Vec::new();
@@ -11459,7 +11407,7 @@ fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder64(_input))?;
+                                    let next_elem = (Decoder65(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11484,7 +11432,7 @@ fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder65(_input))?;
+                                    let next_elem = (Decoder66(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11533,15 +11481,15 @@ fn Decoder62<'input>(_input: &mut Parser<'input>) -> Result<Type156, ParseError>
     })
 }
 
-fn Decoder63<'input>(_input: &mut Parser<'input>) -> Result<Type158, ParseError> {
+fn Decoder64<'input>(_input: &mut Parser<'input>) -> Result<Type158, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11570,7 +11518,7 @@ fn Decoder63<'input>(_input: &mut Parser<'input>) -> Result<Type158, ParseError>
                                         }
                                     };
                                     if matching_ix == 0 {
-                                        let next_elem = (Decoder60(_input))?;
+                                        let next_elem = (Decoder61(_input))?;
                                         accum.push(next_elem);
                                     } else {
                                         break;
@@ -11620,15 +11568,15 @@ fn Decoder63<'input>(_input: &mut Parser<'input>) -> Result<Type158, ParseError>
     })
 }
 
-fn Decoder64<'input>(_input: &mut Parser<'input>) -> Result<Type123, ParseError> {
+fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type123, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11722,15 +11670,15 @@ fn Decoder64<'input>(_input: &mut Parser<'input>) -> Result<Type123, ParseError>
     })
 }
 
-fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError> {
+fn Decoder66<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11755,12 +11703,12 @@ fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError>
                                 })
                             })())?;
                             let component_type = ((|| PResult::Ok((Decoder32(_input))?))())?;
-                            let component_subtype = ((|| PResult::Ok((Decoder58(_input))?))())?;
+                            let component_subtype = ((|| PResult::Ok((Decoder59(_input))?))())?;
                             let component_manufacturer =
                                 ((|| PResult::Ok((Decoder32(_input))?))())?;
                             let component_flags = ((|| PResult::Ok((Decoder32(_input))?))())?;
                             let component_flags_mask = ((|| PResult::Ok((Decoder32(_input))?))())?;
-                            let component_name = ((|| PResult::Ok((Decoder66(_input))?))())?;
+                            let component_name = ((|| PResult::Ok((Decoder67(_input))?))())?;
                             Type124 {
                                 version,
                                 flags,
@@ -11811,13 +11759,13 @@ fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError>
                                     1 => {
                                         let inner = {
                                             let creation_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let modification_time =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             let timescale =
                                                 ((|| PResult::Ok((Decoder32(_input))?))())?;
                                             let duration =
-                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder60(_input))?))())?;
                                             Type117 {
                                                 creation_time,
                                                 modification_time,
@@ -11835,8 +11783,8 @@ fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError>
                                     }
                                 })
                             })())?;
-                            let language = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let pre_defined = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let language = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let pre_defined = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type125 {
                                 version,
                                 flags,
@@ -11862,7 +11810,7 @@ fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder67(_input))?;
+                                    let next_elem = (Decoder68(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -11911,7 +11859,7 @@ fn Decoder65<'input>(_input: &mut Parser<'input>) -> Result<Type150, ParseError>
     })
 }
 
-fn Decoder66<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
     let string = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -11963,15 +11911,15 @@ fn Decoder66<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> 
     PResult::Ok(Type21 { string, null })
 }
 
-fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError> {
+fn Decoder68<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -11995,12 +11943,12 @@ fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError>
                                     (field0, field1, field2)
                                 })
                             })())?;
-                            let graphicsmode = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let graphicsmode = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             let opcolor = ((|| {
                                 PResult::Ok({
                                     let mut accum = Vec::new();
                                     for _ in 0..3u8 {
-                                        accum.push((Decoder49(_input))?);
+                                        accum.push((Decoder50(_input))?);
                                     }
                                     accum
                                 })
@@ -12026,8 +11974,8 @@ fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError>
                                     (field0, field1, field2)
                                 })
                             })())?;
-                            let balance = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                            let reserved = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                            let balance = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                            let reserved = ((|| PResult::Ok((Decoder50(_input))?))())?;
                             Type126 {
                                 version,
                                 flags,
@@ -12052,7 +12000,7 @@ fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder68(_input))?;
+                                    let next_elem = (Decoder69(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -12077,7 +12025,7 @@ fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder69(_input))?;
+                                    let next_elem = (Decoder70(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -12126,15 +12074,15 @@ fn Decoder67<'input>(_input: &mut Parser<'input>) -> Result<Type148, ParseError>
     })
 }
 
-fn Decoder68<'input>(_input: &mut Parser<'input>) -> Result<Type85, ParseError> {
+fn Decoder69<'input>(_input: &mut Parser<'input>) -> Result<Type85, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -12177,13 +12125,13 @@ fn Decoder68<'input>(_input: &mut Parser<'input>) -> Result<Type85, ParseError> 
                                                 let size_field =
                                                     ((|| PResult::Ok((Decoder32(_input))?))())?;
                                                 let r#type =
-                                                    ((|| PResult::Ok((Decoder58(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder59(_input))?))())?;
                                                 let size = ((|| {
                                                     PResult::Ok(match size_field {
                                                         0 => 0u64,
 
                                                         1 => {
-                                                            let inner = (Decoder59(_input))?;
+                                                            let inner = (Decoder60(_input))?;
                                                             ((|x: u64| PResult::Ok(x - 16u64))(
                                                                 inner,
                                                             ))?
@@ -12292,15 +12240,15 @@ fn Decoder68<'input>(_input: &mut Parser<'input>) -> Result<Type85, ParseError> 
     })
 }
 
-fn Decoder69<'input>(_input: &mut Parser<'input>) -> Result<Type145, ParseError> {
+fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type145, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -12333,14 +12281,14 @@ fn Decoder69<'input>(_input: &mut Parser<'input>) -> Result<Type145, ParseError>
                                             for _ in 0..entry_count {
                                                 accum.push({
 let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
 let size = ((|| PResult::Ok(match size_field {
 0 => {
 0u64
 },
 
 1 => {
-let inner = (Decoder59(_input))?;
+let inner = (Decoder60(_input))?;
 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
 },
 
@@ -12571,10 +12519,7 @@ Type82 { size_field, r#type, size, data }
                                         Type140::yes(inner)
                                     }
 
-                                    false => {
-                                        let _ = ();
-                                        Type140::no
-                                    }
+                                    false => Type140::no,
                                 })
                             })())?;
                             Type141 {
@@ -12635,7 +12580,7 @@ Type82 { size_field, r#type, size, data }
                                 PResult::Ok({
                                     let mut accum = Vec::new();
                                     for _ in 0..entry_count {
-                                        accum.push((Decoder59(_input))?);
+                                        accum.push((Decoder60(_input))?);
                                     }
                                     accum
                                 })
@@ -12727,10 +12672,7 @@ Type82 { size_field, r#type, size, data }
                                         Type130::yes(inner)
                                     }
 
-                                    false => {
-                                        let _ = ();
-                                        Type130::no
-                                    }
+                                    false => Type130::no,
                                 })
                             })())?;
                             let entry_count = ((|| PResult::Ok((Decoder32(_input))?))())?;
@@ -12802,15 +12744,15 @@ Type82 { size_field, r#type, size, data }
     })
 }
 
-fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> {
+fn Decoder71<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -12839,15 +12781,15 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
                                     true => {
                                         let inner = {
                                             let item_ID =
-                                                ((|| PResult::Ok((Decoder49(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder50(_input))?))())?;
                                             let item_protection_index =
-                                                ((|| PResult::Ok((Decoder49(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder50(_input))?))())?;
                                             let item_name =
-                                                ((|| PResult::Ok((Decoder73(_input))?))())?;
-                                            let content_type =
                                                 ((|| PResult::Ok((Decoder74(_input))?))())?;
-                                            let content_encoding =
+                                            let content_type =
                                                 ((|| PResult::Ok((Decoder75(_input))?))())?;
+                                            let content_encoding =
+                                                ((|| PResult::Ok((Decoder76(_input))?))())?;
                                             Type91 {
                                                 item_ID,
                                                 item_protection_index,
@@ -12864,7 +12806,7 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
                                             let item_ID = ((|| {
                                                 PResult::Ok(match version == 2u8 {
                                                     true => {
-                                                        let inner = (Decoder49(_input))?;
+                                                        let inner = (Decoder50(_input))?;
                                                         ((|x: u16| PResult::Ok(x as u32))(inner))?
                                                     }
 
@@ -12873,17 +12815,17 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
                                             })(
                                             ))?;
                                             let item_protection_index =
-                                                ((|| PResult::Ok((Decoder49(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder50(_input))?))())?;
                                             let item_type =
-                                                ((|| PResult::Ok((Decoder58(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder59(_input))?))())?;
                                             let item_name =
-                                                ((|| PResult::Ok((Decoder76(_input))?))())?;
+                                                ((|| PResult::Ok((Decoder77(_input))?))())?;
                                             let extra_fields = ((|| {
                                                 PResult::Ok(match item_type {
                                                     (109, 105, 109, 101) => {
                                                         let inner = {
                                                             let content_type = ((|| {
-                                                                PResult::Ok((Decoder77(_input))?)
+                                                                PResult::Ok((Decoder78(_input))?)
                                                             })(
                                                             ))?;
                                                             Type87 { content_type }
@@ -12894,7 +12836,7 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
                                                     (117, 114, 105, 32) => {
                                                         let inner = {
                                                             let item_uri_type = ((|| {
-                                                                PResult::Ok((Decoder77(_input))?)
+                                                                PResult::Ok((Decoder78(_input))?)
                                                             })(
                                                             ))?;
                                                             Type88 { item_uri_type }
@@ -12902,10 +12844,7 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
                                                         Type89::uri(inner)
                                                     }
 
-                                                    _ => {
-                                                        let _ = ();
-                                                        Type89::unknown
-                                                    }
+                                                    _ => Type89::unknown,
                                                 })
                                             })(
                                             ))?;
@@ -12968,15 +12907,15 @@ fn Decoder70<'input>(_input: &mut Parser<'input>) -> Result<Type95, ParseError> 
     })
 }
 
-fn Decoder71<'input>(_input: &mut Parser<'input>) -> Result<Type105, ParseError> {
+fn Decoder72<'input>(_input: &mut Parser<'input>) -> Result<Type105, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -13003,7 +12942,7 @@ fn Decoder71<'input>(_input: &mut Parser<'input>) -> Result<Type105, ParseError>
                                     }
                                 };
                                 if matching_ix == 0 {
-                                    let next_elem = (Decoder72(_input))?;
+                                    let next_elem = (Decoder73(_input))?;
                                     accum.push(next_elem);
                                 } else {
                                     break;
@@ -13052,15 +12991,15 @@ fn Decoder71<'input>(_input: &mut Parser<'input>) -> Result<Type105, ParseError>
     })
 }
 
-fn Decoder72<'input>(_input: &mut Parser<'input>) -> Result<Type103, ParseError> {
+fn Decoder73<'input>(_input: &mut Parser<'input>) -> Result<Type103, ParseError> {
     let size_field = ((|| PResult::Ok((Decoder32(_input))?))())?;
-    let r#type = ((|| PResult::Ok((Decoder58(_input))?))())?;
+    let r#type = ((|| PResult::Ok((Decoder59(_input))?))())?;
     let size = ((|| {
         PResult::Ok(match size_field {
             0 => 0u64,
 
             1 => {
-                let inner = (Decoder59(_input))?;
+                let inner = (Decoder60(_input))?;
                 ((|x: u64| PResult::Ok(x - 16u64))(inner))?
             }
 
@@ -13145,58 +13084,6 @@ fn Decoder72<'input>(_input: &mut Parser<'input>) -> Result<Type103, ParseError>
         size,
         data,
     })
-}
-
-fn Decoder73<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
-    let string = ((|| {
-        PResult::Ok({
-            let mut accum = Vec::new();
-            while _input.remaining() > 0 {
-                let matching_ix = {
-                    _input.open_peek_context();
-                    let b = _input.read_byte()?;
-                    {
-                        let ret = match b {
-                            tmp if (tmp != 0) => 0,
-
-                            0u8 => 1,
-
-                            _ => {
-                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
-                            }
-                        };
-                        _input.close_peek_context()?;
-                        ret
-                    }
-                };
-                if matching_ix == 0 {
-                    let next_elem = {
-                        let b = _input.read_byte()?;
-                        if b != 0 {
-                            b
-                        } else {
-                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
-                        }
-                    };
-                    accum.push(next_elem);
-                } else {
-                    break;
-                }
-            }
-            accum
-        })
-    })())?;
-    let null = ((|| {
-        PResult::Ok({
-            let b = _input.read_byte()?;
-            if b == 0 {
-                b
-            } else {
-                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
-            }
-        })
-    })())?;
-    PResult::Ok(Type21 { string, null })
 }
 
 fn Decoder74<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
@@ -13407,7 +13294,59 @@ fn Decoder77<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> 
     PResult::Ok(Type21 { string, null })
 }
 
-fn Decoder78<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder78<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+    let string = ((|| {
+        PResult::Ok({
+            let mut accum = Vec::new();
+            while _input.remaining() > 0 {
+                let matching_ix = {
+                    _input.open_peek_context();
+                    let b = _input.read_byte()?;
+                    {
+                        let ret = match b {
+                            tmp if (tmp != 0) => 0,
+
+                            0u8 => 1,
+
+                            _ => {
+                                return Err(ParseError::ExcludedBranch(13862338712518612949u64));
+                            }
+                        };
+                        _input.close_peek_context()?;
+                        ret
+                    }
+                };
+                if matching_ix == 0 {
+                    let next_elem = {
+                        let b = _input.read_byte()?;
+                        if b != 0 {
+                            b
+                        } else {
+                            return Err(ParseError::ExcludedBranch(8606461246239977862u64));
+                        }
+                    };
+                    accum.push(next_elem);
+                } else {
+                    break;
+                }
+            }
+            accum
+        })
+    })())?;
+    let null = ((|| {
+        PResult::Ok({
+            let b = _input.read_byte()?;
+            if b == 0 {
+                b
+            } else {
+                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
+            }
+        })
+    })())?;
+    PResult::Ok(Type21 { string, null })
+}
+
+fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -13431,7 +13370,7 @@ fn Decoder78<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> {
+fn Decoder80<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> {
     let initial_segment = ((|| {
         PResult::Ok({
             let tree_index = {
@@ -13458,12 +13397,12 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
             };
             match tree_index {
                 0 => {
-                    let inner = (Decoder81(_input))?;
+                    let inner = (Decoder82(_input))?;
                     Type55::app0(inner)
                 }
 
                 1 => {
-                    let inner = (Decoder82(_input))?;
+                    let inner = (Decoder83(_input))?;
                     Type55::app1(inner)
                 }
 
@@ -13564,7 +13503,7 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder83(_input))?;
+                    let next_elem = (Decoder84(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -13573,8 +13512,8 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
             accum
         })
     })())?;
-    let header = ((|| PResult::Ok((Decoder84(_input))?))())?;
-    let scan = ((|| PResult::Ok((Decoder85(_input))?))())?;
+    let header = ((|| PResult::Ok((Decoder85(_input))?))())?;
+    let scan = ((|| PResult::Ok((Decoder86(_input))?))())?;
     let dnl = ((|| {
         PResult::Ok({
             let tree_index = {
@@ -13645,14 +13584,11 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
             };
             match tree_index {
                 0 => {
-                    let inner = (Decoder86(_input))?;
+                    let inner = (Decoder87(_input))?;
                     Type78::some(inner)
                 }
 
-                1 => {
-                    let _ = ();
-                    Type78::none
-                }
+                1 => Type78::none,
 
                 _ => {
                     return Err(ParseError::ExcludedBranch(11678103101816798445u64));
@@ -13731,7 +13667,7 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder87(_input))?;
+                    let next_elem = (Decoder88(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -13750,7 +13686,7 @@ fn Decoder79<'input>(_input: &mut Parser<'input>) -> Result<Type79, ParseError> 
     })
 }
 
-fn Decoder80<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder81<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -13774,7 +13710,7 @@ fn Decoder80<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder81<'input>(_input: &mut Parser<'input>) -> Result<Type45, ParseError> {
+fn Decoder82<'input>(_input: &mut Parser<'input>) -> Result<Type45, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -13800,12 +13736,12 @@ fn Decoder81<'input>(_input: &mut Parser<'input>) -> Result<Type45, ParseError> 
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder147(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder148(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -13817,7 +13753,7 @@ fn Decoder81<'input>(_input: &mut Parser<'input>) -> Result<Type45, ParseError> 
     })
 }
 
-fn Decoder82<'input>(_input: &mut Parser<'input>) -> Result<Type54, ParseError> {
+fn Decoder83<'input>(_input: &mut Parser<'input>) -> Result<Type54, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -13843,12 +13779,12 @@ fn Decoder82<'input>(_input: &mut Parser<'input>) -> Result<Type54, ParseError> 
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder141(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder142(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -13860,7 +13796,7 @@ fn Decoder82<'input>(_input: &mut Parser<'input>) -> Result<Type54, ParseError> 
     })
 }
 
-fn Decoder83<'input>(_input: &mut Parser<'input>) -> Result<Type65, ParseError> {
+fn Decoder84<'input>(_input: &mut Parser<'input>) -> Result<Type65, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -13923,107 +13859,107 @@ fn Decoder83<'input>(_input: &mut Parser<'input>) -> Result<Type65, ParseError> 
     };
     PResult::Ok(match tree_index {
         0 => {
-            let inner = (Decoder118(_input))?;
+            let inner = (Decoder119(_input))?;
             Type65::dqt(inner)
         }
 
         1 => {
-            let inner = (Decoder119(_input))?;
+            let inner = (Decoder120(_input))?;
             Type65::dht(inner)
         }
 
         2 => {
-            let inner = (Decoder120(_input))?;
+            let inner = (Decoder121(_input))?;
             Type65::dac(inner)
         }
 
         3 => {
-            let inner = (Decoder121(_input))?;
+            let inner = (Decoder122(_input))?;
             Type65::dri(inner)
         }
 
         4 => {
-            let inner = (Decoder81(_input))?;
+            let inner = (Decoder82(_input))?;
             Type65::app0(inner)
         }
 
         5 => {
-            let inner = (Decoder82(_input))?;
+            let inner = (Decoder83(_input))?;
             Type65::app1(inner)
         }
 
         6 => {
-            let inner = (Decoder122(_input))?;
+            let inner = (Decoder123(_input))?;
             Type65::app2(inner)
         }
 
         7 => {
-            let inner = (Decoder123(_input))?;
+            let inner = (Decoder124(_input))?;
             Type65::app3(inner)
         }
 
         8 => {
-            let inner = (Decoder124(_input))?;
+            let inner = (Decoder125(_input))?;
             Type65::app4(inner)
         }
 
         9 => {
-            let inner = (Decoder125(_input))?;
+            let inner = (Decoder126(_input))?;
             Type65::app5(inner)
         }
 
         10 => {
-            let inner = (Decoder126(_input))?;
+            let inner = (Decoder127(_input))?;
             Type65::app6(inner)
         }
 
         11 => {
-            let inner = (Decoder127(_input))?;
+            let inner = (Decoder128(_input))?;
             Type65::app7(inner)
         }
 
         12 => {
-            let inner = (Decoder128(_input))?;
+            let inner = (Decoder129(_input))?;
             Type65::app8(inner)
         }
 
         13 => {
-            let inner = (Decoder129(_input))?;
+            let inner = (Decoder130(_input))?;
             Type65::app9(inner)
         }
 
         14 => {
-            let inner = (Decoder130(_input))?;
+            let inner = (Decoder131(_input))?;
             Type65::app10(inner)
         }
 
         15 => {
-            let inner = (Decoder131(_input))?;
+            let inner = (Decoder132(_input))?;
             Type65::app11(inner)
         }
 
         16 => {
-            let inner = (Decoder132(_input))?;
+            let inner = (Decoder133(_input))?;
             Type65::app12(inner)
         }
 
         17 => {
-            let inner = (Decoder133(_input))?;
+            let inner = (Decoder134(_input))?;
             Type65::app13(inner)
         }
 
         18 => {
-            let inner = (Decoder134(_input))?;
+            let inner = (Decoder135(_input))?;
             Type65::app14(inner)
         }
 
         19 => {
-            let inner = (Decoder135(_input))?;
+            let inner = (Decoder136(_input))?;
             Type65::app15(inner)
         }
 
         20 => {
-            let inner = (Decoder136(_input))?;
+            let inner = (Decoder137(_input))?;
             Type65::com(inner)
         }
 
@@ -14033,7 +13969,7 @@ fn Decoder83<'input>(_input: &mut Parser<'input>) -> Result<Type65, ParseError> 
     })
 }
 
-fn Decoder84<'input>(_input: &mut Parser<'input>) -> Result<Type69, ParseError> {
+fn Decoder85<'input>(_input: &mut Parser<'input>) -> Result<Type69, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -14080,67 +14016,67 @@ fn Decoder84<'input>(_input: &mut Parser<'input>) -> Result<Type69, ParseError> 
     };
     PResult::Ok(match tree_index {
         0 => {
-            let inner = (Decoder103(_input))?;
+            let inner = (Decoder104(_input))?;
             Type69::sof0(inner)
         }
 
         1 => {
-            let inner = (Decoder104(_input))?;
+            let inner = (Decoder105(_input))?;
             Type69::sof1(inner)
         }
 
         2 => {
-            let inner = (Decoder105(_input))?;
+            let inner = (Decoder106(_input))?;
             Type69::sof2(inner)
         }
 
         3 => {
-            let inner = (Decoder106(_input))?;
+            let inner = (Decoder107(_input))?;
             Type69::sof3(inner)
         }
 
         4 => {
-            let inner = (Decoder107(_input))?;
+            let inner = (Decoder108(_input))?;
             Type69::sof5(inner)
         }
 
         5 => {
-            let inner = (Decoder108(_input))?;
+            let inner = (Decoder109(_input))?;
             Type69::sof6(inner)
         }
 
         6 => {
-            let inner = (Decoder109(_input))?;
+            let inner = (Decoder110(_input))?;
             Type69::sof7(inner)
         }
 
         7 => {
-            let inner = (Decoder110(_input))?;
+            let inner = (Decoder111(_input))?;
             Type69::sof9(inner)
         }
 
         8 => {
-            let inner = (Decoder111(_input))?;
+            let inner = (Decoder112(_input))?;
             Type69::sof10(inner)
         }
 
         9 => {
-            let inner = (Decoder112(_input))?;
+            let inner = (Decoder113(_input))?;
             Type69::sof11(inner)
         }
 
         10 => {
-            let inner = (Decoder113(_input))?;
+            let inner = (Decoder114(_input))?;
             Type69::sof13(inner)
         }
 
         11 => {
-            let inner = (Decoder114(_input))?;
+            let inner = (Decoder115(_input))?;
             Type69::sof14(inner)
         }
 
         12 => {
-            let inner = (Decoder115(_input))?;
+            let inner = (Decoder116(_input))?;
             Type69::sof15(inner)
         }
 
@@ -14150,7 +14086,7 @@ fn Decoder84<'input>(_input: &mut Parser<'input>) -> Result<Type69, ParseError> 
     })
 }
 
-fn Decoder85<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> {
+fn Decoder86<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> {
     let segments = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -14218,7 +14154,7 @@ fn Decoder85<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder83(_input))?;
+                    let next_elem = (Decoder84(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -14227,8 +14163,8 @@ fn Decoder85<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
             accum
         })
     })())?;
-    let sos = ((|| PResult::Ok((Decoder88(_input))?))())?;
-    let data = ((|| PResult::Ok((Decoder102(_input))?))())?;
+    let sos = ((|| PResult::Ok((Decoder89(_input))?))())?;
+    let data = ((|| PResult::Ok((Decoder103(_input))?))())?;
     PResult::Ok(Type75 {
         segments,
         sos,
@@ -14236,7 +14172,7 @@ fn Decoder85<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
     })
 }
 
-fn Decoder86<'input>(_input: &mut Parser<'input>) -> Result<Type77, ParseError> {
+fn Decoder87<'input>(_input: &mut Parser<'input>) -> Result<Type77, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -14262,12 +14198,12 @@ fn Decoder86<'input>(_input: &mut Parser<'input>) -> Result<Type77, ParseError> 
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder101(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder102(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -14279,7 +14215,7 @@ fn Decoder86<'input>(_input: &mut Parser<'input>) -> Result<Type77, ParseError> 
     })
 }
 
-fn Decoder87<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> {
+fn Decoder88<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> {
     let segments = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -14347,7 +14283,7 @@ fn Decoder87<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder83(_input))?;
+                    let next_elem = (Decoder84(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -14356,8 +14292,8 @@ fn Decoder87<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
             accum
         })
     })())?;
-    let sos = ((|| PResult::Ok((Decoder88(_input))?))())?;
-    let data = ((|| PResult::Ok((Decoder89(_input))?))())?;
+    let sos = ((|| PResult::Ok((Decoder89(_input))?))())?;
+    let data = ((|| PResult::Ok((Decoder90(_input))?))())?;
     PResult::Ok(Type75 {
         segments,
         sos,
@@ -14365,7 +14301,7 @@ fn Decoder87<'input>(_input: &mut Parser<'input>) -> Result<Type75, ParseError> 
     })
 }
 
-fn Decoder88<'input>(_input: &mut Parser<'input>) -> Result<Type72, ParseError> {
+fn Decoder89<'input>(_input: &mut Parser<'input>) -> Result<Type72, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -14391,12 +14327,12 @@ fn Decoder88<'input>(_input: &mut Parser<'input>) -> Result<Type72, ParseError> 
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder99(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder100(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -14408,7 +14344,7 @@ fn Decoder88<'input>(_input: &mut Parser<'input>) -> Result<Type72, ParseError> 
     })
 }
 
-fn Decoder89<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> {
+fn Decoder90<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> {
     let scan_data = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -14553,47 +14489,47 @@ fn Decoder89<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> 
                         };
                         match tree_index {
                             0 => {
-                                let inner = (Decoder90(_input))?;
+                                let inner = (Decoder91(_input))?;
                                 Type73::mcu(inner)
                             }
 
                             1 => {
-                                let inner = (Decoder91(_input))?;
+                                let inner = (Decoder92(_input))?;
                                 Type73::rst0(inner)
                             }
 
                             2 => {
-                                let inner = (Decoder92(_input))?;
+                                let inner = (Decoder93(_input))?;
                                 Type73::rst1(inner)
                             }
 
                             3 => {
-                                let inner = (Decoder93(_input))?;
+                                let inner = (Decoder94(_input))?;
                                 Type73::rst2(inner)
                             }
 
                             4 => {
-                                let inner = (Decoder94(_input))?;
+                                let inner = (Decoder95(_input))?;
                                 Type73::rst3(inner)
                             }
 
                             5 => {
-                                let inner = (Decoder95(_input))?;
+                                let inner = (Decoder96(_input))?;
                                 Type73::rst4(inner)
                             }
 
                             6 => {
-                                let inner = (Decoder96(_input))?;
+                                let inner = (Decoder97(_input))?;
                                 Type73::rst5(inner)
                             }
 
                             7 => {
-                                let inner = (Decoder97(_input))?;
+                                let inner = (Decoder98(_input))?;
                                 Type73::rst6(inner)
                             }
 
                             8 => {
-                                let inner = (Decoder98(_input))?;
+                                let inner = (Decoder99(_input))?;
                                 Type73::rst7(inner)
                             }
 
@@ -14641,7 +14577,7 @@ fn Decoder89<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> 
     })
 }
 
-fn Decoder90<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
+fn Decoder91<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -14702,7 +14638,7 @@ fn Decoder90<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
     })
 }
 
-fn Decoder91<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder92<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14726,7 +14662,7 @@ fn Decoder91<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder92<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder93<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14750,7 +14686,7 @@ fn Decoder92<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder93<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder94<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14774,7 +14710,7 @@ fn Decoder93<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder94<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder95<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14798,7 +14734,7 @@ fn Decoder94<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder95<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder96<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14822,7 +14758,7 @@ fn Decoder95<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder96<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder97<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14846,7 +14782,7 @@ fn Decoder96<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder97<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder98<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14870,7 +14806,7 @@ fn Decoder97<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder98<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
+fn Decoder99<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> {
     let ff = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -14894,13 +14830,13 @@ fn Decoder98<'input>(_input: &mut Parser<'input>) -> Result<Type41, ParseError> 
     PResult::Ok(Type41 { ff, marker })
 }
 
-fn Decoder99<'input>(_input: &mut Parser<'input>) -> Result<Type71, ParseError> {
+fn Decoder100<'input>(_input: &mut Parser<'input>) -> Result<Type71, ParseError> {
     let num_image_components = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let image_components = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
             for _ in 0..num_image_components {
-                accum.push((Decoder100(_input))?);
+                accum.push((Decoder101(_input))?);
             }
             accum
         })
@@ -14917,7 +14853,7 @@ fn Decoder99<'input>(_input: &mut Parser<'input>) -> Result<Type71, ParseError> 
     })
 }
 
-fn Decoder100<'input>(_input: &mut Parser<'input>) -> Result<Type70, ParseError> {
+fn Decoder101<'input>(_input: &mut Parser<'input>) -> Result<Type70, ParseError> {
     let component_selector = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let entropy_coding_table_ids = ((|| PResult::Ok((Decoder16(_input))?))())?;
     PResult::Ok(Type70 {
@@ -14926,12 +14862,12 @@ fn Decoder100<'input>(_input: &mut Parser<'input>) -> Result<Type70, ParseError>
     })
 }
 
-fn Decoder101<'input>(_input: &mut Parser<'input>) -> Result<Type76, ParseError> {
-    let num_lines = ((|| PResult::Ok((Decoder49(_input))?))())?;
+fn Decoder102<'input>(_input: &mut Parser<'input>) -> Result<Type76, ParseError> {
+    let num_lines = ((|| PResult::Ok((Decoder50(_input))?))())?;
     PResult::Ok(Type76 { num_lines })
 }
 
-fn Decoder102<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> {
+fn Decoder103<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError> {
     let scan_data = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -15078,47 +15014,47 @@ fn Decoder102<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError>
                         };
                         match tree_index {
                             0 => {
-                                let inner = (Decoder90(_input))?;
+                                let inner = (Decoder91(_input))?;
                                 Type73::mcu(inner)
                             }
 
                             1 => {
-                                let inner = (Decoder91(_input))?;
+                                let inner = (Decoder92(_input))?;
                                 Type73::rst0(inner)
                             }
 
                             2 => {
-                                let inner = (Decoder92(_input))?;
+                                let inner = (Decoder93(_input))?;
                                 Type73::rst1(inner)
                             }
 
                             3 => {
-                                let inner = (Decoder93(_input))?;
+                                let inner = (Decoder94(_input))?;
                                 Type73::rst2(inner)
                             }
 
                             4 => {
-                                let inner = (Decoder94(_input))?;
+                                let inner = (Decoder95(_input))?;
                                 Type73::rst3(inner)
                             }
 
                             5 => {
-                                let inner = (Decoder95(_input))?;
+                                let inner = (Decoder96(_input))?;
                                 Type73::rst4(inner)
                             }
 
                             6 => {
-                                let inner = (Decoder96(_input))?;
+                                let inner = (Decoder97(_input))?;
                                 Type73::rst5(inner)
                             }
 
                             7 => {
-                                let inner = (Decoder97(_input))?;
+                                let inner = (Decoder98(_input))?;
                                 Type73::rst6(inner)
                             }
 
                             8 => {
-                                let inner = (Decoder98(_input))?;
+                                let inner = (Decoder99(_input))?;
                                 Type73::rst7(inner)
                             }
 
@@ -15166,7 +15102,7 @@ fn Decoder102<'input>(_input: &mut Parser<'input>) -> Result<Type74, ParseError>
     })
 }
 
-fn Decoder103<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError> {
+fn Decoder104<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15192,55 +15128,12 @@ fn Decoder103<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
-            _input.end_slice()?;
-            ret
-        })
-    })())?;
-    PResult::Ok(Type68 {
-        marker,
-        length,
-        data,
-    })
-}
-
-fn Decoder104<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError> {
-    let marker = ((|| {
-        PResult::Ok({
-            let ff = ((|| {
-                PResult::Ok({
-                    let b = _input.read_byte()?;
-                    if b == 255 {
-                        b
-                    } else {
-                        return Err(ParseError::ExcludedBranch(10618271977672484401u64));
-                    }
-                })
-            })())?;
-            let marker = ((|| {
-                PResult::Ok({
-                    let b = _input.read_byte()?;
-                    if b == 193 {
-                        b
-                    } else {
-                        return Err(ParseError::ExcludedBranch(8756819601933520429u64));
-                    }
-                })
-            })())?;
-            Type41 { ff, marker }
-        })
-    })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
-    let data = ((|| {
-        PResult::Ok({
-            let sz = (length - 2u16) as usize;
-            _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15268,22 +15161,22 @@ fn Decoder105<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 194 {
+                    if b == 193 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(11080817261996913520u64));
+                        return Err(ParseError::ExcludedBranch(8756819601933520429u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15311,22 +15204,22 @@ fn Decoder106<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 195 {
+                    if b == 194 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(12909450577628061793u64));
+                        return Err(ParseError::ExcludedBranch(11080817261996913520u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15354,22 +15247,22 @@ fn Decoder107<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 197 {
+                    if b == 195 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(5274098556056955310u64));
+                        return Err(ParseError::ExcludedBranch(12909450577628061793u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15397,22 +15290,22 @@ fn Decoder108<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 198 {
+                    if b == 197 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(5472222913557901985u64));
+                        return Err(ParseError::ExcludedBranch(5274098556056955310u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15440,22 +15333,22 @@ fn Decoder109<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 199 {
+                    if b == 198 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(935456091642960999u64));
+                        return Err(ParseError::ExcludedBranch(5472222913557901985u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15483,22 +15376,22 @@ fn Decoder110<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 201 {
+                    if b == 199 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(17091795488609854789u64));
+                        return Err(ParseError::ExcludedBranch(935456091642960999u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15526,22 +15419,22 @@ fn Decoder111<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 202 {
+                    if b == 201 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(14420220630934832328u64));
+                        return Err(ParseError::ExcludedBranch(17091795488609854789u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15569,22 +15462,22 @@ fn Decoder112<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 203 {
+                    if b == 202 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(10502663948806018262u64));
+                        return Err(ParseError::ExcludedBranch(14420220630934832328u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15612,22 +15505,22 @@ fn Decoder113<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 205 {
+                    if b == 203 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(5170411260421882161u64));
+                        return Err(ParseError::ExcludedBranch(10502663948806018262u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15655,22 +15548,22 @@ fn Decoder114<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 206 {
+                    if b == 205 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(8862644040087288472u64));
+                        return Err(ParseError::ExcludedBranch(5170411260421882161u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15698,22 +15591,22 @@ fn Decoder115<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 207 {
+                    if b == 206 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(6282714738219454149u64));
+                        return Err(ParseError::ExcludedBranch(8862644040087288472u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder116(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15725,16 +15618,59 @@ fn Decoder115<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError>
     })
 }
 
-fn Decoder116<'input>(_input: &mut Parser<'input>) -> Result<Type67, ParseError> {
+fn Decoder116<'input>(_input: &mut Parser<'input>) -> Result<Type68, ParseError> {
+    let marker = ((|| {
+        PResult::Ok({
+            let ff = ((|| {
+                PResult::Ok({
+                    let b = _input.read_byte()?;
+                    if b == 255 {
+                        b
+                    } else {
+                        return Err(ParseError::ExcludedBranch(10618271977672484401u64));
+                    }
+                })
+            })())?;
+            let marker = ((|| {
+                PResult::Ok({
+                    let b = _input.read_byte()?;
+                    if b == 207 {
+                        b
+                    } else {
+                        return Err(ParseError::ExcludedBranch(6282714738219454149u64));
+                    }
+                })
+            })())?;
+            Type41 { ff, marker }
+        })
+    })())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
+    let data = ((|| {
+        PResult::Ok({
+            let sz = (length - 2u16) as usize;
+            _input.start_slice(sz)?;
+            let ret = ((|| PResult::Ok((Decoder117(_input))?))())?;
+            _input.end_slice()?;
+            ret
+        })
+    })())?;
+    PResult::Ok(Type68 {
+        marker,
+        length,
+        data,
+    })
+}
+
+fn Decoder117<'input>(_input: &mut Parser<'input>) -> Result<Type67, ParseError> {
     let sample_precision = ((|| PResult::Ok((Decoder16(_input))?))())?;
-    let num_lines = ((|| PResult::Ok((Decoder49(_input))?))())?;
-    let num_samples_per_line = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let num_lines = ((|| PResult::Ok((Decoder50(_input))?))())?;
+    let num_samples_per_line = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let num_image_components = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let image_components = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
             for _ in 0..num_image_components {
-                accum.push((Decoder117(_input))?);
+                accum.push((Decoder118(_input))?);
             }
             accum
         })
@@ -15748,7 +15684,7 @@ fn Decoder116<'input>(_input: &mut Parser<'input>) -> Result<Type67, ParseError>
     })
 }
 
-fn Decoder117<'input>(_input: &mut Parser<'input>) -> Result<Type66, ParseError> {
+fn Decoder118<'input>(_input: &mut Parser<'input>) -> Result<Type66, ParseError> {
     let id = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let sampling_factor = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let quantization_table_id = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -15759,7 +15695,7 @@ fn Decoder117<'input>(_input: &mut Parser<'input>) -> Result<Type66, ParseError>
     })
 }
 
-fn Decoder118<'input>(_input: &mut Parser<'input>) -> Result<Type62, ParseError> {
+fn Decoder119<'input>(_input: &mut Parser<'input>) -> Result<Type62, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15785,12 +15721,12 @@ fn Decoder118<'input>(_input: &mut Parser<'input>) -> Result<Type62, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder140(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder141(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15802,7 +15738,7 @@ fn Decoder118<'input>(_input: &mut Parser<'input>) -> Result<Type62, ParseError>
     })
 }
 
-fn Decoder119<'input>(_input: &mut Parser<'input>) -> Result<Type60, ParseError> {
+fn Decoder120<'input>(_input: &mut Parser<'input>) -> Result<Type60, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15828,12 +15764,12 @@ fn Decoder119<'input>(_input: &mut Parser<'input>) -> Result<Type60, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder139(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder140(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15845,7 +15781,7 @@ fn Decoder119<'input>(_input: &mut Parser<'input>) -> Result<Type60, ParseError>
     })
 }
 
-fn Decoder120<'input>(_input: &mut Parser<'input>) -> Result<Type58, ParseError> {
+fn Decoder121<'input>(_input: &mut Parser<'input>) -> Result<Type58, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15871,12 +15807,12 @@ fn Decoder120<'input>(_input: &mut Parser<'input>) -> Result<Type58, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder138(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder139(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15888,7 +15824,7 @@ fn Decoder120<'input>(_input: &mut Parser<'input>) -> Result<Type58, ParseError>
     })
 }
 
-fn Decoder121<'input>(_input: &mut Parser<'input>) -> Result<Type64, ParseError> {
+fn Decoder122<'input>(_input: &mut Parser<'input>) -> Result<Type64, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15914,12 +15850,12 @@ fn Decoder121<'input>(_input: &mut Parser<'input>) -> Result<Type64, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
             _input.start_slice(sz)?;
-            let ret = ((|| PResult::Ok((Decoder137(_input))?))())?;
+            let ret = ((|| PResult::Ok((Decoder138(_input))?))())?;
             _input.end_slice()?;
             ret
         })
@@ -15931,7 +15867,7 @@ fn Decoder121<'input>(_input: &mut Parser<'input>) -> Result<Type64, ParseError>
     })
 }
 
-fn Decoder122<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError> {
+fn Decoder123<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError> {
     let marker = ((|| {
         PResult::Ok({
             let ff = ((|| {
@@ -15957,72 +15893,7 @@ fn Decoder122<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
-    let data = ((|| {
-        PResult::Ok({
-            let sz = (length - 2u16) as usize;
-            _input.start_slice(sz)?;
-            let ret = ((|| {
-                PResult::Ok({
-                    let mut accum = Vec::new();
-                    while _input.remaining() > 0 {
-                        let matching_ix = {
-                            _input.open_peek_context();
-                            _input.read_byte()?;
-                            {
-                                let ret = 0;
-                                _input.close_peek_context()?;
-                                ret
-                            }
-                        };
-                        if matching_ix == 0 {
-                            let next_elem = (Decoder16(_input))?;
-                            accum.push(next_elem);
-                        } else {
-                            break;
-                        }
-                    }
-                    accum
-                })
-            })())?;
-            _input.end_slice()?;
-            ret
-        })
-    })())?;
-    PResult::Ok(Type56 {
-        marker,
-        length,
-        data,
-    })
-}
-
-fn Decoder123<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError> {
-    let marker = ((|| {
-        PResult::Ok({
-            let ff = ((|| {
-                PResult::Ok({
-                    let b = _input.read_byte()?;
-                    if b == 255 {
-                        b
-                    } else {
-                        return Err(ParseError::ExcludedBranch(10618271977672484401u64));
-                    }
-                })
-            })())?;
-            let marker = ((|| {
-                PResult::Ok({
-                    let b = _input.read_byte()?;
-                    if b == 227 {
-                        b
-                    } else {
-                        return Err(ParseError::ExcludedBranch(2795443158724701367u64));
-                    }
-                })
-            })())?;
-            Type41 { ff, marker }
-        })
-    })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16077,17 +15948,17 @@ fn Decoder124<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 228 {
+                    if b == 227 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(3355559118720108211u64));
+                        return Err(ParseError::ExcludedBranch(2795443158724701367u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16142,17 +16013,17 @@ fn Decoder125<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 229 {
+                    if b == 228 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(14742198720488010940u64));
+                        return Err(ParseError::ExcludedBranch(3355559118720108211u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16207,17 +16078,17 @@ fn Decoder126<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 230 {
+                    if b == 229 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(6277645557415946825u64));
+                        return Err(ParseError::ExcludedBranch(14742198720488010940u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16272,17 +16143,17 @@ fn Decoder127<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 231 {
+                    if b == 230 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(2176159342917065583u64));
+                        return Err(ParseError::ExcludedBranch(6277645557415946825u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16337,17 +16208,17 @@ fn Decoder128<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 232 {
+                    if b == 231 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(6957547562921215229u64));
+                        return Err(ParseError::ExcludedBranch(2176159342917065583u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16402,17 +16273,17 @@ fn Decoder129<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 233 {
+                    if b == 232 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(3756953894146529854u64));
+                        return Err(ParseError::ExcludedBranch(6957547562921215229u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16467,17 +16338,17 @@ fn Decoder130<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 234 {
+                    if b == 233 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(12608692552323012024u64));
+                        return Err(ParseError::ExcludedBranch(3756953894146529854u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16532,17 +16403,17 @@ fn Decoder131<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 235 {
+                    if b == 234 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(2716996167109240019u64));
+                        return Err(ParseError::ExcludedBranch(12608692552323012024u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16597,17 +16468,17 @@ fn Decoder132<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 236 {
+                    if b == 235 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(6641423197242755780u64));
+                        return Err(ParseError::ExcludedBranch(2716996167109240019u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16662,17 +16533,17 @@ fn Decoder133<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 237 {
+                    if b == 236 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(4000866269867594892u64));
+                        return Err(ParseError::ExcludedBranch(6641423197242755780u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16727,17 +16598,17 @@ fn Decoder134<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 238 {
+                    if b == 237 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(7832938568744868798u64));
+                        return Err(ParseError::ExcludedBranch(4000866269867594892u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16792,17 +16663,17 @@ fn Decoder135<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 239 {
+                    if b == 238 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(52255437925028600u64));
+                        return Err(ParseError::ExcludedBranch(7832938568744868798u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16857,17 +16728,17 @@ fn Decoder136<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
             let marker = ((|| {
                 PResult::Ok({
                     let b = _input.read_byte()?;
-                    if b == 254 {
+                    if b == 239 {
                         b
                     } else {
-                        return Err(ParseError::ExcludedBranch(5705528789532761578u64));
+                        return Err(ParseError::ExcludedBranch(52255437925028600u64));
                     }
                 })
             })())?;
             Type41 { ff, marker }
         })
     })())?;
-    let length = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let data = ((|| {
         PResult::Ok({
             let sz = (length - 2u16) as usize;
@@ -16906,12 +16777,77 @@ fn Decoder136<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError>
     })
 }
 
-fn Decoder137<'input>(_input: &mut Parser<'input>) -> Result<Type63, ParseError> {
-    let restart_interval = ((|| PResult::Ok((Decoder49(_input))?))())?;
+fn Decoder137<'input>(_input: &mut Parser<'input>) -> Result<Type56, ParseError> {
+    let marker = ((|| {
+        PResult::Ok({
+            let ff = ((|| {
+                PResult::Ok({
+                    let b = _input.read_byte()?;
+                    if b == 255 {
+                        b
+                    } else {
+                        return Err(ParseError::ExcludedBranch(10618271977672484401u64));
+                    }
+                })
+            })())?;
+            let marker = ((|| {
+                PResult::Ok({
+                    let b = _input.read_byte()?;
+                    if b == 254 {
+                        b
+                    } else {
+                        return Err(ParseError::ExcludedBranch(5705528789532761578u64));
+                    }
+                })
+            })())?;
+            Type41 { ff, marker }
+        })
+    })())?;
+    let length = ((|| PResult::Ok((Decoder50(_input))?))())?;
+    let data = ((|| {
+        PResult::Ok({
+            let sz = (length - 2u16) as usize;
+            _input.start_slice(sz)?;
+            let ret = ((|| {
+                PResult::Ok({
+                    let mut accum = Vec::new();
+                    while _input.remaining() > 0 {
+                        let matching_ix = {
+                            _input.open_peek_context();
+                            _input.read_byte()?;
+                            {
+                                let ret = 0;
+                                _input.close_peek_context()?;
+                                ret
+                            }
+                        };
+                        if matching_ix == 0 {
+                            let next_elem = (Decoder16(_input))?;
+                            accum.push(next_elem);
+                        } else {
+                            break;
+                        }
+                    }
+                    accum
+                })
+            })())?;
+            _input.end_slice()?;
+            ret
+        })
+    })())?;
+    PResult::Ok(Type56 {
+        marker,
+        length,
+        data,
+    })
+}
+
+fn Decoder138<'input>(_input: &mut Parser<'input>) -> Result<Type63, ParseError> {
+    let restart_interval = ((|| PResult::Ok((Decoder50(_input))?))())?;
     PResult::Ok(Type63 { restart_interval })
 }
 
-fn Decoder138<'input>(_input: &mut Parser<'input>) -> Result<Type57, ParseError> {
+fn Decoder139<'input>(_input: &mut Parser<'input>) -> Result<Type57, ParseError> {
     let class_table_id = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let value = ((|| PResult::Ok((Decoder16(_input))?))())?;
     PResult::Ok(Type57 {
@@ -16920,7 +16856,7 @@ fn Decoder138<'input>(_input: &mut Parser<'input>) -> Result<Type57, ParseError>
     })
 }
 
-fn Decoder139<'input>(_input: &mut Parser<'input>) -> Result<Type59, ParseError> {
+fn Decoder140<'input>(_input: &mut Parser<'input>) -> Result<Type59, ParseError> {
     let class_table_id = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let num_codes = ((|| {
         PResult::Ok({
@@ -16961,7 +16897,7 @@ fn Decoder139<'input>(_input: &mut Parser<'input>) -> Result<Type59, ParseError>
     })
 }
 
-fn Decoder140<'input>(_input: &mut Parser<'input>) -> Result<Type61, ParseError> {
+fn Decoder141<'input>(_input: &mut Parser<'input>) -> Result<Type61, ParseError> {
     let precision_table_id = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let elements = ((|| {
         PResult::Ok({
@@ -16992,18 +16928,18 @@ fn Decoder140<'input>(_input: &mut Parser<'input>) -> Result<Type61, ParseError>
     })
 }
 
-fn Decoder141<'input>(_input: &mut Parser<'input>) -> Result<Type53, ParseError> {
-    let identifier = ((|| PResult::Ok((Decoder142(_input))?))())?;
+fn Decoder142<'input>(_input: &mut Parser<'input>) -> Result<Type53, ParseError> {
+    let identifier = ((|| PResult::Ok((Decoder143(_input))?))())?;
     let data = ((|| {
         PResult::Ok(match identifier.clone().string.as_slice() {
             [69, 120, 105, 102] => {
-                let inner = (Decoder143(_input))?;
+                let inner = (Decoder144(_input))?;
                 Type52::exif(inner)
             }
 
             [104, 116, 116, 112, 58, 47, 47, 110, 115, 46, 97, 100, 111, 98, 101, 46, 99, 111, 109, 47, 120, 97, 112, 47, 49, 46, 48, 47] =>
             {
-                let inner = (Decoder144(_input))?;
+                let inner = (Decoder145(_input))?;
                 Type52::xmp(inner)
             }
 
@@ -17036,7 +16972,7 @@ fn Decoder141<'input>(_input: &mut Parser<'input>) -> Result<Type53, ParseError>
     PResult::Ok(Type53 { identifier, data })
 }
 
-fn Decoder142<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+fn Decoder143<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
     let string = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -17088,7 +17024,7 @@ fn Decoder142<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError>
     PResult::Ok(Type21 { string, null })
 }
 
-fn Decoder143<'input>(_input: &mut Parser<'input>) -> Result<Type50, ParseError> {
+fn Decoder144<'input>(_input: &mut Parser<'input>) -> Result<Type50, ParseError> {
     let padding = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -17099,11 +17035,11 @@ fn Decoder143<'input>(_input: &mut Parser<'input>) -> Result<Type50, ParseError>
             }
         })
     })())?;
-    let exif = ((|| PResult::Ok((Decoder145(_input))?))())?;
+    let exif = ((|| PResult::Ok((Decoder146(_input))?))())?;
     PResult::Ok(Type50 { padding, exif })
 }
 
-fn Decoder144<'input>(_input: &mut Parser<'input>) -> Result<Type51, ParseError> {
+fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type51, ParseError> {
     let xmp = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -17130,7 +17066,7 @@ fn Decoder144<'input>(_input: &mut Parser<'input>) -> Result<Type51, ParseError>
     PResult::Ok(Type51 { xmp })
 }
 
-fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError> {
+fn Decoder146<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError> {
     let byte_order = ((|| {
         PResult::Ok({
             let tree_index = {
@@ -17207,9 +17143,9 @@ fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError>
     })())?;
     let magic = ((|| {
         PResult::Ok(match byte_order {
-            Type46::le(..) => (Decoder146(_input))?,
+            Type46::le(..) => (Decoder147(_input))?,
 
-            Type46::be(..) => (Decoder49(_input))?,
+            Type46::be(..) => (Decoder50(_input))?,
         })
     })())?;
     let offset = ((|| {
@@ -17226,14 +17162,14 @@ fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError>
             let ret = ((|| {
                 PResult::Ok(match byte_order {
                     Type46::le(..) => {
-                        let num_fields = ((|| PResult::Ok((Decoder146(_input))?))())?;
+                        let num_fields = ((|| PResult::Ok((Decoder147(_input))?))())?;
                         let fields = ((|| {
                             PResult::Ok({
                                 let mut accum = Vec::new();
                                 for _ in 0..num_fields {
                                     accum.push({
-                                        let tag = ((|| PResult::Ok((Decoder146(_input))?))())?;
-                                        let r#type = ((|| PResult::Ok((Decoder146(_input))?))())?;
+                                        let tag = ((|| PResult::Ok((Decoder147(_input))?))())?;
+                                        let r#type = ((|| PResult::Ok((Decoder147(_input))?))())?;
                                         let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
                                         let offset_or_data =
                                             ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -17281,14 +17217,14 @@ fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError>
                     }
 
                     Type46::be(..) => {
-                        let num_fields = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                        let num_fields = ((|| PResult::Ok((Decoder50(_input))?))())?;
                         let fields = ((|| {
                             PResult::Ok({
                                 let mut accum = Vec::new();
                                 for _ in 0..num_fields {
                                     accum.push({
-                                        let tag = ((|| PResult::Ok((Decoder49(_input))?))())?;
-                                        let r#type = ((|| PResult::Ok((Decoder49(_input))?))())?;
+                                        let tag = ((|| PResult::Ok((Decoder50(_input))?))())?;
+                                        let r#type = ((|| PResult::Ok((Decoder50(_input))?))())?;
                                         let length = ((|| PResult::Ok((Decoder32(_input))?))())?;
                                         let offset_or_data =
                                             ((|| PResult::Ok((Decoder32(_input))?))())?;
@@ -17348,7 +17284,7 @@ fn Decoder145<'input>(_input: &mut Parser<'input>) -> Result<Type49, ParseError>
     })
 }
 
-fn Decoder146<'input>(_input: &mut Parser<'input>) -> Result<u16, ParseError> {
+fn Decoder147<'input>(_input: &mut Parser<'input>) -> Result<u16, ParseError> {
     let inner = {
         let field0 = ((|| PResult::Ok((Decoder16(_input))?))())?;
         let field1 = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -17357,12 +17293,12 @@ fn Decoder146<'input>(_input: &mut Parser<'input>) -> Result<u16, ParseError> {
     PResult::Ok(((|x: (u8, u8)| PResult::Ok(u16le(x)))(inner))?)
 }
 
-fn Decoder147<'input>(_input: &mut Parser<'input>) -> Result<Type44, ParseError> {
-    let identifier = ((|| PResult::Ok((Decoder148(_input))?))())?;
+fn Decoder148<'input>(_input: &mut Parser<'input>) -> Result<Type44, ParseError> {
+    let identifier = ((|| PResult::Ok((Decoder149(_input))?))())?;
     let data = ((|| {
         PResult::Ok(match identifier.clone().string.as_slice() {
             [74, 70, 73, 70] => {
-                let inner = (Decoder149(_input))?;
+                let inner = (Decoder150(_input))?;
                 Type43::jfif(inner)
             }
 
@@ -17395,7 +17331,7 @@ fn Decoder147<'input>(_input: &mut Parser<'input>) -> Result<Type44, ParseError>
     PResult::Ok(Type44 { identifier, data })
 }
 
-fn Decoder148<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+fn Decoder149<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
     let string = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -17447,12 +17383,12 @@ fn Decoder148<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError>
     PResult::Ok(Type21 { string, null })
 }
 
-fn Decoder149<'input>(_input: &mut Parser<'input>) -> Result<Type42, ParseError> {
+fn Decoder150<'input>(_input: &mut Parser<'input>) -> Result<Type42, ParseError> {
     let version_major = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let version_minor = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let density_units = ((|| PResult::Ok((Decoder16(_input))?))())?;
-    let density_x = ((|| PResult::Ok((Decoder49(_input))?))())?;
-    let density_y = ((|| PResult::Ok((Decoder49(_input))?))())?;
+    let density_x = ((|| PResult::Ok((Decoder50(_input))?))())?;
+    let density_y = ((|| PResult::Ok((Decoder50(_input))?))())?;
     let thumbnail_width = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let thumbnail_height = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let thumbnail_pixels = ((|| {
@@ -17462,7 +17398,7 @@ fn Decoder149<'input>(_input: &mut Parser<'input>) -> Result<Type42, ParseError>
                 accum.push({
                     let mut accum = Vec::new();
                     for _ in 0..thumbnail_width {
-                        accum.push((Decoder150(_input))?);
+                        accum.push((Decoder151(_input))?);
                     }
                     accum
                 });
@@ -17482,14 +17418,14 @@ fn Decoder149<'input>(_input: &mut Parser<'input>) -> Result<Type42, ParseError>
     })
 }
 
-fn Decoder150<'input>(_input: &mut Parser<'input>) -> Result<Type2, ParseError> {
+fn Decoder151<'input>(_input: &mut Parser<'input>) -> Result<Type2, ParseError> {
     let r = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let g = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let b = ((|| PResult::Ok((Decoder16(_input))?))())?;
     PResult::Ok(Type2 { r, g, b })
 }
 
-fn Decoder151<'input>(_input: &mut Parser<'input>) -> Result<Type20, ParseError> {
+fn Decoder152<'input>(_input: &mut Parser<'input>) -> Result<Type20, ParseError> {
     let magic = ((|| {
         PResult::Ok({
             let field0 = ((|| {
@@ -17530,16 +17466,16 @@ fn Decoder151<'input>(_input: &mut Parser<'input>) -> Result<Type20, ParseError>
     })
 }
 
-fn Decoder152<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
-    PResult::Ok((Decoder162(_input))?)
+fn Decoder153<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+    PResult::Ok((Decoder163(_input))?)
 }
 
-fn Decoder153<'input>(_input: &mut Parser<'input>) -> Result<Type38, ParseError> {
+fn Decoder154<'input>(_input: &mut Parser<'input>) -> Result<Type38, ParseError> {
     let blocks = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
             loop {
-                let elem = (Decoder155(_input))?;
+                let elem = (Decoder156(_input))?;
                 if ((|x: &Type37| PResult::Ok(x.clone().r#final == 1u8))(&elem))? {
                     accum.push(elem);
                     break;
@@ -17597,19 +17533,19 @@ fn Decoder153<'input>(_input: &mut Parser<'input>) -> Result<Type38, ParseError>
     })
 }
 
-fn Decoder154<'input>(_input: &mut Parser<'input>) -> Result<Type39, ParseError> {
+fn Decoder155<'input>(_input: &mut Parser<'input>) -> Result<Type39, ParseError> {
     let crc = ((|| PResult::Ok((Decoder23(_input))?))())?;
     let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
     PResult::Ok(Type39 { crc, length })
 }
 
-fn Decoder155<'input>(_input: &mut Parser<'input>) -> Result<Type37, ParseError> {
-    let r#final = ((|| PResult::Ok((Decoder156(_input))?))())?;
+fn Decoder156<'input>(_input: &mut Parser<'input>) -> Result<Type37, ParseError> {
+    let r#final = ((|| PResult::Ok((Decoder157(_input))?))())?;
     let r#type = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (field0, field1)
             };
             ((|bits: (u8, u8)| PResult::Ok(bits.clone().1 << 1u8 | bits.clone().0))(inner))?
@@ -17618,17 +17554,17 @@ fn Decoder155<'input>(_input: &mut Parser<'input>) -> Result<Type37, ParseError>
     let data = ((|| {
         PResult::Ok(match r#type {
             0 => {
-                let inner = (Decoder157(_input))?;
+                let inner = (Decoder158(_input))?;
                 Type36::uncompressed(inner)
             }
 
             1 => {
-                let inner = (Decoder158(_input))?;
+                let inner = (Decoder159(_input))?;
                 Type36::fixed_huffman(inner)
             }
 
             2 => {
-                let inner = (Decoder159(_input))?;
+                let inner = (Decoder160(_input))?;
                 Type36::dynamic_huffman(inner)
             }
 
@@ -17646,32 +17582,32 @@ fn Decoder155<'input>(_input: &mut Parser<'input>) -> Result<Type37, ParseError>
     })
 }
 
-fn Decoder156<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
+fn Decoder157<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
     let b = _input.read_byte()?;
     PResult::Ok(b)
 }
 
-fn Decoder157<'input>(_input: &mut Parser<'input>) -> Result<Type35, ParseError> {
+fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type35, ParseError> {
     let align = ((|| PResult::Ok(_input.skip_align(8)?))())?;
     let len = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field10 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field11 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field12 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field13 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field14 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field15 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field10 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field11 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field12 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field13 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field14 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field15 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (
                     field0, field1, field2, field3, field4, field5, field6, field7, field8, field9,
                     field10, field11, field12, field13, field14, field15,
@@ -17719,22 +17655,22 @@ fn Decoder157<'input>(_input: &mut Parser<'input>) -> Result<Type35, ParseError>
     let nlen = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field10 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field11 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field12 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field13 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field14 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field15 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field10 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field11 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field12 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field13 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field14 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field15 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (
                     field0, field1, field2, field3, field4, field5, field6, field7, field8, field9,
                     field10, field11, field12, field13, field14, field15,
@@ -17785,14 +17721,14 @@ fn Decoder157<'input>(_input: &mut Parser<'input>) -> Result<Type35, ParseError>
             for _ in 0..len {
                 accum.push({
                     let inner = {
-                        let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                        let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                         (
                             field0, field1, field2, field3, field4, field5, field6, field7,
                         )
@@ -17830,7 +17766,7 @@ fn Decoder157<'input>(_input: &mut Parser<'input>) -> Result<Type35, ParseError>
     })
 }
 
-fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError> {
+fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError> {
     let codes = ((|| {
         PResult::Ok({
             let format = parse_huffman(
@@ -17872,15 +17808,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -17895,7 +17831,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -17917,15 +17853,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -17940,7 +17876,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -17962,15 +17898,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -17985,7 +17921,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18007,15 +17943,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18030,7 +17966,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18052,15 +17988,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18075,7 +18011,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18097,15 +18033,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18120,7 +18056,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18142,15 +18078,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18165,7 +18101,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18187,15 +18123,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18210,7 +18146,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18229,7 +18165,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -18242,15 +18178,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18265,7 +18201,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18284,7 +18220,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -18297,15 +18233,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18320,7 +18256,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18339,7 +18275,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -18352,15 +18288,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18375,7 +18311,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18394,7 +18330,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -18407,15 +18343,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18430,7 +18366,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18449,9 +18385,9 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -18466,15 +18402,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18489,7 +18425,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18508,9 +18444,9 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -18525,15 +18461,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18548,7 +18484,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18567,9 +18503,9 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -18584,15 +18520,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18607,7 +18543,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18626,9 +18562,9 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -18643,15 +18579,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18666,7 +18602,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18685,11 +18621,11 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -18708,15 +18644,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18731,7 +18667,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18750,11 +18686,11 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -18773,15 +18709,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18796,7 +18732,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18815,11 +18751,11 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -18838,15 +18774,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18861,7 +18797,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18880,11 +18816,11 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -18903,15 +18839,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18926,7 +18862,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -18945,13 +18881,13 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -18971,15 +18907,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -18994,7 +18930,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19013,13 +18949,13 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -19039,15 +18975,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19062,7 +18998,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19081,13 +19017,13 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -19107,15 +19043,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19130,7 +19066,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19149,13 +19085,13 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -19175,15 +19111,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19198,7 +19134,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19217,15 +19153,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19246,15 +19182,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19269,7 +19205,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19288,15 +19224,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19317,15 +19253,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19340,7 +19276,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19359,15 +19295,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19388,15 +19324,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19411,7 +19347,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19430,15 +19366,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19459,15 +19395,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19482,7 +19418,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19504,15 +19440,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19527,7 +19463,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                         })
                                     })())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code as u16))?)
+                                        PResult::Ok((Decoder161(_input, distance_code as u16))?)
                                     })(
                                     ))?;
                                     Type31 {
@@ -19540,10 +19476,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                                 Type32::some(inner)
                             }
 
-                            _ => {
-                                let _ = ();
-                                Type32::none
-                            }
+                            _ => Type32::none,
                         })
                     })())?;
                     Type33 { code, extra }
@@ -19572,7 +19505,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19584,7 +19517,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19596,7 +19529,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19608,7 +19541,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19620,7 +19553,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19632,7 +19565,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19644,7 +19577,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19656,7 +19589,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19668,7 +19601,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19680,7 +19613,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19692,7 +19625,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19704,7 +19637,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19716,7 +19649,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19728,7 +19661,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19740,7 +19673,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19752,7 +19685,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19764,7 +19697,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19776,7 +19709,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19788,7 +19721,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19800,7 +19733,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19812,7 +19745,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19824,7 +19757,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19836,7 +19769,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19848,7 +19781,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19860,7 +19793,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19872,7 +19805,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19884,7 +19817,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19896,7 +19829,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19908,7 +19841,7 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(3837024443630474590u64));
+                            return Err(ParseError::ExcludedBranch(5042737927225156353u64));
                         }
                     },
 
@@ -19923,15 +19856,15 @@ fn Decoder158<'input>(_input: &mut Parser<'input>) -> Result<Type34, ParseError>
     })
 }
 
-fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError> {
+fn Decoder160<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError> {
     let hlit = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (field0, field1, field2, field3, field4)
             };
             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19948,11 +19881,11 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
     let hdist = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (field0, field1, field2, field3, field4)
             };
             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -19969,10 +19902,10 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
     let hclen = ((|| {
         PResult::Ok({
             let inner = {
-                let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                 (field0, field1, field2, field3)
             };
             ((|bits: (u8, u8, u8, u8)| {
@@ -19991,9 +19924,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
             for _ in 0..hclen + 4u8 {
                 accum.push({
                     let inner = {
-                        let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                        let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                        let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                        let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                         (field0, field1, field2)
                     };
                     ((|bits: (u8, u8, u8)| {
@@ -20024,8 +19957,8 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         PResult::Ok(match code as u8 {
                             16 => {
                                 let inner = {
-                                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                                     (field0, field1)
                                 };
                                 ((|bits: (u8, u8)| {
@@ -20035,9 +19968,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
 
                             17 => {
                                 let inner = {
-                                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                                     (field0, field1, field2)
                                 };
                                 ((|bits: (u8, u8, u8)| {
@@ -20051,13 +19984,13 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
 
                             18 => {
                                 let inner = {
-                                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                                     (field0, field1, field2, field3, field4, field5, field6)
                                 };
                                 ((|bits: (u8, u8, u8, u8, u8, u8, u8)| {
@@ -20098,7 +20031,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
 
                                                 _ => {
                                                     return Err(ParseError::ExcludedBranch(
-                                                        9457288612631872053u64,
+                                                        7746167170491206541u64,
                                                     ));
                                                 }
                                             },
@@ -20149,7 +20082,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
 
                                     _ => {
                                         return Err(ParseError::ExcludedBranch(
-                                            9457288612631872053u64,
+                                            7746167170491206541u64,
                                         ));
                                     }
                                 },
@@ -20204,7 +20137,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20225,7 +20158,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20246,7 +20179,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20267,7 +20200,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20288,7 +20221,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20309,7 +20242,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20330,7 +20263,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20351,7 +20284,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20370,7 +20303,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -20382,7 +20315,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20401,7 +20334,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -20413,7 +20346,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20432,7 +20365,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -20444,7 +20377,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20463,7 +20396,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0,)
                                             };
                                             ((|bits: (u8,)| PResult::Ok(bits.clone().0))(inner))?
@@ -20475,7 +20408,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20494,9 +20427,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -20510,7 +20443,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20529,9 +20462,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -20545,7 +20478,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20564,9 +20497,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -20580,7 +20513,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20599,9 +20532,9 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1)
                                             };
                                             ((|bits: (u8, u8)| {
@@ -20615,7 +20548,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20634,11 +20567,11 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -20656,7 +20589,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20675,11 +20608,11 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -20697,7 +20630,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20716,11 +20649,11 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -20738,7 +20671,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20757,11 +20690,11 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2)
                                             };
                                             ((|bits: (u8, u8, u8)| {
@@ -20779,7 +20712,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20798,13 +20731,13 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -20823,7 +20756,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20842,13 +20775,13 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -20867,7 +20800,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20886,13 +20819,13 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -20911,7 +20844,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20930,13 +20863,13 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3)
                                             };
                                             ((|bits: (u8, u8, u8, u8)| {
@@ -20955,7 +20888,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -20974,15 +20907,15 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -21002,7 +20935,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -21021,15 +20954,15 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -21049,7 +20982,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -21068,15 +21001,15 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -21096,7 +21029,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -21115,15 +21048,15 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                         PResult::Ok({
                                             let inner = {
                                                 let field0 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field1 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field2 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field3 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 let field4 =
-                                                    ((|| PResult::Ok((Decoder156(_input))?))())?;
+                                                    ((|| PResult::Ok((Decoder157(_input))?))())?;
                                                 (field0, field1, field2, field3, field4)
                                             };
                                             ((|bits: (u8, u8, u8, u8, u8)| {
@@ -21143,7 +21076,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -21164,7 +21097,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                     let distance_code =
                                         ((|| PResult::Ok((distance_alphabet_format(_input))?))())?;
                                     let distance_record = ((|| {
-                                        PResult::Ok((Decoder160(_input, distance_code.clone()))?)
+                                        PResult::Ok((Decoder161(_input, distance_code.clone()))?)
                                     })(
                                     ))?;
                                     Type25 {
@@ -21177,10 +21110,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                                 Type26::some(inner)
                             }
 
-                            _ => {
-                                let _ = ();
-                                Type26::none
-                            }
+                            _ => Type26::none,
                         })
                     })())?;
                     Type27 { code, extra }
@@ -21209,7 +21139,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21221,7 +21151,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21233,7 +21163,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21245,7 +21175,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21257,7 +21187,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21269,7 +21199,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21281,7 +21211,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21293,7 +21223,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21305,7 +21235,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21317,7 +21247,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21329,7 +21259,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21341,7 +21271,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21353,7 +21283,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21365,7 +21295,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21377,7 +21307,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21389,7 +21319,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21401,7 +21331,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21413,7 +21343,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21425,7 +21355,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21437,7 +21367,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21449,7 +21379,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21461,7 +21391,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21473,7 +21403,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21485,7 +21415,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21497,7 +21427,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21509,7 +21439,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21521,7 +21451,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21533,7 +21463,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21545,7 +21475,7 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
                         .to_vec(),
 
                         _ => {
-                            return Err(ParseError::ExcludedBranch(13749635282143713177u64));
+                            return Err(ParseError::ExcludedBranch(12571316263812849558u64));
                         }
                     },
 
@@ -21568,70 +21498,70 @@ fn Decoder159<'input>(_input: &mut Parser<'input>) -> Result<Type30, ParseError>
     })
 }
 
-fn Decoder160<'input>(
+fn Decoder161<'input>(
     _input: &mut Parser<'input>,
     distance_code: u16,
 ) -> Result<Type24, ParseError> {
     PResult::Ok(match distance_code as u8 {
-        0 => (Decoder161(_input, 0u8, 1u16))?,
+        0 => (Decoder162(_input, 0u8, 1u16))?,
 
-        1 => (Decoder161(_input, 0u8, 2u16))?,
+        1 => (Decoder162(_input, 0u8, 2u16))?,
 
-        2 => (Decoder161(_input, 0u8, 3u16))?,
+        2 => (Decoder162(_input, 0u8, 3u16))?,
 
-        3 => (Decoder161(_input, 0u8, 4u16))?,
+        3 => (Decoder162(_input, 0u8, 4u16))?,
 
-        4 => (Decoder161(_input, 1u8, 5u16))?,
+        4 => (Decoder162(_input, 1u8, 5u16))?,
 
-        5 => (Decoder161(_input, 1u8, 7u16))?,
+        5 => (Decoder162(_input, 1u8, 7u16))?,
 
-        6 => (Decoder161(_input, 2u8, 9u16))?,
+        6 => (Decoder162(_input, 2u8, 9u16))?,
 
-        7 => (Decoder161(_input, 2u8, 13u16))?,
+        7 => (Decoder162(_input, 2u8, 13u16))?,
 
-        8 => (Decoder161(_input, 3u8, 17u16))?,
+        8 => (Decoder162(_input, 3u8, 17u16))?,
 
-        9 => (Decoder161(_input, 3u8, 25u16))?,
+        9 => (Decoder162(_input, 3u8, 25u16))?,
 
-        10 => (Decoder161(_input, 4u8, 33u16))?,
+        10 => (Decoder162(_input, 4u8, 33u16))?,
 
-        11 => (Decoder161(_input, 4u8, 49u16))?,
+        11 => (Decoder162(_input, 4u8, 49u16))?,
 
-        12 => (Decoder161(_input, 5u8, 65u16))?,
+        12 => (Decoder162(_input, 5u8, 65u16))?,
 
-        13 => (Decoder161(_input, 5u8, 97u16))?,
+        13 => (Decoder162(_input, 5u8, 97u16))?,
 
-        14 => (Decoder161(_input, 6u8, 129u16))?,
+        14 => (Decoder162(_input, 6u8, 129u16))?,
 
-        15 => (Decoder161(_input, 6u8, 193u16))?,
+        15 => (Decoder162(_input, 6u8, 193u16))?,
 
-        16 => (Decoder161(_input, 7u8, 257u16))?,
+        16 => (Decoder162(_input, 7u8, 257u16))?,
 
-        17 => (Decoder161(_input, 7u8, 385u16))?,
+        17 => (Decoder162(_input, 7u8, 385u16))?,
 
-        18 => (Decoder161(_input, 8u8, 513u16))?,
+        18 => (Decoder162(_input, 8u8, 513u16))?,
 
-        19 => (Decoder161(_input, 8u8, 769u16))?,
+        19 => (Decoder162(_input, 8u8, 769u16))?,
 
-        20 => (Decoder161(_input, 9u8, 1025u16))?,
+        20 => (Decoder162(_input, 9u8, 1025u16))?,
 
-        21 => (Decoder161(_input, 9u8, 1537u16))?,
+        21 => (Decoder162(_input, 9u8, 1537u16))?,
 
-        22 => (Decoder161(_input, 10u8, 2049u16))?,
+        22 => (Decoder162(_input, 10u8, 2049u16))?,
 
-        23 => (Decoder161(_input, 10u8, 3073u16))?,
+        23 => (Decoder162(_input, 10u8, 3073u16))?,
 
-        24 => (Decoder161(_input, 11u8, 4097u16))?,
+        24 => (Decoder162(_input, 11u8, 4097u16))?,
 
-        25 => (Decoder161(_input, 11u8, 6145u16))?,
+        25 => (Decoder162(_input, 11u8, 6145u16))?,
 
-        26 => (Decoder161(_input, 12u8, 8193u16))?,
+        26 => (Decoder162(_input, 12u8, 8193u16))?,
 
-        27 => (Decoder161(_input, 12u8, 12289u16))?,
+        27 => (Decoder162(_input, 12u8, 12289u16))?,
 
-        28 => (Decoder161(_input, 13u8, 16385u16))?,
+        28 => (Decoder162(_input, 13u8, 16385u16))?,
 
-        29 => (Decoder161(_input, 13u8, 24577u16))?,
+        29 => (Decoder162(_input, 13u8, 24577u16))?,
 
         _other => {
             unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
@@ -21639,7 +21569,7 @@ fn Decoder160<'input>(
     })
 }
 
-fn Decoder161<'input>(
+fn Decoder162<'input>(
     _input: &mut Parser<'input>,
     extra_bits: u8,
     start: u16,
@@ -21650,7 +21580,7 @@ fn Decoder161<'input>(
 
             1 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0,)
                 };
                 ((|bits: (u8,)| PResult::Ok(bits.clone().0 as u16))(inner))?
@@ -21658,8 +21588,8 @@ fn Decoder161<'input>(
 
             2 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1)
                 };
                 ((|bits: (u8, u8)| {
@@ -21669,9 +21599,9 @@ fn Decoder161<'input>(
 
             3 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1, field2)
                 };
                 ((|bits: (u8, u8, u8)| {
@@ -21685,10 +21615,10 @@ fn Decoder161<'input>(
 
             4 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1, field2, field3)
                 };
                 ((|bits: (u8, u8, u8, u8)| {
@@ -21703,11 +21633,11 @@ fn Decoder161<'input>(
 
             5 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1, field2, field3, field4)
                 };
                 ((|bits: (u8, u8, u8, u8, u8)| {
@@ -21723,12 +21653,12 @@ fn Decoder161<'input>(
 
             6 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1, field2, field3, field4, field5)
                 };
                 ((|bits: (u8, u8, u8, u8, u8, u8)| {
@@ -21745,13 +21675,13 @@ fn Decoder161<'input>(
 
             7 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (field0, field1, field2, field3, field4, field5, field6)
                 };
                 ((|bits: (u8, u8, u8, u8, u8, u8, u8)| {
@@ -21769,14 +21699,14 @@ fn Decoder161<'input>(
 
             8 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7,
                     )
@@ -21797,15 +21727,15 @@ fn Decoder161<'input>(
 
             9 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7, field8,
                     )
@@ -21827,16 +21757,16 @@ fn Decoder161<'input>(
 
             10 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7, field8,
                         field9,
@@ -21860,17 +21790,17 @@ fn Decoder161<'input>(
 
             11 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field10 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field10 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7, field8,
                         field9, field10,
@@ -21895,18 +21825,18 @@ fn Decoder161<'input>(
 
             12 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field10 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field11 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field10 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field11 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7, field8,
                         field9, field10, field11,
@@ -21932,19 +21862,19 @@ fn Decoder161<'input>(
 
             13 => {
                 let inner = {
-                    let field0 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field1 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field2 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field3 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field4 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field5 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field6 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field7 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field8 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field9 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field10 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field11 = ((|| PResult::Ok((Decoder156(_input))?))())?;
-                    let field12 = ((|| PResult::Ok((Decoder156(_input))?))())?;
+                    let field0 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field1 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field2 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field3 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field4 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field5 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field6 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field7 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field8 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field9 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field10 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field11 = ((|| PResult::Ok((Decoder157(_input))?))())?;
+                    let field12 = ((|| PResult::Ok((Decoder157(_input))?))())?;
                     (
                         field0, field1, field2, field3, field4, field5, field6, field7, field8,
                         field9, field10, field11, field12,
@@ -21983,7 +21913,7 @@ fn Decoder161<'input>(
     })
 }
 
-fn Decoder162<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
+fn Decoder163<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError> {
     let string = ((|| {
         PResult::Ok({
             let mut accum = Vec::new();
@@ -22035,7 +21965,7 @@ fn Decoder162<'input>(_input: &mut Parser<'input>) -> Result<Type21, ParseError>
     PResult::Ok(Type21 { string, null })
 }
 
-fn Decoder163<'input>(_input: &mut Parser<'input>) -> Result<Type0, ParseError> {
+fn Decoder164<'input>(_input: &mut Parser<'input>) -> Result<Type0, ParseError> {
     let signature = ((|| {
         PResult::Ok({
             let field0 = ((|| {
@@ -22083,25 +22013,22 @@ fn Decoder163<'input>(_input: &mut Parser<'input>) -> Result<Type0, ParseError> 
     PResult::Ok(Type0 { signature, version })
 }
 
-fn Decoder164<'input>(_input: &mut Parser<'input>) -> Result<Type4, ParseError> {
-    let descriptor = ((|| PResult::Ok((Decoder180(_input))?))())?;
+fn Decoder165<'input>(_input: &mut Parser<'input>) -> Result<Type4, ParseError> {
+    let descriptor = ((|| PResult::Ok((Decoder181(_input))?))())?;
     let global_color_table = ((|| {
         PResult::Ok(match descriptor.clone().flags & 128u8 != 0u8 {
             true => {
                 let inner = {
                     let mut accum = Vec::new();
                     for _ in 0..2u8 << (descriptor.clone().flags & 7u8) {
-                        accum.push((Decoder178(_input))?);
+                        accum.push((Decoder179(_input))?);
                     }
                     accum
                 };
                 Type3::yes(inner)
             }
 
-            false => {
-                let _ = ();
-                Type3::no
-            }
+            false => Type3::no,
         })
     })())?;
     PResult::Ok(Type4 {
@@ -22110,7 +22037,7 @@ fn Decoder164<'input>(_input: &mut Parser<'input>) -> Result<Type4, ParseError> 
     })
 }
 
-fn Decoder165<'input>(_input: &mut Parser<'input>) -> Result<Type17, ParseError> {
+fn Decoder166<'input>(_input: &mut Parser<'input>) -> Result<Type17, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -22145,12 +22072,12 @@ fn Decoder165<'input>(_input: &mut Parser<'input>) -> Result<Type17, ParseError>
     };
     PResult::Ok(match tree_index {
         0 => {
-            let inner = (Decoder167(_input))?;
+            let inner = (Decoder168(_input))?;
             Type17::graphic_block(inner)
         }
 
         1 => {
-            let inner = (Decoder168(_input))?;
+            let inner = (Decoder169(_input))?;
             Type17::special_purpose_block(inner)
         }
 
@@ -22160,7 +22087,7 @@ fn Decoder165<'input>(_input: &mut Parser<'input>) -> Result<Type17, ParseError>
     })
 }
 
-fn Decoder166<'input>(_input: &mut Parser<'input>) -> Result<Type18, ParseError> {
+fn Decoder167<'input>(_input: &mut Parser<'input>) -> Result<Type18, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22174,7 +22101,7 @@ fn Decoder166<'input>(_input: &mut Parser<'input>) -> Result<Type18, ParseError>
     PResult::Ok(Type18 { separator })
 }
 
-fn Decoder167<'input>(_input: &mut Parser<'input>) -> Result<Type13, ParseError> {
+fn Decoder168<'input>(_input: &mut Parser<'input>) -> Result<Type13, ParseError> {
     let graphic_control_extension = ((|| {
         PResult::Ok({
             let tree_index = {
@@ -22209,14 +22136,11 @@ fn Decoder167<'input>(_input: &mut Parser<'input>) -> Result<Type13, ParseError>
             };
             match tree_index {
                 0 => {
-                    let inner = (Decoder173(_input))?;
+                    let inner = (Decoder174(_input))?;
                     Type6::some(inner)
                 }
 
-                1 => {
-                    let _ = ();
-                    Type6::none
-                }
+                1 => Type6::none,
 
                 _ => {
                     return Err(ParseError::ExcludedBranch(15496895076277599409u64));
@@ -22224,14 +22148,14 @@ fn Decoder167<'input>(_input: &mut Parser<'input>) -> Result<Type13, ParseError>
             }
         })
     })())?;
-    let graphic_rendering_block = ((|| PResult::Ok((Decoder174(_input))?))())?;
+    let graphic_rendering_block = ((|| PResult::Ok((Decoder175(_input))?))())?;
     PResult::Ok(Type13 {
         graphic_control_extension,
         graphic_rendering_block,
     })
 }
 
-fn Decoder168<'input>(_input: &mut Parser<'input>) -> Result<Type16, ParseError> {
+fn Decoder169<'input>(_input: &mut Parser<'input>) -> Result<Type16, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -22256,12 +22180,12 @@ fn Decoder168<'input>(_input: &mut Parser<'input>) -> Result<Type16, ParseError>
     };
     PResult::Ok(match tree_index {
         0 => {
-            let inner = (Decoder169(_input))?;
+            let inner = (Decoder170(_input))?;
             Type16::application_extension(inner)
         }
 
         1 => {
-            let inner = (Decoder170(_input))?;
+            let inner = (Decoder171(_input))?;
             Type16::comment_extension(inner)
         }
 
@@ -22271,7 +22195,7 @@ fn Decoder168<'input>(_input: &mut Parser<'input>) -> Result<Type16, ParseError>
     })
 }
 
-fn Decoder169<'input>(_input: &mut Parser<'input>) -> Result<Type14, ParseError> {
+fn Decoder170<'input>(_input: &mut Parser<'input>) -> Result<Type14, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22342,7 +22266,7 @@ fn Decoder169<'input>(_input: &mut Parser<'input>) -> Result<Type14, ParseError>
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder171(_input))?;
+                    let next_elem = (Decoder172(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -22351,7 +22275,7 @@ fn Decoder169<'input>(_input: &mut Parser<'input>) -> Result<Type14, ParseError>
             accum
         })
     })())?;
-    let terminator = ((|| PResult::Ok((Decoder172(_input))?))())?;
+    let terminator = ((|| PResult::Ok((Decoder173(_input))?))())?;
     PResult::Ok(Type14 {
         separator,
         label,
@@ -22363,7 +22287,7 @@ fn Decoder169<'input>(_input: &mut Parser<'input>) -> Result<Type14, ParseError>
     })
 }
 
-fn Decoder170<'input>(_input: &mut Parser<'input>) -> Result<Type15, ParseError> {
+fn Decoder171<'input>(_input: &mut Parser<'input>) -> Result<Type15, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22406,7 +22330,7 @@ fn Decoder170<'input>(_input: &mut Parser<'input>) -> Result<Type15, ParseError>
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder171(_input))?;
+                    let next_elem = (Decoder172(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -22415,7 +22339,7 @@ fn Decoder170<'input>(_input: &mut Parser<'input>) -> Result<Type15, ParseError>
             accum
         })
     })())?;
-    let terminator = ((|| PResult::Ok((Decoder172(_input))?))())?;
+    let terminator = ((|| PResult::Ok((Decoder173(_input))?))())?;
     PResult::Ok(Type15 {
         separator,
         label,
@@ -22424,7 +22348,7 @@ fn Decoder170<'input>(_input: &mut Parser<'input>) -> Result<Type15, ParseError>
     })
 }
 
-fn Decoder171<'input>(_input: &mut Parser<'input>) -> Result<Type7, ParseError> {
+fn Decoder172<'input>(_input: &mut Parser<'input>) -> Result<Type7, ParseError> {
     let len_bytes = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22447,7 +22371,7 @@ fn Decoder171<'input>(_input: &mut Parser<'input>) -> Result<Type7, ParseError> 
     PResult::Ok(Type7 { len_bytes, data })
 }
 
-fn Decoder172<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
+fn Decoder173<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
     let b = _input.read_byte()?;
     PResult::Ok(if b == 0 {
         b
@@ -22456,7 +22380,7 @@ fn Decoder172<'input>(_input: &mut Parser<'input>) -> Result<u8, ParseError> {
     })
 }
 
-fn Decoder173<'input>(_input: &mut Parser<'input>) -> Result<Type5, ParseError> {
+fn Decoder174<'input>(_input: &mut Parser<'input>) -> Result<Type5, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22488,9 +22412,9 @@ fn Decoder173<'input>(_input: &mut Parser<'input>) -> Result<Type5, ParseError> 
         })
     })())?;
     let flags = ((|| PResult::Ok((Decoder16(_input))?))())?;
-    let delay_time = ((|| PResult::Ok((Decoder146(_input))?))())?;
+    let delay_time = ((|| PResult::Ok((Decoder147(_input))?))())?;
     let transparent_color_index = ((|| PResult::Ok((Decoder16(_input))?))())?;
-    let terminator = ((|| PResult::Ok((Decoder172(_input))?))())?;
+    let terminator = ((|| PResult::Ok((Decoder173(_input))?))())?;
     PResult::Ok(Type5 {
         separator,
         label,
@@ -22502,7 +22426,7 @@ fn Decoder173<'input>(_input: &mut Parser<'input>) -> Result<Type5, ParseError> 
     })
 }
 
-fn Decoder174<'input>(_input: &mut Parser<'input>) -> Result<Type12, ParseError> {
+fn Decoder175<'input>(_input: &mut Parser<'input>) -> Result<Type12, ParseError> {
     let tree_index = {
         _input.open_peek_context();
         let b = _input.read_byte()?;
@@ -22522,12 +22446,12 @@ fn Decoder174<'input>(_input: &mut Parser<'input>) -> Result<Type12, ParseError>
     };
     PResult::Ok(match tree_index {
         0 => {
-            let inner = (Decoder175(_input))?;
+            let inner = (Decoder176(_input))?;
             Type12::table_based_image(inner)
         }
 
         1 => {
-            let inner = (Decoder176(_input))?;
+            let inner = (Decoder177(_input))?;
             Type12::plain_text_extension(inner)
         }
 
@@ -22537,28 +22461,25 @@ fn Decoder174<'input>(_input: &mut Parser<'input>) -> Result<Type12, ParseError>
     })
 }
 
-fn Decoder175<'input>(_input: &mut Parser<'input>) -> Result<Type11, ParseError> {
-    let descriptor = ((|| PResult::Ok((Decoder177(_input))?))())?;
+fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type11, ParseError> {
+    let descriptor = ((|| PResult::Ok((Decoder178(_input))?))())?;
     let local_color_table = ((|| {
         PResult::Ok(match descriptor.clone().flags & 128u8 != 0u8 {
             true => {
                 let inner = {
                     let mut accum = Vec::new();
                     for _ in 0..2u8 << (descriptor.clone().flags & 7u8) {
-                        accum.push((Decoder178(_input))?);
+                        accum.push((Decoder179(_input))?);
                     }
                     accum
                 };
                 Type3::yes(inner)
             }
 
-            false => {
-                let _ = ();
-                Type3::no
-            }
+            false => Type3::no,
         })
     })())?;
-    let data = ((|| PResult::Ok((Decoder179(_input))?))())?;
+    let data = ((|| PResult::Ok((Decoder180(_input))?))())?;
     PResult::Ok(Type11 {
         descriptor,
         local_color_table,
@@ -22566,7 +22487,7 @@ fn Decoder175<'input>(_input: &mut Parser<'input>) -> Result<Type11, ParseError>
     })
 }
 
-fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> {
+fn Decoder177<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22597,10 +22518,10 @@ fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> 
             }
         })
     })())?;
-    let text_grid_left_position = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let text_grid_top_position = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let text_grid_width = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let text_grid_height = ((|| PResult::Ok((Decoder146(_input))?))())?;
+    let text_grid_left_position = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let text_grid_top_position = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let text_grid_width = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let text_grid_height = ((|| PResult::Ok((Decoder147(_input))?))())?;
     let character_cell_width = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let character_cell_height = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let text_foreground_color_index = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -22627,7 +22548,7 @@ fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> 
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder171(_input))?;
+                    let next_elem = (Decoder172(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -22636,7 +22557,7 @@ fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> 
             accum
         })
     })())?;
-    let terminator = ((|| PResult::Ok((Decoder172(_input))?))())?;
+    let terminator = ((|| PResult::Ok((Decoder173(_input))?))())?;
     PResult::Ok(Type8 {
         separator,
         label,
@@ -22654,7 +22575,7 @@ fn Decoder176<'input>(_input: &mut Parser<'input>) -> Result<Type8, ParseError> 
     })
 }
 
-fn Decoder177<'input>(_input: &mut Parser<'input>) -> Result<Type9, ParseError> {
+fn Decoder178<'input>(_input: &mut Parser<'input>) -> Result<Type9, ParseError> {
     let separator = ((|| {
         PResult::Ok({
             let b = _input.read_byte()?;
@@ -22665,10 +22586,10 @@ fn Decoder177<'input>(_input: &mut Parser<'input>) -> Result<Type9, ParseError> 
             }
         })
     })())?;
-    let image_left_position = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let image_top_position = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let image_width = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let image_height = ((|| PResult::Ok((Decoder146(_input))?))())?;
+    let image_left_position = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let image_top_position = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let image_width = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let image_height = ((|| PResult::Ok((Decoder147(_input))?))())?;
     let flags = ((|| PResult::Ok((Decoder16(_input))?))())?;
     PResult::Ok(Type9 {
         separator,
@@ -22680,14 +22601,14 @@ fn Decoder177<'input>(_input: &mut Parser<'input>) -> Result<Type9, ParseError> 
     })
 }
 
-fn Decoder178<'input>(_input: &mut Parser<'input>) -> Result<Type2, ParseError> {
+fn Decoder179<'input>(_input: &mut Parser<'input>) -> Result<Type2, ParseError> {
     let r = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let g = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let b = ((|| PResult::Ok((Decoder16(_input))?))())?;
     PResult::Ok(Type2 { r, g, b })
 }
 
-fn Decoder179<'input>(_input: &mut Parser<'input>) -> Result<Type10, ParseError> {
+fn Decoder180<'input>(_input: &mut Parser<'input>) -> Result<Type10, ParseError> {
     let lzw_min_code_size = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let image_data = ((|| {
         PResult::Ok({
@@ -22711,7 +22632,7 @@ fn Decoder179<'input>(_input: &mut Parser<'input>) -> Result<Type10, ParseError>
                     }
                 };
                 if matching_ix == 0 {
-                    let next_elem = (Decoder171(_input))?;
+                    let next_elem = (Decoder172(_input))?;
                     accum.push(next_elem);
                 } else {
                     break;
@@ -22720,7 +22641,7 @@ fn Decoder179<'input>(_input: &mut Parser<'input>) -> Result<Type10, ParseError>
             accum
         })
     })())?;
-    let terminator = ((|| PResult::Ok((Decoder172(_input))?))())?;
+    let terminator = ((|| PResult::Ok((Decoder173(_input))?))())?;
     PResult::Ok(Type10 {
         lzw_min_code_size,
         image_data,
@@ -22728,9 +22649,9 @@ fn Decoder179<'input>(_input: &mut Parser<'input>) -> Result<Type10, ParseError>
     })
 }
 
-fn Decoder180<'input>(_input: &mut Parser<'input>) -> Result<Type1, ParseError> {
-    let screen_width = ((|| PResult::Ok((Decoder146(_input))?))())?;
-    let screen_height = ((|| PResult::Ok((Decoder146(_input))?))())?;
+fn Decoder181<'input>(_input: &mut Parser<'input>) -> Result<Type1, ParseError> {
+    let screen_width = ((|| PResult::Ok((Decoder147(_input))?))())?;
+    let screen_height = ((|| PResult::Ok((Decoder147(_input))?))())?;
     let flags = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let bg_color_index = ((|| PResult::Ok((Decoder16(_input))?))())?;
     let pixel_aspect_ratio = ((|| PResult::Ok((Decoder16(_input))?))())?;
@@ -22743,7 +22664,7 @@ fn Decoder180<'input>(_input: &mut Parser<'input>) -> Result<Type1, ParseError> 
     })
 }
 
-fn Decoder181<'input>(_input: &mut Parser<'input>) -> Result<u32, ParseError> {
+fn Decoder182<'input>(_input: &mut Parser<'input>) -> Result<u32, ParseError> {
     let inner = {
         let field0 = ((|| {
             PResult::Ok({

--- a/src/bin/doodle/format.rs
+++ b/src/bin/doodle/format.rs
@@ -93,7 +93,7 @@ mod test {
                 ),
             ),
         ]);
-        let fref = module.define_format("test.lenpref_wro_mask", f);
+        let forward_ref = module.define_format("test.wro_mask", f);
         let mut data = Vec::with_capacity(37); // 4 (len) + 32 (data) + 1 (mask)
         let len_bytes = [0, 0, 0, 32];
         let mask = 0x7F;
@@ -104,7 +104,7 @@ mod test {
         }
         data.push(mask);
 
-        let program = doodle::decoder::Compiler::compile_program(&module, &fref.call())
+        let program = doodle::decoder::Compiler::compile_program(&module, &forward_ref.call())
             .unwrap_or_else(|msg| panic!("Failed to compile: {msg}"));
         let (output, _) = program.run(ReadCtxt::new(&data))?;
         match output {

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -138,7 +138,7 @@ impl ByteSet {
         });
     }
 
-    #[allow(dead_code)]
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn remove(&mut self, b: u8) {
         self.set_bit_with(b, |byte, i| {
             *byte &= !(1 << i);

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -29,6 +29,10 @@ impl GenType {
     //     }
     // }
 
+    /// Attempt to extract the type-index and corresponding name (`Label`) from `self`.
+    ///
+    /// Returns `None` if the type in question is not itself a concrete definition (`GenType::Def`)
+    /// or an abstract reference to a locally-defined adhoc type (`GenType::Inline` of nested `LocalType::LocalDef`).
     pub(crate) fn try_as_adhoc(&self) -> Option<(usize, &Label)> {
         match self {
             GenType::Def((ix, lbl), ..)

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -640,6 +640,7 @@ impl Value {
         }
     }
 
+    /// FIXME - do we really need this?
     #[allow(dead_code)]
     fn unwrap_char(self) -> char {
         match self {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -87,12 +87,10 @@ pub fn repeat_between(min: Expr, max: Expr, format: Format) -> Format {
     Format::RepeatBetween(min, max, Box::new(format))
 }
 
-#[allow(dead_code)]
 pub fn repeat_until_last(cond: Expr, format: Format) -> Format {
     Format::RepeatUntilLast(cond, Box::new(format))
 }
 
-#[allow(dead_code)]
 pub fn repeat_until_seq(cond: Expr, format: Format) -> Format {
     Format::RepeatUntilSeq(cond, Box::new(format))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1288,18 +1288,18 @@ impl<'a> MatchTreeStep<'a> {
         }
     }
 
-    /// Constructs a [MatchTreeStep] that accepts a repetition whose count is bounded above and below, with a trailing sequence of partially-consuemd formats ([`Next`]s)
+    /// Constructs a [MatchTreeStep] that accepts a repetition whose count is bounded above and below, with a trailing sequence of partially-consumed formats ([`Next`]s)
     ///
-    /// The format in quiestion will  an arbitrary number of times between `min` and `max`, where `minmax ::= (min, max)`
+    /// The format in question will repeat an arbitrary number of times between `min` and `max`, where `min_max ::= (min, max)`
     ///
     /// Presupposes that the invariant `max >= min` is upheld.
     fn from_repeat_between(
         module: &'a FormatModule,
-        minmax: (usize, usize),
+        min_max: (usize, usize),
         format: &'a Format,
         next: Rc<Next<'a>>,
     ) -> MatchTreeStep<'a> {
-        let (min, max) = minmax;
+        let (min, max) = min_max;
         assert!(
             min <= max,
             "min-max pair ({}, {}) incoherent (min > max)",
@@ -1748,6 +1748,7 @@ impl<'a> MatchTreeStep<'a> {
                         }
                     },
                     _ => {
+                        // FIXME: if there is a cleaner way to address this case, attempt to apply it
                         unreachable!("inexact repeat-between bounds (not technically a problem but not what the combinator was designed for...");
                     }
                 }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -7,13 +7,13 @@ pub enum ParseError {
     FailToken,
     /// For Repeat1, RepeatCount, or RepeatUntil*, indicates that an inadequate number of values were read before encountering end-of-buffer or end-of-slice.
     InsufficientRepeats,
-    /// Indicates a succesful parse within a negated context, as in the case of PeekNot
+    /// Indicates a successful parse within a negated context, as in the case of PeekNot
     NegatedSuccess,
     /// Used for any logical branch without a handler, such as a refuted Expr::Match or MatchTree descent; u64 value is a trace mechanic for determining which error was triggered
     ExcludedBranch(u64),
     /// Attempted read would overrun either the overall buffer, or a context-local `Format::Slice`.
     Overrun(OverrunKind),
-    /// A `Format::EndOfInput` token occuring anywhere except the final offset of a Slice or the overall buffer.
+    /// A `Format::EndOfInput` token occurring anywhere except the final offset of a Slice or the overall buffer.
     IncompleteParse { bytes_remaining: usize },
     /// Any unrecoverable error in the state of the Parser itself.
     InternalError(StateError),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -37,7 +37,7 @@ impl<'a> Parser<'a> {
         Ok(())
     }
 
-    /// Attempts to advance ther buffer by one after capturing the value of the byte at the current logical
+    /// Attempts to advance the buffer by one after capturing the value of the byte at the current logical
     /// offset into the buffer.
     ///
     /// In bits-mode, this will be a sub-indexed 0-or-1-valued `u8` of the bit in question,
@@ -126,7 +126,7 @@ impl<'a> Parser<'a> {
         self.offset.escape_bits_mode()
     }
 
-    /// Returns the number of bits that have been read thusfar in the current
+    /// Returns the number of bits that have been read thus-far in the current
     /// bits-mode context.
     ///
     /// Will return `None` instead if we are not in bits-mode.
@@ -152,7 +152,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Attempts to close the most recently-opened slice, skipping to the end of the slice
-    /// if succesful.
+    /// if successful.
     ///
     /// Will only fail if there are no slices to close, or if the current offset-value somehow
     /// exceeded the slice end-point unexpectedly. In either case, the error cannot be recovered
@@ -180,7 +180,7 @@ impl<'a> Parser<'a> {
     /// Opens a new PeekNot context, marking the current offset and its modality to be recover3d
     /// when the matching [`Parser::close_peek_not_context`] call is reached.
     pub fn open_peek_not_context(&mut self) {
-        self.offset.open_peeknot()
+        self.offset.open_peek_not()
     }
 
     /// Closes the most recently-opened PeekNot context, recovering the offset and its modality
@@ -200,7 +200,7 @@ impl<'a> Parser<'a> {
         self.offset.open_parallel()
     }
 
-    /// Rewinds to the branch-point of the latest 'Alts' context (e.g. after an individual branch could not be parsed succesfully).
+    /// Rewinds to the branch-point of the latest 'Alts' context (e.g. after an individual branch could not be parsed successfully).
     ///
     /// According to the `is_last` parameter, may also re-create the branch-point to allow chaining with future branches.
     ///

--- a/src/parser/offset.rs
+++ b/src/parser/offset.rs
@@ -450,7 +450,7 @@ impl BufferOffset {
     }
 
     /// Creates and pushes a new [`Lens::PeekNot`] to the internal `ViewStack`.
-    pub(crate) fn open_peeknot(&mut self) {
+    pub(crate) fn open_peek_not(&mut self) {
         let checkpoint = self.current_offset;
         let peeknot = Lens::PeekNot { checkpoint };
         self.view_stack.push_lens(peeknot);

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -148,7 +148,6 @@ impl IntransitiveOrd for Precedence {
 }
 
 impl Precedence {
-    #![allow(dead_code)]
     pub(crate) const TOP: Self = Precedence::Top;
     pub(crate) const ARROW: Self = Precedence::Calculus;
     pub(crate) const MATCH: Self = Precedence::Calculus;
@@ -167,7 +166,6 @@ impl Precedence {
     pub(crate) const ATOM: Self = Precedence::Atomic;
 
     pub(crate) const FORMAT_COMPOUND: Self = Self::Top;
-    pub(crate) const FORMAT_ATOM: Self = Self::Atomic;
 
     pub(crate) fn bump_format(&self) -> Self {
         match self {

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -15,7 +15,7 @@ pub(crate) enum Precedence {
     ArithInfix(ArithLevel),
     /// Infix bitwise operation of the designated bitwise sub-precedence
     BitwiseInfix(BitwiseLevel),
-    /// Unchainable quantiative comparison, such as inequality and equality operations
+    /// Unchainable quantitative comparison, such as inequality and equality operations
     Comparison(CompareLevel),
     /// Functional abstractions such as `match` expressions and closures
     Calculus,


### PR DESCRIPTION
Gets rid of the `#![allow(dead_code)]` attribute at the root of `rust_ast.rs` to surface unused variants and methods (and removes them).

Fixes many proper typos in comments, and changes identifiers in certain places to keep spellchecking simple.

Basic heuristics to selectively elide vacuous expressions like

```rust
let _ = ();
```

from generated code by determining, using a loose heuristic, whether any given `RustExpr` is 'pure' in the Haskell sense. 

Promotes any hard-coded strings leftover in `rust_ast.rs` or `codegen/mod.rs` that inject 'extra' content into standard productions, into associated fields of the types being augmented, which are then expanded as first-class elements of the Rust-AST model rather than hacky afterthoughts.