### PR TITLE
Pattern::Int(Bounds) to simplify matching a range of integers.

### DIFF
--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -7,15 +7,26 @@ pub struct Bounds {
 }
 
 impl Bounds {
-    pub fn new(min: usize, max: Option<usize>) -> Bounds {
-        Bounds { min, max }
+    pub const fn new(min: usize, max: usize) -> Bounds {
+        Bounds {
+            min,
+            max: Some(max),
+        }
     }
 
-    pub fn exact(n: usize) -> Bounds {
+    pub const fn exact(n: usize) -> Bounds {
         Bounds {
             min: n,
             max: Some(n),
         }
+    }
+
+    pub const fn at_least(min: usize) -> Bounds {
+        Bounds { min, max: None }
+    }
+
+    pub const fn any() -> Bounds {
+        Bounds { min: 0, max: None }
     }
 
     pub fn is_exact(&self) -> Option<usize> {

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -1,6 +1,7 @@
+use serde::Serialize;
 use std::ops::{Add, BitAnd, BitOr, Div, Mul, Shl, Shr, Sub};
 
-#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug, Serialize)]
 pub struct Bounds {
     pub min: usize,
     pub max: Option<usize>,

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2541,6 +2541,7 @@ impl<'a> Elaborator<'a> {
             Pattern::U16(n) => GTPattern::U16(*n),
             Pattern::U32(n) => GTPattern::U32(*n),
             Pattern::U64(n) => GTPattern::U64(*n),
+            Pattern::Int(_) => unimplemented!(),
             Pattern::Char(c) => GTPattern::Char(*c),
             Pattern::Tuple(elts) => {
                 let mut t_elts = Vec::with_capacity(elts.len());

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -115,7 +115,7 @@ impl TypedFormat<GenType> {
                 inner.lookahead_bounds()
             }
 
-            TypedFormat::Align(n) => Bounds::new(0, Some(n - 1)),
+            TypedFormat::Align(n) => Bounds::new(0, n - 1),
             TypedFormat::Byte(_) => Bounds::exact(1),
             TypedFormat::Variant(_, _, f) => f.lookahead_bounds(),
             TypedFormat::Union(_, branches) | TypedFormat::UnionNondet(_, branches) => branches
@@ -140,12 +140,10 @@ impl TypedFormat<GenType> {
             }
 
             TypedFormat::Repeat1(_, f) | TypedFormat::RepeatUntilLast(_, _, f) => {
-                f.lookahead_bounds() * Bounds::new(1, None)
+                f.lookahead_bounds() * Bounds::at_least(1)
             }
 
-            TypedFormat::Repeat(_, _f) | TypedFormat::RepeatUntilSeq(_, _, _f) => {
-                Bounds::new(0, None)
-            }
+            TypedFormat::Repeat(_, _f) | TypedFormat::RepeatUntilSeq(_, _, _f) => Bounds::any(),
 
             TypedFormat::Slice(_, t_expr, _) => t_expr.bounds(),
 
@@ -165,7 +163,7 @@ impl TypedFormat<GenType> {
                 .reduce(Bounds::union)
                 .unwrap(),
 
-            TypedFormat::Apply(_, _, _) => Bounds::new(1, None),
+            TypedFormat::Apply(_, _, _) => Bounds::at_least(1),
         }
     }
 
@@ -179,7 +177,7 @@ impl TypedFormat<GenType> {
             | TypedFormat::EndOfInput
             | TypedFormat::Fail => Bounds::exact(0),
 
-            TypedFormat::Align(n) => Bounds::new(0, Some(n - 1)),
+            TypedFormat::Align(n) => Bounds::new(0, n - 1),
             TypedFormat::Byte(_) => Bounds::exact(1),
             TypedFormat::Variant(_, _, f) => f.match_bounds(),
             TypedFormat::Union(_, branches) | TypedFormat::UnionNondet(_, branches) => branches
@@ -204,12 +202,10 @@ impl TypedFormat<GenType> {
             }
 
             TypedFormat::Repeat1(_, f) | TypedFormat::RepeatUntilLast(_, _, f) => {
-                f.match_bounds() * Bounds::new(1, None)
+                f.match_bounds() * Bounds::at_least(1)
             }
 
-            TypedFormat::Repeat(_, _f) | TypedFormat::RepeatUntilSeq(_, _, _f) => {
-                Bounds::new(0, None)
-            }
+            TypedFormat::Repeat(_, _f) | TypedFormat::RepeatUntilSeq(_, _, _f) => Bounds::any(),
 
             TypedFormat::Slice(_, t_expr, _) => t_expr.bounds(),
 
@@ -227,7 +223,7 @@ impl TypedFormat<GenType> {
                 .reduce(Bounds::union)
                 .unwrap(),
 
-            TypedFormat::Apply(_, _, _) => Bounds::new(1, None),
+            TypedFormat::Apply(_, _, _) => Bounds::at_least(1),
         }
     }
 
@@ -374,7 +370,7 @@ impl<TypeRep> TypedExpr<TypeRep> {
             TypedExpr::U64(n) => Bounds::exact(*n as usize),
             TypedExpr::Arith(_t, Arith::Add, a, b) => a.bounds() + b.bounds(),
             TypedExpr::Arith(_t, Arith::Mul, a, b) => a.bounds() * b.bounds(),
-            _ => Bounds::new(0, None),
+            _ => Bounds::any(),
         }
     }
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -49,6 +49,10 @@ impl Value {
             (Pattern::U16(i0), Value::U16(i1)) => i0 == i1,
             (Pattern::U32(i0), Value::U32(i1)) => i0 == i1,
             (Pattern::U64(i0), Value::U64(i1)) => i0 == i1,
+            (Pattern::Int(bounds), Value::U8(n)) => bounds.contains(usize::from(*n)),
+            (Pattern::Int(bounds), Value::U16(n)) => bounds.contains(usize::from(*n)),
+            (Pattern::Int(bounds), Value::U32(n)) => bounds.contains(usize::try_from(*n).unwrap()),
+            (Pattern::Int(bounds), Value::U64(n)) => bounds.contains(usize::try_from(*n).unwrap()),
             (Pattern::Char(c0), Value::Char(c1)) => c0 == c1,
             (Pattern::Tuple(ps), Value::Tuple(vs)) | (Pattern::Seq(ps), Value::Seq(vs))
                 if ps.len() == vs.len() =>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -554,7 +554,13 @@ impl Expr {
             Expr::U32(n) => Bounds::exact(*n as usize),
             Expr::U64(n) => Bounds::exact(*n as usize),
             Expr::Arith(Arith::Add, a, b) => a.bounds() + b.bounds(),
+            Expr::Arith(Arith::Sub, a, b) => a.bounds() - b.bounds(),
             Expr::Arith(Arith::Mul, a, b) => a.bounds() * b.bounds(),
+            Expr::Arith(Arith::Div, a, b) => a.bounds() / b.bounds(),
+            Expr::Arith(Arith::BitOr, a, b) => a.bounds() | b.bounds(),
+            Expr::Arith(Arith::BitAnd, a, b) => a.bounds() & b.bounds(),
+            Expr::Arith(Arith::Shl, a, b) => a.bounds() << b.bounds(),
+            Expr::Arith(Arith::Shr, a, b) => a.bounds() >> b.bounds(),
             _ => Bounds::new(0, None),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -561,7 +561,7 @@ impl Expr {
             Expr::Arith(Arith::BitAnd, a, b) => a.bounds() & b.bounds(),
             Expr::Arith(Arith::Shl, a, b) => a.bounds() << b.bounds(),
             Expr::Arith(Arith::Shr, a, b) => a.bounds() >> b.bounds(),
-            _ => Bounds::new(0, None),
+            _ => Bounds::any(),
         }
     }
 }
@@ -700,7 +700,7 @@ impl Format {
             Format::ItemVar(level, _args) => module.get_format(*level).match_bounds(module),
             Format::Fail => Bounds::exact(0),
             Format::EndOfInput => Bounds::exact(0),
-            Format::Align(n) => Bounds::new(0, Some(n - 1)),
+            Format::Align(n) => Bounds::new(0, n - 1),
             Format::Byte(_) => Bounds::exact(1),
             Format::Variant(_label, f) => f.match_bounds(module),
             Format::Union(branches) | Format::UnionNondet(branches) => branches
@@ -718,14 +718,14 @@ impl Format {
                 .map(|(_, f)| f.match_bounds(module))
                 .reduce(Bounds::add)
                 .unwrap_or(Bounds::exact(0)),
-            Format::Repeat(_) => Bounds::new(0, None),
-            Format::Repeat1(f) => f.match_bounds(module) * Bounds::new(1, None),
+            Format::Repeat(_) => Bounds::any(),
+            Format::Repeat1(f) => f.match_bounds(module) * Bounds::at_least(1),
             Format::RepeatCount(expr, f) => f.match_bounds(module) * expr.bounds(),
             Format::RepeatBetween(xmin, xmax, f) => {
                 f.match_bounds(module) * (Bounds::union(xmin.bounds(), xmax.bounds()))
             }
-            Format::RepeatUntilLast(_, f) => f.match_bounds(module) * Bounds::new(1, None),
-            Format::RepeatUntilSeq(_, _f) => Bounds::new(0, None),
+            Format::RepeatUntilLast(_, f) => f.match_bounds(module) * Bounds::at_least(1),
+            Format::RepeatUntilSeq(_, _f) => Bounds::any(),
             Format::Peek(_) => Bounds::exact(0),
             Format::PeekNot(_) => Bounds::exact(0),
             Format::Slice(expr, _) => expr.bounds(),
@@ -740,7 +740,7 @@ impl Format {
                 .reduce(Bounds::union)
                 .unwrap(),
             Format::Dynamic(_name, _dynformat, f) => f.match_bounds(module),
-            Format::Apply(_) => Bounds::new(1, None),
+            Format::Apply(_) => Bounds::at_least(1),
         }
     }
 
@@ -750,7 +750,7 @@ impl Format {
             Format::ItemVar(level, _args) => module.get_format(*level).lookahead_bounds(module),
             Format::Fail => Bounds::exact(0),
             Format::EndOfInput => Bounds::exact(0),
-            Format::Align(n) => Bounds::new(0, Some(n - 1)),
+            Format::Align(n) => Bounds::new(0, n - 1),
             Format::Byte(_) => Bounds::exact(1),
             Format::Variant(_label, f) => f.lookahead_bounds(module),
             Format::Union(branches) | Format::UnionNondet(branches) => branches
@@ -768,14 +768,14 @@ impl Format {
                 .map(|(_, f)| f.lookahead_bounds(module))
                 .reduce(Bounds::add)
                 .unwrap_or(Bounds::exact(0)),
-            Format::Repeat(_) => Bounds::new(0, None),
-            Format::Repeat1(f) => f.lookahead_bounds(module) * Bounds::new(1, None),
+            Format::Repeat(_) => Bounds::any(),
+            Format::Repeat1(f) => f.lookahead_bounds(module) * Bounds::at_least(1),
             Format::RepeatCount(expr, f) => f.lookahead_bounds(module) * expr.bounds(),
             Format::RepeatBetween(xmin, xmax, f) => {
                 f.lookahead_bounds(module) * Bounds::union(xmin.bounds(), xmax.bounds())
             }
-            Format::RepeatUntilLast(_, f) => f.lookahead_bounds(module) * Bounds::new(1, None),
-            Format::RepeatUntilSeq(_, _f) => Bounds::new(0, None),
+            Format::RepeatUntilLast(_, f) => f.lookahead_bounds(module) * Bounds::at_least(1),
+            Format::RepeatUntilSeq(_, _f) => Bounds::any(),
             Format::Peek(f) => f.lookahead_bounds(module),
             Format::PeekNot(f) => f.lookahead_bounds(module),
             Format::Slice(expr, _) => expr.bounds(),
@@ -790,7 +790,7 @@ impl Format {
                 .reduce(Bounds::union)
                 .unwrap(),
             Format::Dynamic(_name, _dynformat, f) => f.lookahead_bounds(module),
-            Format::Apply(_) => Bounds::new(1, None),
+            Format::Apply(_) => Bounds::at_least(1),
         }
     }
 

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,3 +1,4 @@
+use crate::bounds::Bounds;
 use crate::{BaseType, Expr, Format, FormatModule, IntoLabel, Label, TypeScope, ValueType};
 use anyhow::Result as AResult;
 use serde::Serialize;
@@ -13,6 +14,7 @@ pub enum Pattern {
     U16(u16),
     U32(u32),
     U64(u64),
+    Int(Bounds),
     Char(char),
     Tuple(Vec<Pattern>),
     Variant(Label, Box<Pattern>),
@@ -45,6 +47,11 @@ impl Pattern {
             (Pattern::U8(..), ValueType::Base(BaseType::U8)) => {}
             (Pattern::U16(..), ValueType::Base(BaseType::U16)) => {}
             (Pattern::U32(..), ValueType::Base(BaseType::U32)) => {}
+            (Pattern::U64(..), ValueType::Base(BaseType::U64)) => {}
+            (Pattern::Int(..), ValueType::Base(BaseType::U8)) => {}
+            (Pattern::Int(..), ValueType::Base(BaseType::U16)) => {}
+            (Pattern::Int(..), ValueType::Base(BaseType::U32)) => {}
+            (Pattern::Int(..), ValueType::Base(BaseType::U64)) => {}
             (Pattern::Tuple(ps), ValueType::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope(scope, Rc::new(t.clone()));

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -663,6 +663,11 @@ impl TypeChecker {
                 let var = self.init_var_simple(UType::Base(BaseType::U64))?.0;
                 Ok(var)
             }
+            Pattern::Int(_) => {
+                let var = self.get_new_uvar();
+                self.unify_utype_baseset(var.into(), BaseSet::USome)?;
+                Ok(var)
+            }
             Pattern::Char(_) => {
                 let var = self.init_var_simple(UType::Base(BaseType::Char))?.0;
                 Ok(var)


### PR DESCRIPTION
Not used or tested anywhere yet, could be used in deflate format. Codegen is unimplemented and type checking could use a look.