### PR TITLE
Split out ValueType, Rc-based TypeHint for Expr, Box Expr in Format

### DIFF
--- a/doodle-formats/Cargo.toml
+++ b/doodle-formats/Cargo.toml
@@ -26,4 +26,3 @@ clap = { version = "4.2", features = ["derive"] }
 anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-lazy_static = "1.4"

--- a/doodle-formats/benches/inflate_bench.rs
+++ b/doodle-formats/benches/inflate_bench.rs
@@ -5,11 +5,10 @@ use doodle::{
     FormatModule,
 };
 use doodle_formats::format;
-use lazy_static::lazy_static;
 
 // amortize the cost of constructing the program to avoid overhead in the inflate profile
-lazy_static! {
-    static ref PROGRAM: Program = {
+thread_local! {
+    static PROGRAM: Program = {
         let mut module = FormatModule::new();
         let format = format::main(&mut module).call();
         let program = Compiler::compile_program(&module, &format).unwrap();
@@ -19,10 +18,10 @@ lazy_static! {
 
 fn run_decoder(f: &str) -> Value {
     let input = std::fs::read(f).unwrap();
-    let value = match PROGRAM.run(ReadCtxt::new(&input)) {
+    let value = PROGRAM.with(|p|  match p.run(ReadCtxt::new(&input)) {
         Ok((value, _)) => value,
         Err(_) => unreachable!(),
-    };
+    });
     value
 }
 

--- a/doodle-formats/src/format.rs
+++ b/doodle-formats/src/format.rs
@@ -51,7 +51,7 @@ pub fn main(module: &mut FormatModule) -> FormatRef {
                     var("gzip-raw"),
                     "item",
                     Format::DecodeBytes(
-                        record_projs(var("item"), &["data", "inflate"]),
+                        Box::new(record_projs(var("item"), &["data", "inflate"])),
                         Box::new(tar.call()),
                     ),
                 ),
@@ -108,7 +108,10 @@ mod test {
             ("len", base.u32be()),
             (
                 "mask",
-                Format::WithRelativeOffset(var("len"), Box::new(Format::Byte(mask_bytes))),
+                Format::WithRelativeOffset(
+                    Box::new(var("len")),
+                    Box::new(Format::Byte(mask_bytes)),
+                ),
             ),
             (
                 "data",
@@ -116,7 +119,7 @@ mod test {
                     var("len"),
                     Format::Map(
                         Box::new(base.u8()),
-                        lambda("byte", bit_and(var("mask"), var("byte"))),
+                        Box::new(lambda("byte", bit_and(var("mask"), var("byte")))),
                     ),
                 ),
             ),

--- a/doodle-formats/src/format/deflate.rs
+++ b/doodle-formats/src/format/deflate.rs
@@ -61,6 +61,7 @@ fn dist_value_u8(x: &'static str) -> Expr {
 ///
 /// Auto-recursive for n > 1, using a successively smaller prefix of the tuple expression.
 fn bits_value_u16(name: &'static str, n: usize) -> Expr {
+    // FIXME - try to balance the tree with explicit conditional flow over value of n
     if n > 1 {
         bit_or(
             shl_u16(tuple_proj(var(name), n - 1), cast(n - 1)),
@@ -83,7 +84,7 @@ fn dist8(base: &BaseModule) -> Format {
 /// standard LSB-to-MSB write order for numeric values in the DEFLATE specification.
 fn bits8(n: usize, base: &BaseModule) -> Format {
     if n == 0 {
-        return Format::Compute(Box::new(Expr::U8(0)));
+        return compute(Expr::U8(0));
     }
 
     map(
@@ -96,7 +97,7 @@ fn bits8(n: usize, base: &BaseModule) -> Format {
 /// standard LSB-to-MSB write order for numeric values in the DEFLATE specification.
 fn bits16(n: usize, base: &BaseModule) -> Format {
     if n == 0 {
-        return Format::Compute(Box::new(Expr::U16(0)));
+        return compute(Expr::U16(0));
     }
 
     map(
@@ -231,7 +232,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "distance",
-                Format::Compute(Box::new(add(var("start"), var("distance-extra-bits")))),
+                compute(add(var("start"), var("distance-extra-bits"))),
             ),
         ]),
     );
@@ -825,7 +826,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         (Pattern::U8(16), bits2.clone()),
                                         (Pattern::U8(17), bits3.clone()),
                                         (Pattern::U8(18), bits7.clone()),
-                                        (Pattern::Wildcard, Format::Compute(Box::new(Expr::U8(0)))),
+                                        (Pattern::Wildcard, compute(Expr::U8(0))),
                                     ],
                                 ),
                             ),

--- a/doodle-formats/src/format/deflate.rs
+++ b/doodle-formats/src/format/deflate.rs
@@ -116,10 +116,10 @@ fn length_record(
         ("length-extra-bits", bits8(extra_bits, base)),
         (
             "length",
-            Format::Compute(Box::new(add(
+            compute(add(
                 Expr::U16(start as u16),
                 as_u16(var("length-extra-bits")),
-            ))),
+            )),
         ),
         (
             "distance-code",
@@ -142,10 +142,10 @@ fn length_record_fixed(
         ("length-extra-bits", bits8(extra_bits, base)),
         (
             "length",
-            Format::Compute(Box::new(add(
+            compute(add(
                 Expr::U16(start as u16),
                 as_u16(var("length-extra-bits")),
-            ))),
+            )),
         ),
         ("distance-code", dist8(base)),
         (
@@ -377,10 +377,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ("bytes", repeat_count(var("len"), bits8(8, base))),
             (
                 "codes-values",
-                Format::Compute(Box::new(flat_map(
+                compute(flat_map(
                     lambda("x", Expr::Seq(vec![variant("literal", var("x"))])),
                     var("bytes"),
-                ))),
+                )),
             ),
         ]),
     );
@@ -678,7 +678,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "codes-values",
-                Format::Compute(Box::new(flat_map(
+                compute(flat_map(
                     lambda(
                         "x",
                         expr_match(
@@ -698,7 +698,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         ),
                     ),
                     var("codes"),
-                ))),
+                )),
             ),
         ]),
     );
@@ -836,7 +836,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "literal-length-distance-alphabet-code-lengths-value",
-                Format::Compute(Box::new(flat_map_accum(
+                compute(flat_map_accum(
                     lambda_tuple(
                         ["last-symbol", "cl-code-extra"],
                         expr_match(
@@ -894,23 +894,23 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     expr_none(),
                     ValueType::Option(Box::new(ValueType::Base(BaseType::U8))),
                     var("literal-length-distance-alphabet-code-lengths"),
-                ))),
+                )),
             ),
             (
                 "literal-length-alphabet-code-lengths-value",
-                Format::Compute(Box::new(sub_seq(
+                compute(sub_seq(
                     var("literal-length-distance-alphabet-code-lengths-value"),
                     Expr::U32(0),
                     add(as_u32(var("hlit")), Expr::U32(257)),
-                ))),
+                )),
             ),
             (
                 "distance-alphabet-code-lengths-value",
-                Format::Compute(Box::new(sub_seq(
+                compute(sub_seq(
                     var("literal-length-distance-alphabet-code-lengths-value"),
                     add(as_u32(var("hlit")), Expr::U32(257)),
                     add(as_u32(var("hdist")), Expr::U32(1)),
-                ))),
+                )),
             ),
             (
                 "codes",
@@ -1212,7 +1212,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "codes-values",
-                Format::Compute(Box::new(flat_map(
+                compute(flat_map(
                     lambda(
                         "x",
                         expr_match(
@@ -1233,7 +1233,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         ),
                     ),
                     var("codes"),
-                ))),
+                )),
             ),
         ]),
     );
@@ -1278,7 +1278,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             ),
             (
                 "codes",
-                Format::Compute(Box::new(flat_map(
+                compute(flat_map(
                     lambda(
                         "x",
                         expr_match(
@@ -1300,11 +1300,11 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         ),
                     ),
                     var("blocks"),
-                ))),
+                )),
             ),
             (
                 "inflate",
-                Format::Compute(Box::new(flat_map_list(
+                compute(flat_map_list(
                     lambda_tuple(
                         ["buffer", "symbol"],
                         expr_match(
@@ -1330,7 +1330,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     ),
                     ValueType::Base(BaseType::U8),
                     var("codes"),
-                ))),
+                )),
             ),
         ]),
     )

--- a/doodle-formats/src/format/elf.rs
+++ b/doodle-formats/src/format/elf.rs
@@ -296,7 +296,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         record([
             (
                 "ident",
-                Format::Slice(Expr::U32(EI_NIDENT), Box::new(elf_ident.call())),
+                Format::Slice(Box::new(Expr::U32(EI_NIDENT)), Box::new(elf_ident.call())),
             ), // machine-independent ELF identification array (byte-oriented)
             ("type", e_type.call_args(vec![var_is_be.clone()])), // file-type identifier
             ("machine", e_machine.call_args(vec![var_is_be.clone()])), // identifier for the architecture required by the ELF image
@@ -583,7 +583,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         ],
         // FIXME - we can refine this a lot more based on the type passed in
         Format::Match(
-            var("type"),
+            Box::new(var("type")),
             vec![
                 (Pattern::Wildcard, repeat_count(var("size"), base.u8())), // abstract (unrefined) section
             ],
@@ -638,7 +638,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     (Pattern::Wildcard, Expr::Bool(true)),
                 ],
             ),
-            Format::WithRelativeOffset(sub(off_as_64(offset_file), var("__eoh")), Box::new(f)),
+            Format::WithRelativeOffset(
+                Box::new(sub(off_as_64(offset_file), var("__eoh"))),
+                Box::new(f),
+            ),
         )
     };
 
