### PR TITLE
Format::Where to apply boolean conditions to values.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2790,6 +2790,9 @@ impl<'a> Elaborator<'a> {
                 let gt = self.get_gt_from_index(index);
                 GTFormat::Map(gt, Box::new(t_inner), t_lambda)
             }
+            Format::Where(_inner, _lambda) => {
+                unimplemented!();
+            }
             Format::Compute(expr) => {
                 let index = self.get_and_increment_index();
                 let t_expr = self.elaborate_expr(expr);

--- a/src/disjoint.rs
+++ b/src/disjoint.rs
@@ -1,0 +1,89 @@
+use crate::{Expr, IntRel, Label};
+
+struct Constraint {
+    name: Label,
+    lower: Option<u64>,
+    upper: Option<u64>,
+}
+
+impl Constraint {
+    fn new(name: &Label, lower: Option<u64>, upper: Option<u64>) -> Constraint {
+        Constraint {
+            name: name.clone(),
+            lower,
+            upper,
+        }
+    }
+
+    fn from_expr(expr: &Expr) -> Option<Constraint> {
+        match expr {
+            Expr::IntRel(op, lhs, rhs) => {
+                match (op, lhs.as_ref(), rhs.as_ref()) {
+                    (IntRel::Eq, Expr::Var(name), expr) | (IntRel::Eq, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, Some(val), Some(val)))
+                    }
+                    (IntRel::Ne, _, _) => None, // FIXME
+                    (IntRel::Lt, Expr::Var(name), expr) | (IntRel::Gt, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(
+                            name,
+                            None,
+                            Some(val.checked_sub(1).unwrap()),
+                        ))
+                    }
+                    (IntRel::Gt, Expr::Var(name), expr) | (IntRel::Lt, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(
+                            name,
+                            Some(val.checked_add(1).unwrap()),
+                            None,
+                        ))
+                    }
+                    (IntRel::Lte, Expr::Var(name), expr) | (IntRel::Gte, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, None, Some(val)))
+                    }
+                    (IntRel::Gte, Expr::Var(name), expr) | (IntRel::Lte, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, Some(val), None))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn get_u64(expr: &Expr) -> Option<u64> {
+        match expr {
+            Expr::U8(n) => Some(u64::from(*n)),
+            Expr::U16(n) => Some(u64::from(*n)),
+            Expr::U32(n) => Some(u64::from(*n)),
+            Expr::U64(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    fn disjoint(&self, other: &Constraint) -> bool {
+        if self.name == other.name {
+            match (self.lower, self.upper, other.lower, other.upper) {
+                (Some(lo), _, _, Some(hi)) if lo > hi => true,
+                (Some(lo), _, _, Some(hi)) if lo > hi => true,
+
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+}
+
+// both expr must be bool
+// conservative approximation, if true then definitely disjoint
+pub fn disjoint(a: &Expr, b: &Expr) -> bool {
+    match (Constraint::from_expr(a), Constraint::from_expr(b)) {
+        (Some(ac), Some(bc)) => ac.disjoint(&bc),
+        _ => false,
+    }
+}

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -1316,6 +1316,13 @@ impl Decoder {
                 let image = ParsedValue::inherit(&orig, v);
                 Ok((ParsedValue::Mapped(Box::new(orig), Box::new(image)), input))
             }
+            Decoder::Where(d, expr) => {
+                let (v, input) = d.parse_with_loc(program, scope, input)?;
+                match expr.eval_lambda_with_loc(scope, &v).unwrap_bool() {
+                    true => Ok((v, input)),
+                    false => Err(ParseError::loc_fail(scope, input)),
+                }
+            }
             Decoder::Compute(expr) => {
                 let v = expr.eval_with_loc(scope);
                 Ok((v.as_ref().clone(), input))

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -169,6 +169,7 @@ fn check_covered(
         }
         Format::WithRelativeOffset(_, _) => {} // FIXME
         Format::Map(format, _expr) => check_covered(module, path, format)?,
+        Format::Where(format, _expr) => check_covered(module, path, format)?,
         Format::Compute(_expr) => {}
         Format::Let(_name, _expr, format) => check_covered(module, path, format)?,
         Format::Match(_head, branches) => {
@@ -258,6 +259,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Bits(format) => self.write_flat(value, format),
             Format::WithRelativeOffset(_, format) => self.write_flat(value, format),
             Format::Map(_format, _expr) => Ok(()),
+            Format::Where(_format, _expr) => Ok(()),
             Format::Compute(_expr) => Ok(()),
             Format::Let(_name, _expr, format) => self.write_flat(value, format),
             Format::Match(_head, branches) => match value {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -360,6 +360,7 @@ impl<'module> MonoidalPrinter<'module> {
                     }
                 }
             }
+            Format::Where(format, _expr) => self.compile_parsed_decoded_value(value, format),
             Format::Compute(_expr) => self.compile_parsed_value(value),
             Format::Let(_name, _expr, format) => self.compile_parsed_decoded_value(value, format),
             Format::Match(_head, branches) => match value {
@@ -471,6 +472,7 @@ impl<'module> MonoidalPrinter<'module> {
                     }
                 }
             }
+            Format::Where(format, _expr) => self.compile_decoded_value(value, format),
             Format::Compute(_expr) => self.compile_value(value),
             Format::Let(_name, _expr, format) => self.compile_decoded_value(value, format),
             Format::Match(_head, branches) => match value {
@@ -1669,6 +1671,14 @@ impl<'module> MonoidalPrinter<'module> {
                 let expr_frag = self.compile_expr(expr, Precedence::ATOM);
                 cond_paren(
                     self.compile_nested_format("map", Some(&[expr_frag]), format, prec),
+                    prec,
+                    Precedence::FORMAT_COMPOUND,
+                )
+            }
+            Format::Where(format, expr) => {
+                let expr_frag = self.compile_expr(expr, Precedence::ATOM);
+                cond_paren(
+                    self.compile_nested_format("assert", Some(&[expr_frag]), format, prec),
                     prec,
                     Precedence::FORMAT_COMPOUND,
                 )

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2377,6 +2377,16 @@ impl TypeChecker {
                 self.unify_var_pair(newvar, out_var)?;
                 Ok(newvar)
             }
+            Format::Where(inner, f) => {
+                let newvar = self.get_new_uvar();
+                let inner_t = self.infer_utype_format(inner, ctxt)?;
+
+                let (in_v, out_var) = self.infer_vars_expr_lambda(f, ctxt.scope)?;
+                self.unify_var_pair(newvar, in_v)?;
+                self.unify_var_utype(newvar, inner_t)?;
+                self.unify_var_utype(out_var, Rc::new(UType::Base(BaseType::Bool)))?;
+                Ok(newvar)
+            }
             Format::Compute(x) => {
                 let newvar = self.get_new_uvar();
                 let xt = self.infer_utype_expr(x, ctxt.scope)?;


### PR DESCRIPTION
This adds a format for boolean assertions. It would help if we had expressions for boolean or/and/not.

There is also a new module for checking if two expressions are disjoint, intended to be used to disambiguate unions that have disjoint assertions on their branches, however it is not used yet.