### PR TITLE
Extend codegen support to Format::Where

### DIFF
--- a/doodle-formats/src/format/png.rs
+++ b/doodle-formats/src/format/png.rs
@@ -161,7 +161,10 @@ pub fn main(
 
     let iccp_data = record(vec![
         ("profile-name", null_terminated(keyword.call())),
-        ("compression-method", is_byte(0)), // REVIEW: technically the value is unrestricted but 0 := deflate is the only defined value
+        (
+            "compression-method",
+            where_lambda(base.u8(), "x", expr_eq(var("x"), Expr::U8(0))),
+        ), // NOTE: 0 := deflate is the only defined value
         ("compressed-profile", zlib.call()),
     ]);
 

--- a/generated/codegen_tests.rs
+++ b/generated/codegen_tests.rs
@@ -138,7 +138,7 @@ fn test_decoder_riff() -> TestResult {
 fn test_decoder_tar() -> TestResult {
     let buffer = std::fs::read(std::path::Path::new(&testpath("test.tar")))?;
     let mut input = Parser::new(&buffer);
-    let parsed_data = Decoder15(&mut input)?;
+    let parsed_data = Decoder16(&mut input)?;
     match parsed_data {
         TarBlock {
             header,

--- a/generated/sample_codegen.rs
+++ b/generated/sample_codegen.rs
@@ -5206,11 +5206,11 @@ fn Decoder43<'input>(
                     })())?;
                     let compression_method = ((|| {
                         PResult::Ok({
-                            let b = _input.read_byte()?;
-                            if b == 0 {
-                                b
+                            let inner = (Decoder18(_input))?;
+                            if ((|x: u8| PResult::Ok(x == 0u8))(inner.clone()))? {
+                                inner
                             } else {
-                                return Err(ParseError::ExcludedBranch(10396965092922267801u64));
+                                return Err(ParseError::FalsifiedWhere);
                             }
                         })
                     })())?;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -468,7 +468,7 @@ impl CodeGen {
                 let cl_inner = self.translate(inner.get_dec());
                 CaseLogic::Derived(
                     DerivedLogic::Where(
-                        embed_lambda_dft(f, ClosureKind::Predicate, true),
+                        embed_lambda_dft(f, ClosureKind::Transform, true),
                         Box::new(cl_inner)
                     )
                 )
@@ -2288,7 +2288,10 @@ impl ToAst for DerivedLogic<GTExpr> {
             DerivedLogic::Where(f, inner) => {
                 let assign_inner = RustStmt::assign("inner", RustExpr::from(inner.to_ast(ctxt)));
                 let ctrl = {
-                    let cond_valid = f.clone().call_with([RustExpr::local("inner")]).wrap_try();
+                    let cond_valid = f
+                        .clone()
+                        .call_with([RustExpr::local("inner").call_method("clone")])
+                        .wrap_try();
                     let b_valid = vec![RustStmt::Return(
                         ReturnKind::Implicit,
                         RustExpr::local("inner"),

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2790,6 +2790,9 @@ impl<'a> Elaborator<'a> {
                 let gt = self.get_gt_from_index(index);
                 GTFormat::Map(gt, Box::new(t_inner), t_lambda)
             }
+            Format::Where(_inner, _lambda) => {
+                unimplemented!();
+            }
             Format::Compute(expr) => {
                 let index = self.get_and_increment_index();
                 let t_expr = self.elaborate_expr(expr);

--- a/src/codegen/typed_decoder.rs
+++ b/src/codegen/typed_decoder.rs
@@ -77,6 +77,7 @@ pub(crate) enum TypedDecoder<TypeRep> {
     Bits(TypeRep, Box<TypedDecoderExt<TypeRep>>),
     WithRelativeOffset(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
     Map(TypeRep, Box<TypedDecoderExt<TypeRep>>, TypedExpr<TypeRep>),
+    Where(TypeRep, Box<TypedDecoderExt<TypeRep>>, TypedExpr<TypeRep>),
     Compute(TypeRep, TypedExpr<TypeRep>),
     Let(
         TypeRep,
@@ -406,6 +407,10 @@ impl<'a> GTCompiler<'a> {
             GTFormat::Map(gt, a, expr) => {
                 let da = Box::new(self.compile_gt_format(a, None, next.clone())?);
                 Ok(TypedDecoder::Map(gt.clone(), da, expr.clone()))
+            }
+            GTFormat::Where(gt, a, expr) => {
+                let da = Box::new(self.compile_gt_format(a, None, next.clone())?);
+                Ok(TypedDecoder::Where(gt.clone(), da, expr.clone()))
             }
             GTFormat::Compute(gt, expr) => Ok(TypedDecoder::Compute(gt.clone(), expr.clone())),
             GTFormat::Let(gt, name, expr, a) => {

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -79,6 +79,7 @@ pub enum TypedFormat<TypeRep> {
     Bits(TypeRep, Box<TypedFormat<TypeRep>>),
     WithRelativeOffset(TypeRep, TypedExpr<TypeRep>, Box<TypedFormat<TypeRep>>),
     Map(TypeRep, Box<TypedFormat<TypeRep>>, TypedExpr<TypeRep>),
+    Where(TypeRep, Box<TypedFormat<TypeRep>>, TypedExpr<TypeRep>),
     Compute(TypeRep, TypedExpr<TypeRep>),
     Let(
         TypeRep,
@@ -156,6 +157,7 @@ impl TypedFormat<GenType> {
             }
 
             TypedFormat::Map(_, f, _)
+            | TypedFormat::Where(_, f, _)
             | TypedFormat::Dynamic(_, _, _, f)
             | TypedFormat::Let(_, _, _, f) => f.lookahead_bounds(),
 
@@ -218,6 +220,7 @@ impl TypedFormat<GenType> {
             TypedFormat::WithRelativeOffset(_, _, _) => Bounds::exact(0),
 
             TypedFormat::Map(_, f, _)
+            | TypedFormat::Where(_, f, _)
             | TypedFormat::Dynamic(_, _, _, f)
             | TypedFormat::Let(_, _, _, f) => f.match_bounds(),
 
@@ -273,6 +276,7 @@ impl TypedFormat<GenType> {
             | TypedFormat::Bits(gt, ..)
             | TypedFormat::WithRelativeOffset(gt, ..)
             | TypedFormat::Map(gt, ..)
+            | TypedFormat::Where(gt, ..)
             | TypedFormat::Compute(gt, ..)
             | TypedFormat::Let(gt, ..)
             | TypedFormat::Match(gt, ..)
@@ -585,6 +589,9 @@ mod __impls {
                     Format::WithRelativeOffset(ofs.into(), rebox(inner))
                 }
                 TypedFormat::Map(_, inner, lambda) => Format::Map(rebox(inner), Expr::from(lambda)),
+                TypedFormat::Where(_, inner, lambda) => {
+                    Format::Where(rebox(inner), Expr::from(lambda))
+                }
                 TypedFormat::Compute(_, expr) => Format::Compute(Expr::from(expr)),
                 TypedFormat::Let(_, name, val, inner) => {
                     Format::Let(name, Expr::from(val), rebox(inner))

--- a/src/disjoint.rs
+++ b/src/disjoint.rs
@@ -1,0 +1,89 @@
+use crate::{Expr, IntRel, Label};
+
+struct Constraint {
+    name: Label,
+    lower: Option<u64>,
+    upper: Option<u64>,
+}
+
+impl Constraint {
+    fn new(name: &Label, lower: Option<u64>, upper: Option<u64>) -> Constraint {
+        Constraint {
+            name: name.clone(),
+            lower,
+            upper,
+        }
+    }
+
+    fn from_expr(expr: &Expr) -> Option<Constraint> {
+        match expr {
+            Expr::IntRel(op, lhs, rhs) => {
+                match (op, lhs.as_ref(), rhs.as_ref()) {
+                    (IntRel::Eq, Expr::Var(name), expr) | (IntRel::Eq, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, Some(val), Some(val)))
+                    }
+                    (IntRel::Ne, _, _) => None, // FIXME
+                    (IntRel::Lt, Expr::Var(name), expr) | (IntRel::Gt, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(
+                            name,
+                            None,
+                            Some(val.checked_sub(1).unwrap()),
+                        ))
+                    }
+                    (IntRel::Gt, Expr::Var(name), expr) | (IntRel::Lt, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(
+                            name,
+                            Some(val.checked_add(1).unwrap()),
+                            None,
+                        ))
+                    }
+                    (IntRel::Lte, Expr::Var(name), expr) | (IntRel::Gte, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, None, Some(val)))
+                    }
+                    (IntRel::Gte, Expr::Var(name), expr) | (IntRel::Lte, expr, Expr::Var(name)) => {
+                        let val = Constraint::get_u64(expr)?;
+                        Some(Constraint::new(name, Some(val), None))
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn get_u64(expr: &Expr) -> Option<u64> {
+        match expr {
+            Expr::U8(n) => Some(u64::from(*n)),
+            Expr::U16(n) => Some(u64::from(*n)),
+            Expr::U32(n) => Some(u64::from(*n)),
+            Expr::U64(n) => Some(*n),
+            _ => None,
+        }
+    }
+
+    fn disjoint(&self, other: &Constraint) -> bool {
+        if self.name == other.name {
+            match (self.lower, self.upper, other.lower, other.upper) {
+                (Some(lo), _, _, Some(hi)) if lo > hi => true,
+                (Some(lo), _, _, Some(hi)) if lo > hi => true,
+
+                _ => false,
+            }
+        } else {
+            false
+        }
+    }
+}
+
+// both expr must be bool
+// conservative approximation, if true then definitely disjoint
+pub fn disjoint(a: &Expr, b: &Expr) -> bool {
+    match (Constraint::from_expr(a), Constraint::from_expr(b)) {
+        (Some(ac), Some(bc)) => ac.disjoint(&bc),
+        _ => false,
+    }
+}

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -271,3 +271,8 @@ pub fn flat_map_list(f: Expr, ret_type: ValueType, seq: Expr) -> Expr {
 pub fn dup(count: Expr, expr: Expr) -> Expr {
     Expr::Dup(Box::new(count), Box::new(expr))
 }
+
+/// Composed `Format::Where` and `Expr::Lambda` taking a raw format, an arbitrary name for the lambda expression head, and the lambda body as an Expr.
+pub fn where_lambda(raw: Format, name: impl IntoLabel, body: Expr) -> Format {
+    Format::Where(Box::new(raw), lambda(name, body))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1723,7 +1723,9 @@ impl<'a> MatchTreeStep<'a> {
                     }
                 }
             }
-            TypedFormat::Map(_, f, _expr) => Self::from_gt_format(module, f, next),
+            TypedFormat::Map(_, f, _expr) | TypedFormat::Where(_, f, _expr) => {
+                Self::from_gt_format(module, f, next)
+            }
             TypedFormat::Compute(_, _expr) => Self::from_next(module, next),
             TypedFormat::Let(_, _name, _expr, f) => Self::from_gt_format(module, f, next),
             TypedFormat::Match(_, _, branches) => {

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -1316,6 +1316,13 @@ impl Decoder {
                 let image = ParsedValue::inherit(&orig, v);
                 Ok((ParsedValue::Mapped(Box::new(orig), Box::new(image)), input))
             }
+            Decoder::Where(d, expr) => {
+                let (v, input) = d.parse_with_loc(program, scope, input)?;
+                match expr.eval_lambda_with_loc(scope, &v).unwrap_bool() {
+                    true => Ok((v, input)),
+                    false => Err(ParseError::loc_fail(scope, input)),
+                }
+            }
             Decoder::Compute(expr) => {
                 let v = expr.eval_with_loc(scope);
                 Ok((v.as_ref().clone(), input))

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -169,6 +169,7 @@ fn check_covered(
         }
         Format::WithRelativeOffset(_, _) => {} // FIXME
         Format::Map(format, _expr) => check_covered(module, path, format)?,
+        Format::Where(format, _expr) => check_covered(module, path, format)?,
         Format::Compute(_expr) => {}
         Format::Let(_name, _expr, format) => check_covered(module, path, format)?,
         Format::Match(_head, branches) => {
@@ -258,6 +259,7 @@ impl<'module, W: io::Write> Context<'module, W> {
             Format::Bits(format) => self.write_flat(value, format),
             Format::WithRelativeOffset(_, format) => self.write_flat(value, format),
             Format::Map(_format, _expr) => Ok(()),
+            Format::Where(_format, _expr) => Ok(()),
             Format::Compute(_expr) => Ok(()),
             Format::Let(_name, _expr, format) => self.write_flat(value, format),
             Format::Match(_head, branches) => match value {

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -360,6 +360,7 @@ impl<'module> MonoidalPrinter<'module> {
                     }
                 }
             }
+            Format::Where(format, _expr) => self.compile_parsed_decoded_value(value, format),
             Format::Compute(_expr) => self.compile_parsed_value(value),
             Format::Let(_name, _expr, format) => self.compile_parsed_decoded_value(value, format),
             Format::Match(_head, branches) => match value {
@@ -471,6 +472,7 @@ impl<'module> MonoidalPrinter<'module> {
                     }
                 }
             }
+            Format::Where(format, _expr) => self.compile_decoded_value(value, format),
             Format::Compute(_expr) => self.compile_value(value),
             Format::Let(_name, _expr, format) => self.compile_decoded_value(value, format),
             Format::Match(_head, branches) => match value {
@@ -1669,6 +1671,14 @@ impl<'module> MonoidalPrinter<'module> {
                 let expr_frag = self.compile_expr(expr, Precedence::ATOM);
                 cond_paren(
                     self.compile_nested_format("map", Some(&[expr_frag]), format, prec),
+                    prec,
+                    Precedence::FORMAT_COMPOUND,
+                )
+            }
+            Format::Where(format, expr) => {
+                let expr_frag = self.compile_expr(expr, Precedence::ATOM);
+                cond_paren(
+                    self.compile_nested_format("assert", Some(&[expr_frag]), format, prec),
                     prec,
                     Precedence::FORMAT_COMPOUND,
                 )

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -5,6 +5,8 @@ pub type PResult<T> = Result<T, ParseError>;
 pub enum ParseError {
     /// Explicit `Format::Fail` or any of its derived equivalents
     FailToken,
+    /// Validation failure for a Format::Where
+    FalsifiedWhere,
     /// For Repeat1, RepeatCount, or RepeatUntil*, indicates that an inadequate number of values were read before encountering end-of-buffer or end-of-slice.
     InsufficientRepeats,
     /// Indicates a successful parse within a negated context, as in the case of PeekNot
@@ -32,6 +34,7 @@ impl std::fmt::Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ParseError::FailToken => write!(f, "reached Fail token"),
+            ParseError::FalsifiedWhere => write!(f, "parsed value deemed invalid by Where lambda"),
             ParseError::InsufficientRepeats => write!(
                 f,
                 "failed to find enough format repeats to satisfy requirement"

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2377,6 +2377,16 @@ impl TypeChecker {
                 self.unify_var_pair(newvar, out_var)?;
                 Ok(newvar)
             }
+            Format::Where(inner, f) => {
+                let newvar = self.get_new_uvar();
+                let inner_t = self.infer_utype_format(inner, ctxt)?;
+
+                let (in_v, out_var) = self.infer_vars_expr_lambda(f, ctxt.scope)?;
+                self.unify_var_pair(newvar, in_v)?;
+                self.unify_var_utype(newvar, inner_t)?;
+                self.unify_var_utype(out_var, Rc::new(UType::Base(BaseType::Bool)))?;
+                Ok(newvar)
+            }
             Format::Compute(x) => {
                 let newvar = self.get_new_uvar();
                 let xt = self.infer_utype_expr(x, ctxt.scope)?;


### PR DESCRIPTION
Downstream changes to #177 including codegen support and application of new helper `where_lambda` to PNG iCCP validation (rather than hardcoding `:= 0` at the syntax-level)