@@ -671,7 +674,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 "sections",
                 // FIXME: this suggests the definition of a Format-level Option::map helper
                 Format::Match(
-                    var("section_headers"),
+                    Box::new(var("section_headers")),
                     vec![
                         (
                             pat_some(Pattern::binding("shdrs")),
@@ -690,10 +693,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                     ),
                                     Format::WithRelativeOffset(
-                                        sub(
+                                        Box::new(sub(
                                             off_as_64(record_proj(var("shdr"), "offset")),
                                             var("__eoh"),
-                                        ),
+                                        )),
                                         Box::new(elf_section.call_args(vec![
                                             record_proj(var("shdr"), "type"),
                                             full_as_64(record_proj(var("shdr"), "size")),

--- a/doodle-formats/src/format/elf.rs
+++ b/doodle-formats/src/format/elf.rs
@@ -294,11 +294,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
     let elf_header = module.define_format(
         "elf.header",
         record([
-            (
-                "ident",
-                Format::Slice(Box::new(Expr::U32(EI_NIDENT)), Box::new(elf_ident.call())),
-            ), // machine-independent ELF identification array (byte-oriented)
-            ("type", e_type.call_args(vec![var_is_be.clone()])), // file-type identifier
+            ("ident", slice(Expr::U32(EI_NIDENT), elf_ident.call())), // machine-independent ELF identification array (byte-oriented)
+            ("type", e_type.call_args(vec![var_is_be.clone()])),      // file-type identifier
             ("machine", e_machine.call_args(vec![var_is_be.clone()])), // identifier for the architecture required by the ELF image
             ("version", e_version.call_args(vec![var_is_be.clone()])), // ELF version (should agree with the equivalent field in `ident`)
             (

--- a/doodle-formats/src/format/gzip.rs
+++ b/doodle-formats/src/format/gzip.rs
@@ -65,7 +65,10 @@ pub fn main(module: &mut FormatModule, deflate: FormatRef, base: &BaseModule) ->
             ("xlen", base.u16le()),
             (
                 "subfields",
-                Format::Slice(var("xlen"), Box::new(repeat(fextra_subfield.call()))),
+                Format::Slice(
+                    Box::new(var("xlen")),
+                    Box::new(repeat(fextra_subfield.call())),
+                ),
             ),
         ]),
     );

--- a/doodle-formats/src/format/jpeg.rs
+++ b/doodle-formats/src/format/jpeg.rs
@@ -17,7 +17,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
             ("length", base.u16be()),
             (
                 "data",
-                Format::Slice(sub(var("length"), Expr::U16(2)), Box::new(data)),
+                Format::Slice(Box::new(sub(var("length"), Expr::U16(2))), Box::new(data)),
             ),
         ])
     };
@@ -479,7 +479,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
             ),
             (
                 "scan-data-stream",
-                Format::Compute(flat_map(
+                Format::Compute(Box::new(flat_map(
                     lambda(
                         "x",
                         expr_match(
@@ -525,7 +525,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
                         ),
                     ),
                     var("scan-data"),
-                )),
+                ))),
             ),
         ]),
     );

--- a/doodle-formats/src/format/jpeg.rs
+++ b/doodle-formats/src/format/jpeg.rs
@@ -476,7 +476,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
             ),
             (
                 "scan-data-stream",
-                Format::Compute(Box::new(flat_map(
+                compute(flat_map(
                     lambda(
                         "x",
                         expr_match(
@@ -522,7 +522,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
                         ),
                     ),
                     var("scan-data"),
-                ))),
+                )),
             ),
         ]),
     );

--- a/doodle-formats/src/format/jpeg.rs
+++ b/doodle-formats/src/format/jpeg.rs
@@ -15,10 +15,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule, tiff: &FormatRef) -> F
         record([
             ("marker", marker(id)),
             ("length", base.u16be()),
-            (
-                "data",
-                Format::Slice(Box::new(sub(var("length"), Expr::U16(2))), Box::new(data)),
-            ),
+            ("data", slice(sub(var("length"), Expr::U16(2)), data)),
         ])
     };
 

--- a/doodle-formats/src/format/mpeg4.rs
+++ b/doodle-formats/src/format/mpeg4.rs
@@ -40,19 +40,19 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 Format::Match(
                     Box::new(var("size-field")),
                     vec![
-                        (Pattern::U32(0), Format::Compute(Box::new(Expr::U64(0)))), // FIXME
+                        (Pattern::U32(0), compute(Expr::U64(0))), // FIXME
                         (
                             Pattern::U32(1),
                             map(base.u64be(), lambda("x", sub(var("x"), Expr::U64(16)))),
                         ),
                         (
                             Pattern::Wildcard,
-                            Format::Compute(Box::new(as_u64(sub(var("size-field"), Expr::U32(8))))),
+                            compute(as_u64(sub(var("size-field"), Expr::U32(8)))),
                         ),
                     ],
                 ),
             ),
-            ("data", Format::Slice(Box::new(var("size")), Box::new(data))),
+            ("data", slice(var("size"), data)),
         ])
     }
 
@@ -244,7 +244,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         ("base_offset_size_index_size", base.u8()), // two four-bit fields
         (
             "offset_size",
-            Format::Compute(Box::new(shr(var("offset_size_length_size"), Expr::U8(4)))),
+            compute(shr(var("offset_size_length_size"), Expr::U8(4))),
         ),
         (
             "length_size",
@@ -268,7 +268,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     var("base_offset_size_index_size"),
                     Expr::U8(7),
                 ))),
-                Format::Compute(Box::new(Expr::U8(0))),
+                compute(Expr::U8(0)),
             ),
         ),
         (
@@ -302,7 +302,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         Format::Match(
                             Box::new(var("base_offset_size")),
                             vec![
-                                (Pattern::U8(0), Format::Compute(Box::new(Expr::U64(0)))),
+                                (Pattern::U8(0), compute(Expr::U64(0))),
                                 (
                                     Pattern::U8(4),
                                     map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -322,10 +322,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Format::Match(
                                         Box::new(var("index_size")),
                                         vec![
-                                            (
-                                                Pattern::U8(0),
-                                                Format::Compute(Box::new(Expr::U64(0))),
-                                            ),
+                                            (Pattern::U8(0), compute(Expr::U64(0))),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -339,10 +336,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Format::Match(
                                         Box::new(var("offset_size")),
                                         vec![
-                                            (
-                                                Pattern::U8(0),
-                                                Format::Compute(Box::new(Expr::U64(0))),
-                                            ),
+                                            (Pattern::U8(0), compute(Expr::U64(0))),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -356,10 +350,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     Format::Match(
                                         Box::new(var("length_size")),
                                         vec![
-                                            (
-                                                Pattern::U8(0),
-                                                Format::Compute(Box::new(Expr::U64(0))),
-                                            ),
+                                            (Pattern::U8(0), compute(Expr::U64(0))),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -531,7 +522,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         if_then_else(
                             expr_eq(var("default_length"), Expr::U32(0)),
                             base.u32be(),
-                            Format::Compute(Box::new(var("default_length"))),
+                            compute(var("default_length")),
                         ),
                     ),
                     (

--- a/doodle-formats/src/format/mpeg4.rs
+++ b/doodle-formats/src/format/mpeg4.rs
@@ -248,26 +248,17 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         ),
         (
             "length_size",
-            Format::Compute(Box::new(bit_and(
-                var("offset_size_length_size"),
-                Expr::U8(7),
-            ))),
+            compute(bit_and(var("offset_size_length_size"), Expr::U8(7))),
         ),
         (
             "base_offset_size",
-            Format::Compute(Box::new(shr(
-                var("base_offset_size_index_size"),
-                Expr::U8(4),
-            ))),
+            compute(shr(var("base_offset_size_index_size"), Expr::U8(4))),
         ),
         (
             "index_size",
             if_then_else(
                 expr_gt(var("version"), Expr::U8(0)),
-                Format::Compute(Box::new(bit_and(
-                    var("base_offset_size_index_size"),
-                    Expr::U8(7),
-                ))),
+                compute(bit_and(var("base_offset_size_index_size"), Expr::U8(7))),
                 compute(Expr::U8(0)),
             ),
         ),

--- a/doodle-formats/src/format/mpeg4.rs
+++ b/doodle-formats/src/format/mpeg4.rs
@@ -38,21 +38,21 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             (
                 "size",
                 Format::Match(
-                    var("size-field"),
+                    Box::new(var("size-field")),
                     vec![
-                        (Pattern::U32(0), Format::Compute(Expr::U64(0))), // FIXME
+                        (Pattern::U32(0), Format::Compute(Box::new(Expr::U64(0)))), // FIXME
                         (
                             Pattern::U32(1),
                             map(base.u64be(), lambda("x", sub(var("x"), Expr::U64(16)))),
                         ),
                         (
                             Pattern::Wildcard,
-                            Format::Compute(as_u64(sub(var("size-field"), Expr::U32(8)))),
+                            Format::Compute(Box::new(as_u64(sub(var("size-field"), Expr::U32(8))))),
                         ),
                     ],
                 ),
             ),
-            ("data", Format::Slice(var("size"), Box::new(data))),
+            ("data", Format::Slice(Box::new(var("size")), Box::new(data))),
         ])
     }
 
@@ -244,22 +244,31 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         ("base_offset_size_index_size", base.u8()), // two four-bit fields
         (
             "offset_size",
-            Format::Compute(shr(var("offset_size_length_size"), Expr::U8(4))),
+            Format::Compute(Box::new(shr(var("offset_size_length_size"), Expr::U8(4)))),
         ),
         (
             "length_size",
-            Format::Compute(bit_and(var("offset_size_length_size"), Expr::U8(7))),
+            Format::Compute(Box::new(bit_and(
+                var("offset_size_length_size"),
+                Expr::U8(7),
+            ))),
         ),
         (
             "base_offset_size",
-            Format::Compute(shr(var("base_offset_size_index_size"), Expr::U8(4))),
+            Format::Compute(Box::new(shr(
+                var("base_offset_size_index_size"),
+                Expr::U8(4),
+            ))),
         ),
         (
             "index_size",
             if_then_else(
                 expr_gt(var("version"), Expr::U8(0)),
-                Format::Compute(bit_and(var("base_offset_size_index_size"), Expr::U8(7))),
-                Format::Compute(Expr::U8(0)),
+                Format::Compute(Box::new(bit_and(
+                    var("base_offset_size_index_size"),
+                    Expr::U8(7),
+                ))),
+                Format::Compute(Box::new(Expr::U8(0))),
             ),
         ),
         (
@@ -291,9 +300,9 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     (
                         "base_offset",
                         Format::Match(
-                            var("base_offset_size"),
+                            Box::new(var("base_offset_size")),
                             vec![
-                                (Pattern::U8(0), Format::Compute(Expr::U64(0))),
+                                (Pattern::U8(0), Format::Compute(Box::new(Expr::U64(0)))),
                                 (
                                     Pattern::U8(4),
                                     map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -311,9 +320,12 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (
                                     "extent_index",
                                     Format::Match(
-                                        var("index_size"),
+                                        Box::new(var("index_size")),
                                         vec![
-                                            (Pattern::U8(0), Format::Compute(Expr::U64(0))),
+                                            (
+                                                Pattern::U8(0),
+                                                Format::Compute(Box::new(Expr::U64(0))),
+                                            ),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -325,9 +337,12 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (
                                     "extent_offset",
                                     Format::Match(
-                                        var("offset_size"),
+                                        Box::new(var("offset_size")),
                                         vec![
-                                            (Pattern::U8(0), Format::Compute(Expr::U64(0))),
+                                            (
+                                                Pattern::U8(0),
+                                                Format::Compute(Box::new(Expr::U64(0))),
+                                            ),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -339,9 +354,12 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (
                                     "extent_length",
                                     Format::Match(
-                                        var("length_size"),
+                                        Box::new(var("length_size")),
                                         vec![
-                                            (Pattern::U8(0), Format::Compute(Expr::U64(0))),
+                                            (
+                                                Pattern::U8(0),
+                                                Format::Compute(Box::new(Expr::U64(0))),
+                                            ),
                                             (
                                                 Pattern::U8(4),
                                                 map(base.u32be(), lambda("x", as_u64(var("x")))),
@@ -513,7 +531,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         if_then_else(
                             expr_eq(var("default_length"), Expr::U32(0)),
                             base.u32be(),
-                            Format::Compute(var("default_length")),
+                            Format::Compute(Box::new(var("default_length"))),
                         ),
                     ),
                     (

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -1282,7 +1282,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         ),
                         (
                             "field_set",
-                            Format::Compute(Box::new(subset_fields(
+                            compute(subset_fields(
                                 var("flags"),
                                 [
                                     "on_curve_point",
@@ -1292,7 +1292,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     "y_is_same_or_positive_y_short_vector",
                                     "overlap_simple",
                                 ],
-                            ))),
+                            )),
                         ),
                     ]),
                 );
@@ -1417,10 +1417,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     ),
                     (
                         "number_of_coordinates",
-                        Format::Compute(Box::new(add(
-                            Expr::U16(1),
-                            last_elem("end_points_of_contour"),
-                        ))),
+                        compute(add(Expr::U16(1), last_elem("end_points_of_contour"))),
                     ),
                     ("flags", glyf_flags_simple(var("number_of_coordinates"))),
                     (

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -119,12 +119,7 @@ fn s64be(base: &BaseModule) -> Format {
 
 fn u24be(base: &BaseModule) -> Format {
     map(
-        Format::Tuple(vec![
-            Format::Compute(Box::new(Expr::U8(0))),
-            base.u8(),
-            base.u8(),
-            base.u8(),
-        ]),
+        Format::Tuple(vec![compute(Expr::U8(0)), base.u8(), base.u8(), base.u8()]),
         lambda("x", Expr::U32Be(Box::new(var("x")))),
     )
 }
@@ -923,11 +918,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             [
                                 (Pattern::U32(0x0001_0000), "MaxpV1", maxp_version_1.call()),
                                 (Pattern::U32(0x0000_5000), "MaxpPostScript", Format::EMPTY),
-                                (
-                                    bind("unknown"),
-                                    "MaxpUnknown",
-                                    Format::Compute(Box::new(var("unknown"))),
-                                ), // FIXME - do we need this at all?
+                                (bind("unknown"), "MaxpUnknown", compute(var("unknown"))), // FIXME - do we need this at all?
                             ],
                         ),
                     ),
@@ -1076,7 +1067,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (
                                     Pattern::binding("unknown"),
                                     "NameVersionUnknown",
-                                    Format::Compute(Box::new(var("unknown"))),
+                                    compute(var("unknown")),
                                 ),
                             ],
                         ),
@@ -1214,11 +1205,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 (Pattern::U32(0x0002_0000), "Version2", postv2),
                                 (Pattern::U32(0x0002_5000), "Version2Dot5", postv2dot5),
                                 (Pattern::U32(0x0003_0000), "Version3", Format::EMPTY),
-                                (
-                                    bind("unknown"),
-                                    "VersionUnknown",
-                                    Format::Compute(Box::new(var("unknown"))),
-                                ),
+                                (bind("unknown"), "VersionUnknown", compute(var("unknown"))),
                             ],
                         ),
                     ),
@@ -1290,7 +1277,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             if_then_else(
                                 is_nonzero_u8(record_proj(var("flags"), "repeat_flag")),
                                 base.u8(),
-                                Format::Compute(Box::new(Expr::U8(0))),
+                                compute(Expr::U8(0)),
                             ),
                         ),
                         (
@@ -1382,7 +1369,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             "x_is_same_or_positive_x_short_vector",
                         )),
                         // this wants to be i16
-                        Format::Compute(Box::new(Expr::U16(0))),
+                        compute(Expr::U16(0)),
                         s16be(base),
                     ),
                 )
@@ -1411,7 +1398,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             "y_is_same_or_positive_y_short_vector",
                         )),
                         // this wants to be i16
-                        Format::Compute(Box::new(Expr::U16(0))),
+                        compute(Expr::U16(0)),
                         s16be(base),
                     ),
                 )
@@ -1552,7 +1539,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 "instructions_length",
                                 repeat_count(var("instructions_length"), base.u8()),
                             ),
-                            Format::Compute(Box::new(seq_empty())),
+                            compute(seq_empty()),
                         ),
                     ),
                 ])
@@ -1794,11 +1781,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                         [
                             (Pattern::U16(1), "Version1", ttc_header1(var("start"))),
                             (Pattern::U16(2), "Version2", ttc_header2(var("start"))),
-                            (
-                                bind("unknown"),
-                                "UnknownVersion",
-                                Format::Compute(Box::new(var("unknown"))),
-                            ),
+                            (bind("unknown"), "UnknownVersion", compute(var("unknown"))),
                         ],
                     ),
                 ),

--- a/doodle-formats/src/format/peano.rs
+++ b/doodle-formats/src/format/peano.rs
@@ -9,7 +9,7 @@ pub fn main(module: &mut FormatModule) -> FormatRef {
                 repeat_between(Expr::U16(0), Expr::U16(9), is_byte(b'S')),
                 is_byte(b'Z'),
             ])),
-            lambda_tuple(["s", "_z"], seq_length(var("s"))),
+            Box::new(lambda_tuple(["s", "_z"], seq_length(var("s")))),
         ),
     );
     module.define_format("peano.sequence", repeat1(peano_number.call()))

--- a/doodle-formats/src/format/png.rs
+++ b/doodle-formats/src/format/png.rs
@@ -28,10 +28,7 @@ pub fn main(
                 ),
             ), // NOTE: < 2^31
             ("tag", tag),
-            (
-                "data",
-                Format::Slice(Box::new(var("length")), Box::new(data)),
-            ),
+            ("data", slice(var("length"), data)),
             ("crc", base.u32be()), // FIXME check this
         ])
     };

--- a/doodle-formats/src/format/png.rs
+++ b/doodle-formats/src/format/png.rs
@@ -28,7 +28,10 @@ pub fn main(
                 ),
             ), // NOTE: < 2^31
             ("tag", tag),
-            ("data", Format::Slice(var("length"), Box::new(data))),
+            (
+                "data",
+                Format::Slice(Box::new(var("length")), Box::new(data)),
+            ),
             ("crc", base.u32be()), // FIXME check this
         ])
     };
@@ -145,7 +148,7 @@ pub fn main(
         zlib.call(),
         "zlib",
         Format::DecodeBytes(
-            record_projs(var("zlib"), &["data", "inflate"]),
+            Box::new(record_projs(var("zlib"), &["data", "inflate"])),
             Box::new(utf8text_nz.call()),
         ),
     );
@@ -258,7 +261,7 @@ pub fn main(
         zlib.call(),
         "zlib",
         Format::DecodeBytes(
-            record_projs(var("zlib"), &["data", "inflate"]),
+            Box::new(record_projs(var("zlib"), &["data", "inflate"])),
             // FIXME - we need to define a new format for latin1 without a null terminal (viz. why asciiz_string won't work)
             Box::new(utf8text.call()),
         ),
@@ -421,7 +424,7 @@ pub fn main(
             (
                 "data",
                 Format::Slice(
-                    var("length"),
+                    Box::new(var("length")),
                     Box::new(match_variant(
                         var("tag"),
                         [
@@ -480,7 +483,7 @@ pub fn main(
                         ),
                     ),
                     "idat",
-                    Format::DecodeBytes(var("idat"), Box::new(zlib.call())),
+                    Format::DecodeBytes(Box::new(var("idat")), Box::new(zlib.call())),
                 ),
             ),
             (

--- a/doodle-formats/src/format/riff.rs
+++ b/doodle-formats/src/format/riff.rs
@@ -12,10 +12,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         record([
             ("tag", tag),
             ("length", base.u32le()),
-            (
-                "data",
-                Format::Slice(Box::new(var("length")), Box::new(data)),
-            ),
+            ("data", slice(var("length"), data)),
             ("pad", cond_maybe(is_odd(var("length")), is_byte(0x00))),
         ])
     };

--- a/doodle-formats/src/format/riff.rs
+++ b/doodle-formats/src/format/riff.rs
@@ -12,7 +12,10 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         record([
             ("tag", tag),
             ("length", base.u32le()),
-            ("data", Format::Slice(var("length"), Box::new(data))),
+            (
+                "data",
+                Format::Slice(Box::new(var("length")), Box::new(data)),
+            ),
             ("pad", cond_maybe(is_odd(var("length")), is_byte(0x00))),
         ])
     };

--- a/doodle-formats/src/format/tar.rs
+++ b/doodle-formats/src/format/tar.rs
@@ -50,9 +50,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         )
     };
 
-    let cstr_arr = |len: u16| -> Format {
-        Format::Slice(Box::new(Expr::U16(len)), Box::new(tar_asciiz.call()))
-    };
+    let cstr_arr = |len: u16| -> Format { slice(Expr::U16(len), tar_asciiz.call()) };
     let magic = is_bytes(MAGIC);
     let size_field = {
         let octal_digit = map(
@@ -116,11 +114,11 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
         ]),
     );
 
-    let filename = Format::Slice(Box::new(Expr::U16(100)), Box::new(tar_str_optz_ne.call()));
+    let filename = slice(Expr::U16(100), tar_str_optz_ne.call());
 
-    let linkname = Format::Slice(Box::new(Expr::U16(100)), Box::new(tar_str_optz.call()));
+    let linkname = slice(Expr::U16(100), tar_str_optz.call());
 
-    let prefix = Format::Slice(Box::new(Expr::U16(155)), Box::new(tar_str_optz.call()));
+    let prefix = slice(Expr::U16(155), tar_str_optz.call());
 
     // This specification is only guaranteed to work for UStar archives. Anything else might work
     // by happenstance but may fail just as easily.

--- a/doodle-formats/src/format/tar.rs
+++ b/doodle-formats/src/format/tar.rs
@@ -74,7 +74,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 ("__nil", nul_or_wsp.call()),
                 (
                     "value",
-                    Format::Compute(Box::new(bit_or(
+                    compute(bit_or(
                         shl(
                             o4u32(Expr::U8(0), var("oA"), var("o9"), var("o8")),
                             Expr::U32(24),
@@ -86,7 +86,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                             ),
                             o4u32(var("o3"), var("o2"), var("o1"), var("o0")),
                         ),
-                    ))),
+                    )),
                 ),
             ]),
             lambda("rec", Expr::record_proj(var("rec"), "value")),

--- a/doodle-formats/src/format/tiff.rs
+++ b/doodle-formats/src/format/tiff.rs
@@ -49,7 +49,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             (
                 "magic",
                 Format::Match(
-                    var("byte-order"),
+                    Box::new(var("byte-order")),
                     vec![
                         (Pattern::variant("le", Pattern::Wildcard), base.u16le()), // 42
                         (Pattern::variant("be", Pattern::Wildcard), base.u16be()), // 42
@@ -59,7 +59,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             (
                 "offset",
                 Format::Match(
-                    var("byte-order"),
+                    Box::new(var("byte-order")),
                     vec![
                         (Pattern::variant("le", Pattern::Wildcard), base.u32le()),
                         (Pattern::variant("be", Pattern::Wildcard), base.u32be()),
@@ -70,9 +70,9 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                 "ifd",
                 Format::WithRelativeOffset(
                     // TODO: Offset from start of the TIFF header
-                    sub(var("offset"), Expr::U32(8)),
+                    Box::new(sub(var("offset"), Expr::U32(8))),
                     Box::new(Format::Match(
-                        var("byte-order"),
+                        Box::new(var("byte-order")),
                         vec![
                             (Pattern::variant("le", Pattern::Wildcard), ifd(false)),
                             (Pattern::variant("be", Pattern::Wildcard), ifd(true)),

--- a/doodle-formats/src/format/waldo.rs
+++ b/doodle-formats/src/format/waldo.rs
@@ -14,7 +14,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
             (
                 "waldo",
                 Format::WithRelativeOffset(
-                    sub(var("where"), var("here")),
+                    Box::new(sub(var("where"), var("here"))),
                     Box::new(is_bytes(b"Waldo")),
                 ),
             ),

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -100,7 +100,7 @@ impl Bounds {
     /// `self` over the range `min..=max`.
     pub(crate) fn significant_bits(&self) -> Bounds {
         Self {
-            min: sigbits(self.min) as usize,
+            min: sigbits(self.min),
             max: self.max.map(sigbits),
         }
     }
@@ -236,10 +236,7 @@ impl Sub for Bounds {
                 Some(m2) => self.min.saturating_sub(m2),
                 None => 0,
             },
-            max: match self.max {
-                Some(m1) => Some(m1.saturating_sub(rhs.min)),
-                None => None,
-            },
+            max: self.max.map(|m1| m1.saturating_sub(rhs.min)),
         }
     }
 }
@@ -267,10 +264,7 @@ impl Div<Bounds> for Bounds {
                 Some(m2) => self.min.checked_div(m2).unwrap(),
                 None => 0,
             },
-            max: match self.max {
-                Some(m1) => Some(m1 / usize::max(rhs.min, 1)),
-                _ => None,
-            },
+            max: self.max.map(|m1| m1 / usize::max(rhs.min, 1)),
         }
     }
 }
@@ -301,10 +295,9 @@ impl Shr<Bounds> for Bounds {
                 Some(m2) => self.min.checked_shr(u32::try_from(m2).unwrap()).unwrap(),
                 None => 0,
             },
-            max: match self.max {
-                Some(m1) => Some(m1.checked_shr(u32::try_from(rhs.min).unwrap()).unwrap()),
-                _ => None,
-            },
+            max: self
+                .max
+                .map(|m1| m1.checked_shr(u32::try_from(rhs.min).unwrap()).unwrap()),
         }
     }
 }

--- a/src/byte_set.rs
+++ b/src/byte_set.rs
@@ -414,7 +414,7 @@ mod tests {
                 let bs_range_exc = if end < 255 {
                     ByteSet::from(start..end+1)
                 } else {
-                    bs_range_inc.clone()
+                    bs_range_inc
                 };
                 let bs_iter = (start..=end).collect::<ByteSet>();
                 let bs_manual = {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3588,7 +3588,7 @@ mod tests {
     #[test]
     fn test_popcheck_compute_simple() {
         let x = Format::Byte(ByteSet::full());
-        let fx = Format::Compute(Box::new(Expr::Var("x".into())));
+        let fx = compute(Expr::Var("x".into()));
         let gx = Format::Compute(Box::new(Expr::Arith(
             Arith::Add,
             Box::new(Expr::Var("x".into())),

--- a/src/codegen/name.rs
+++ b/src/codegen/name.rs
@@ -232,7 +232,7 @@ impl NameCtxt {
 
     /// Registers the current PathLabel on-stack into the appropriate [`PHeap`] in the association-table,
     /// returning it for later promotion using [`NameCtxt::find_name_for`]
-    pub fn produce_name<'a>(&mut self) -> PathLabel {
+    pub fn produce_name(&mut self) -> PathLabel {
         let identifier = Self::generate_name(&self.stack);
         Self::resolve(&mut self.table, identifier.clone(), &self.stack);
         self.stack.clone()
@@ -280,7 +280,7 @@ mod tests {
 
     #[test]
     fn test_record_tree() {
-        let ref mut ctxt = NameCtxt::new();
+        let ctxt = &mut NameCtxt::new();
         let root = ctxt
             .push_atom(NameAtom::Explicit(Label::Borrowed("root")))
             .produce_name();

--- a/src/codegen/typed_decoder.rs
+++ b/src/codegen/typed_decoder.rs
@@ -61,33 +61,61 @@ pub(crate) enum TypedDecoder<TypeRep> {
     Record(TypeRep, Vec<(Label, TypedDecoderExt<TypeRep>)>),
     Repeat0While(TypeRep, MatchTree, Box<TypedDecoderExt<TypeRep>>),
     Repeat1Until(TypeRep, MatchTree, Box<TypedDecoderExt<TypeRep>>),
-    RepeatCount(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
+    RepeatCount(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
     RepeatBetween(
         TypeRep,
         MatchTree,
-        TypedExpr<TypeRep>,
-        TypedExpr<TypeRep>,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedExpr<TypeRep>>,
         Box<TypedDecoderExt<TypeRep>>,
     ),
-    RepeatUntilLast(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
-    RepeatUntilSeq(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
+    RepeatUntilLast(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
+    RepeatUntilSeq(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
     Peek(TypeRep, Box<TypedDecoderExt<TypeRep>>),
     PeekNot(TypeRep, Box<TypedDecoderExt<TypeRep>>),
-    Slice(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
+    Slice(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
     Bits(TypeRep, Box<TypedDecoderExt<TypeRep>>),
-    WithRelativeOffset(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
-    Map(TypeRep, Box<TypedDecoderExt<TypeRep>>, TypedExpr<TypeRep>),
-    Where(TypeRep, Box<TypedDecoderExt<TypeRep>>, TypedExpr<TypeRep>),
-    Compute(TypeRep, TypedExpr<TypeRep>),
+    WithRelativeOffset(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
+    Map(
+        TypeRep,
+        Box<TypedDecoderExt<TypeRep>>,
+        Box<TypedExpr<TypeRep>>,
+    ),
+    Where(
+        TypeRep,
+        Box<TypedDecoderExt<TypeRep>>,
+        Box<TypedExpr<TypeRep>>,
+    ),
+    Compute(TypeRep, Box<TypedExpr<TypeRep>>),
     Let(
         TypeRep,
         Label,
-        TypedExpr<TypeRep>,
+        Box<TypedExpr<TypeRep>>,
         Box<TypedDecoderExt<TypeRep>>,
     ),
     Match(
         TypeRep,
-        TypedExpr<TypeRep>,
+        Box<TypedExpr<TypeRep>>,
         Vec<(TypedPattern<TypeRep>, TypedDecoderExt<TypeRep>)>,
     ),
     Dynamic(
@@ -97,16 +125,24 @@ pub(crate) enum TypedDecoder<TypeRep> {
         Box<TypedDecoderExt<TypeRep>>,
     ),
     Apply(TypeRep, Label),
-    Maybe(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
+    Maybe(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
     Pos,
     ForEach(
         TypeRep,
-        TypedExpr<TypeRep>,
+        Box<TypedExpr<TypeRep>>,
         Label,
         Box<TypedDecoderExt<TypeRep>>,
     ),
     SkipRemainder,
-    DecodeBytes(TypeRep, TypedExpr<TypeRep>, Box<TypedDecoderExt<TypeRep>>),
+    DecodeBytes(
+        TypeRep,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedDecoderExt<TypeRep>>,
+    ),
     LetFormat(
         TypeRep,
         Box<TypedDecoderExt<TypeRep>>,
@@ -370,7 +406,7 @@ impl<'a> GTCompiler<'a> {
                     for count in 0..=max {
                         let f_count = TypedFormat::RepeatCount(
                             gt.clone(),
-                            TypedExpr::U32(count as u32),
+                            Box::new(TypedExpr::U32(count as u32)),
                             a.clone(),
                         );
                         branches.push(f_count.into());

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1652,8 +1652,8 @@ mod tests {
 
     #[test]
     fn compile_alt_slice_byte() {
-        let slice_a = Format::Slice(Box::new(Expr::U8(1)), Box::new(is_byte(0x00)));
-        let slice_b = Format::Slice(Box::new(Expr::U8(1)), Box::new(is_byte(0xFF)));
+        let slice_a = slice(Expr::U8(1), is_byte(0x00));
+        let slice_b = slice(Expr::U8(1), is_byte(0xFF));
         let f = alts([("a", slice_a), ("b", slice_b)]);
         let d = Compiler::compile_one(&f).unwrap();
         accepts(
@@ -1674,8 +1674,8 @@ mod tests {
 
     #[test]
     fn compile_alt_slice_ambiguous1() {
-        let slice_a = Format::Slice(Box::new(Expr::U8(1)), Box::new(is_byte(0x00)));
-        let slice_b = Format::Slice(Box::new(Expr::U8(1)), Box::new(is_byte(0x00)));
+        let slice_a = slice(Expr::U8(1), is_byte(0x00));
+        let slice_b = slice(Expr::U8(1), is_byte(0x00));
         let f = alts([("a", slice_a), ("b", slice_b)]);
         assert!(Compiler::compile_one(&f).is_err());
     }
@@ -1684,8 +1684,8 @@ mod tests {
     fn compile_alt_slice_ambiguous2() {
         let tuple_a = Format::Tuple(vec![is_byte(0x00), is_byte(0x00)]);
         let tuple_b = Format::Tuple(vec![is_byte(0x00), is_byte(0xFF)]);
-        let slice_a = Format::Slice(Box::new(Expr::U8(1)), Box::new(tuple_a));
-        let slice_b = Format::Slice(Box::new(Expr::U8(1)), Box::new(tuple_b));
+        let slice_a = slice(Expr::U8(1), tuple_a);
+        let slice_b = slice(Expr::U8(1), tuple_b);
         let f = alts([("a", slice_a), ("b", slice_b)]);
         assert!(Compiler::compile_one(&f).is_err());
     }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -1264,10 +1264,7 @@ impl Decoder {
                 let bytes = {
                     let raw = bytes.eval_value(scope);
                     let seq_vals = raw.get_sequence().expect("bad type for DecodeBytes input");
-                    seq_vals
-                        .into_iter()
-                        .map(|v| v.get_as_u8())
-                        .collect::<Vec<u8>>()
+                    seq_vals.iter().map(|v| v.get_as_u8()).collect::<Vec<u8>>()
                 };
                 let new_input = ReadCtxt::new(&bytes);
                 let (va, rem_input) = a.parse(program, scope, new_input)?;
@@ -1275,17 +1272,17 @@ impl Decoder {
                 match rem_input.read_byte() {
                     Some((b, _)) => {
                         // FIXME - this error-value doesn't properly distinguish between offsets within the main input or the sub-buffer
-                        return Err(DecodeError::Trailing {
+                        Err(DecodeError::Trailing {
                             byte: b,
                             offset: rem_input.offset,
-                        });
+                        })
                     }
                     None => Ok((va, input)),
                 }
             }
             Decoder::LetFormat(da, name, db) => {
                 let (va, input) = da.parse(program, scope, input)?;
-                let new_scope = Scope::Single(SingleScope::new(scope, &name, &va));
+                let new_scope = Scope::Single(SingleScope::new(scope, name, &va));
                 db.parse(program, &new_scope, input)
             }
             Decoder::ForEach(expr, lbl, a) => {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -628,7 +628,7 @@ pub fn format_some(f: Format) -> Format {
 
 /// Helper for constructing `Option::None` within the Format model-language.
 pub fn format_none() -> Format {
-    Format::Compute(Box::new(expr_none()))
+    compute(expr_none())
 }
 
 /// Shortcut for `where_lambda` applied over the simple predicate [`is_nonzero_u8`]
@@ -813,4 +813,16 @@ where
 /// corresponding to `f` applied to the `Some(_)` case, or dft if `x` is `None`.
 pub fn expr_option_map_or(dft: Expr, f: impl FnOnce(Expr) -> Expr, x: Expr) -> Expr {
     expr_match(x, [(pat_some(bind("x")), f(var("x"))), (pat_none(), dft)])
+}
+
+/// Helper function for [`Format::Compute`].
+#[inline]
+pub fn compute(expr: Expr) -> Format {
+    Format::Compute(Box::new(expr))
+}
+
+/// Helper function for [`Format::Slice`]
+#[inline]
+pub fn slice(len: Expr, inner: Format) -> Format {
+    Format::Slice(Box::new(len), Box::new(inner))
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -22,7 +22,7 @@ pub fn packed_bits_u8<const N: usize>(
     field_bit_lengths: [u8; N],
     field_names: [&'static str; N],
 ) -> Format {
-    const BINDING_NAME: &'static str = "packedbits";
+    const BINDING_NAME: &str = "packedbits";
     let _totlen: u8 = field_bit_lengths.iter().sum();
     assert_eq!(
         _totlen, 8,
@@ -73,7 +73,7 @@ pub fn packed_bits_u16<const N: usize>(
     field_bit_lengths: [u8; N],
     field_names: [&'static str; N],
 ) -> Format {
-    const BINDING_NAME: &'static str = "packedbits";
+    const BINDING_NAME: &str = "packedbits";
     let _totlen: u8 = field_bit_lengths.iter().sum();
     assert_eq!(
         _totlen, 16,
@@ -146,7 +146,7 @@ pub fn alts<Name: IntoLabel>(branches: impl IntoIterator<Item = (Name, Format)>)
 
 /// Helper-function for [`Expr::Match`] that accepts any iterable container `branches` of `(Pattern, Expr)` pairs.
 pub fn expr_match(head: Expr, branches: impl IntoIterator<Item = (Pattern, Expr)>) -> Expr {
-    Expr::Match(Box::new(head), Vec::from_iter(branches.into_iter()))
+    Expr::Match(Box::new(head), Vec::from_iter(branches))
 }
 
 /// Helper-function for [`Format::Match`] where the body of every branch is a
@@ -183,7 +183,7 @@ pub fn match_variant<Name: IntoLabel>(
 ///
 /// If the given branches cannot be deterministically distinguished within a fixed finite lookahead, use [`union_nondet`] instead.
 pub fn union(branches: impl IntoIterator<Item = Format>) -> Format {
-    Format::Union(Vec::from_iter(branches.into_iter()))
+    Format::Union(Vec::from_iter(branches))
 }
 
 /// Helper-function for constructing a [`Format::Union`] over branches that cannot be deterministically distinguished within a fixed finite lookahead.
@@ -383,7 +383,7 @@ pub fn record_proj(head: Expr, label: impl IntoLabel) -> Expr {
 /// Otherwise, will return `(((head->label0)->label1)->...)->labelN`.
 pub fn record_projs(head: Expr, labels: &[&'static str]) -> Expr {
     if labels.is_empty() {
-        return head;
+        head
     } else {
         record_projs(record_proj(head, labels[0]), &labels[1..])
     }
@@ -659,7 +659,7 @@ pub fn chain(f0: Format, name: impl IntoLabel, f: Format) -> Format {
 
 /// Shortcut for matching an explicit pattern of bytes wrapped in a sequence.
 pub fn pattern_bytestring(bytes: &[u8]) -> Pattern {
-    Pattern::Seq(bytes.into_iter().map(|b| Pattern::U8(*b)).collect())
+    Pattern::Seq(bytes.iter().map(|b| Pattern::U8(*b)).collect())
 }
 
 /// Helper for the identity function as an Expr::Lambda

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2314,10 +2314,10 @@ mod test {
                 Label::Borrowed("x"),
                 Box::new(Expr::Var(Label::Borrowed("y"))),
                 Box::new(Format::Record(vec![
-                    (Label::Borrowed("y"), Format::Compute(Box::new(Expr::U8(5)))),
+                    (Label::Borrowed("y"), compute(Expr::U8(5))),
                     (
                         Label::Borrowed("z"),
-                        Format::Compute(Box::new(Expr::Var(Label::Borrowed("x")))),
+                        compute(Expr::Var(Label::Borrowed("x"))),
                     ),
                 ])),
             )),

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -1427,7 +1427,7 @@ impl Decoder {
                 let (v, input) = d.parse_with_loc(program, scope, input)?;
                 match expr.eval_lambda_with_loc(scope, &v).unwrap_bool() {
                     true => Ok((v, input)),
-                    false => Err(DecodeError::loc_bad_where(scope, expr.clone(), v)),
+                    false => Err(DecodeError::loc_bad_where(scope, *expr.clone(), v)),
                 }
             }
             Decoder::Compute(expr) => {
@@ -1516,7 +1516,10 @@ fn make_huffman_codes(lengths: &[usize]) -> Format {
         if len != 0 {
             codes.push(Format::Map(
                 Box::new(bit_range(len, next_code[len])),
-                Expr::Lambda("_".into(), Box::new(Expr::U16(n.try_into().unwrap()))),
+                Box::new(Expr::Lambda(
+                    "_".into(),
+                    Box::new(Expr::U16(n.try_into().unwrap())),
+                )),
             ));
             //println!("{:?}", codes[codes.len()-1]);
             next_code[len] += 1;

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -304,7 +304,7 @@ impl<'module, W: io::Write> Context<'module, W> {
                 Value::Branch(index, value) => {
                     let (_pattern, format) = &branches[*index];
                     self.write_flat(value, format)?;
-                    return Ok(());
+                    Ok(())
                 }
                 _ => panic!("expected branch, found {value:?}"),
             },

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1669,7 +1669,7 @@ impl<'module> MonoidalPrinter<'module> {
             }
             Format::RepeatBetween(min, max, format) => {
                 let expr_frag = self.compile_expr(
-                    &Expr::Tuple(vec![min.clone(), max.clone()]),
+                    &Expr::Tuple(vec![*min.clone(), *max.clone()]),
                     Precedence::ATOM,
                 );
                 cond_paren(

--- a/src/parser/offset.rs
+++ b/src/parser/offset.rs
@@ -57,9 +57,9 @@ impl ByteOffset {
     }
 
     pub(crate) fn increment_by(&self, delta: usize) -> Self {
-        match self {
-            &ByteOffset::Bytes(n_bytes) => Self::Bytes(n_bytes + delta),
-            &ByteOffset::Bits {
+        match *self {
+            ByteOffset::Bytes(n_bytes) => Self::Bytes(n_bytes + delta),
+            ByteOffset::Bits {
                 starting_byte,
                 bits_advanced,
             } => Self::Bits {
@@ -117,9 +117,9 @@ impl ByteOffset {
     }
 
     pub(crate) fn abs_bit_offset(&self) -> usize {
-        match self {
-            &ByteOffset::Bytes(n) => n * 8,
-            &ByteOffset::Bits {
+        match *self {
+            ByteOffset::Bytes(n) => n * 8,
+            ByteOffset::Bits {
                 starting_byte,
                 bits_advanced,
             } => starting_byte * 8 + bits_advanced,
@@ -134,9 +134,9 @@ impl ByteOffset {
     }
 
     pub(crate) fn as_bytes(&self) -> (usize, Option<usize>) {
-        match self {
-            &ByteOffset::Bytes(n) => (n, None),
-            &ByteOffset::Bits {
+        match *self {
+            ByteOffset::Bytes(n) => (n, None),
+            ByteOffset::Bits {
                 starting_byte,
                 bits_advanced,
             } => {

--- a/src/valuetype.rs
+++ b/src/valuetype.rs
@@ -159,12 +159,18 @@ impl ValueType {
     }
 }
 
+/// Alias to reduce the number of code-sites we need to update if we pick a different Smart-Pointer type
+/// as the backer of `TypeHint`
+type Container<T> = std::rc::Rc<T>; // Box<T>;
+
 #[repr(transparent)]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub struct TypeHint(std::rc::Rc<ValueType>);
+pub struct TypeHint(
+    Container<ValueType>
+);
 
 impl TypeHint {
-    pub fn into_inner(&self) -> &std::rc::Rc<ValueType> {
+    pub fn into_inner(&self) -> &Container<ValueType> {
         &self.0
     }
 }
@@ -186,6 +192,6 @@ impl Serialize for TypeHint {
 
 impl From<ValueType> for TypeHint {
     fn from(t: ValueType) -> Self {
-        Self(std::rc::Rc::new(t))
+        Self(Container::new(t))
     }
 }

--- a/src/valuetype.rs
+++ b/src/valuetype.rs
@@ -1,0 +1,191 @@
+use crate::typecheck::UnificationError;
+use anyhow::{anyhow, Result as AResult};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashSet};
+
+use super::Label;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Hash, PartialOrd, Ord)]
+pub enum BaseType {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    Char,
+}
+
+impl BaseType {
+    pub(crate) fn is_numeric(&self) -> bool {
+        matches!(self, Self::U8 | Self::U16 | Self::U32 | Self::U64)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize)]
+pub enum ValueType {
+    Any,
+    Empty,
+    Base(BaseType),
+    Tuple(Vec<ValueType>),
+    Record(Vec<(Label, ValueType)>),
+    Union(BTreeMap<Label, ValueType>),
+    Seq(Box<ValueType>),
+    Option(Box<ValueType>),
+}
+
+impl From<BaseType> for ValueType {
+    fn from(b: BaseType) -> Self {
+        ValueType::Base(b)
+    }
+}
+
+impl ValueType {
+    pub const BOOL: Self = ValueType::Base(BaseType::Bool);
+
+    // NOTE - should be updated if we ever add new integer types
+    /// Alias for the widest (unsigned) integer type we support as a ValueType
+    pub const UMAX: Self = ValueType::Base(BaseType::U64);
+}
+
+impl ValueType {
+    pub const UNIT: ValueType = ValueType::Tuple(Vec::new());
+
+    pub(crate) fn record_proj(&self, label: &str) -> ValueType {
+        match self {
+            ValueType::Record(fields) => match fields.iter().find(|(l, _)| label == l) {
+                Some((_, t)) => t.clone(),
+                None => panic!("{label} not found in record type"),
+            },
+            _ => panic!("expected record type"),
+        }
+    }
+
+    pub(crate) fn unwrap_tuple_type(self) -> AResult<Vec<ValueType>> {
+        match self {
+            ValueType::Tuple(ts) => Ok(ts),
+            t => Err(anyhow!("type is not a tuple: {t:?}")),
+        }
+    }
+
+    pub(crate) fn as_tuple_type(&self) -> &[ValueType] {
+        match self {
+            ValueType::Tuple(ts) => ts.as_slice(),
+            other => panic!("type is not a tuple: {other:?}"),
+        }
+    }
+
+    pub fn is_equivalent(&self, other: &ValueType) -> Result<(), UnificationError<ValueType>> {
+        self.unify(other)?;
+        Ok(())
+    }
+
+    pub(crate) fn unify(
+        &self,
+        other: &ValueType,
+    ) -> Result<ValueType, UnificationError<ValueType>> {
+        match (self, other) {
+            (ValueType::Empty, ValueType::Empty) => Ok(ValueType::Empty),
+
+            // NOTE - we have to specify these patterns before the similar cases for Empty because we want (Empty, Any) in either order to yield Empty
+            (ValueType::Any, rhs) => Ok(rhs.clone()),
+            (lhs, ValueType::Any) => Ok(lhs.clone()),
+
+            (ValueType::Empty, rhs) => Ok(rhs.clone()),
+            (lhs, ValueType::Empty) => Ok(lhs.clone()),
+
+            (ValueType::Base(b1), ValueType::Base(b2)) => {
+                if b1 == b2 {
+                    Ok(ValueType::Base(*b1))
+                } else {
+                    Err(UnificationError::Unsatisfiable(self.clone(), other.clone()))
+                }
+            }
+            (ValueType::Tuple(ts1), ValueType::Tuple(ts2)) => {
+                if ts1.len() != ts2.len() {
+                    // tuple arity mismatch
+                    return Err(UnificationError::Unsatisfiable(self.clone(), other.clone()));
+                }
+                let mut ts = Vec::new();
+                for (t1, t2) in Iterator::zip(ts1.iter(), ts2.iter()) {
+                    ts.push(t1.unify(t2)?);
+                }
+                Ok(ValueType::Tuple(ts))
+            }
+            (ValueType::Record(fs1), ValueType::Record(fs2)) => {
+                if fs1.len() != fs2.len() {
+                    // field count mismatch
+                    return Err(UnificationError::Unsatisfiable(self.clone(), other.clone()));
+                }
+                // NOTE - because fields are parsed in declared order, two records with conflicting field orders are not operationally equivalent
+                let mut fs = Vec::new();
+                for ((l1, t1), (l2, t2)) in Iterator::zip(fs1.iter(), fs2.iter()) {
+                    if l1 != l2 {
+                        // field label mismatch
+                        return Err(UnificationError::Unsatisfiable(self.clone(), other.clone()));
+                    }
+                    fs.push((l1.clone(), t1.unify(t2)?));
+                }
+                Ok(ValueType::Record(fs))
+            }
+            (ValueType::Union(bs1), ValueType::Union(bs2)) => {
+                let mut bs: BTreeMap<Label, ValueType> = BTreeMap::new();
+
+                let keys1 = bs1.keys().collect::<HashSet<_>>();
+                let keys2 = bs2.keys().collect::<HashSet<_>>();
+
+                let keys_common = HashSet::union(&keys1, &keys2).cloned();
+
+                for key in keys_common.into_iter() {
+                    match (bs1.get(key), bs2.get(key)) {
+                        (Some(t1), Some(t2)) => {
+                            let t = t1.unify(t2)?;
+                            bs.insert(key.clone(), t);
+                        }
+                        (Some(t), None) | (None, Some(t)) => {
+                            bs.insert(key.clone(), t.clone());
+                        }
+                        (None, None) => unreachable!("key must appear in at least one operand"),
+                    }
+                }
+
+                Ok(ValueType::Union(bs))
+            }
+            (ValueType::Seq(t1), ValueType::Seq(t2)) => Ok(ValueType::Seq(Box::new(t1.unify(t2)?))),
+            (ValueType::Option(t1), ValueType::Option(t2)) => {
+                Ok(ValueType::Option(Box::new(t1.unify(t2)?)))
+            }
+            (t1, t2) => Err(UnificationError::Unsatisfiable(t1.clone(), t2.clone())),
+        }
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TypeHint(std::rc::Rc<ValueType>);
+
+impl TypeHint {
+    pub fn into_inner(&self) -> &std::rc::Rc<ValueType> {
+        &self.0
+    }
+}
+
+impl AsRef<ValueType> for TypeHint {
+    fn as_ref(&self) -> &ValueType {
+        self.0.as_ref()
+    }
+}
+
+impl Serialize for TypeHint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl From<ValueType> for TypeHint {
+    fn from(t: ValueType) -> Self {
+        Self(std::rc::Rc::new(t))
+    }
+}


### PR DESCRIPTION
Significantly reduces the stack footprint of owned values of type Format, Expr by using smart-pointer indirection for their largest arguments (ValueType for Expr, Expr for Format)