### PR TITLE
Implementation of Expr::FindByKey

### DIFF
--- a/doodle-formats/src/format/deflate.rs
+++ b/doodle-formats/src/format/deflate.rs
@@ -413,7 +413,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                     vec![
                                         (
                                             Pattern::U16(257),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 3,
                                                 base,
                                                 0,
@@ -422,7 +422,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(258),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 4,
                                                 base,
                                                 0,
@@ -431,7 +431,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(259),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 5,
                                                 base,
                                                 0,
@@ -440,7 +440,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(260),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 6,
                                                 base,
                                                 0,
@@ -449,7 +449,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(261),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 7,
                                                 base,
                                                 0,
@@ -458,7 +458,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(262),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 8,
                                                 base,
                                                 0,
@@ -467,7 +467,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(263),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 9,
                                                 base,
                                                 0,
@@ -476,7 +476,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(264),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 10,
                                                 base,
                                                 0,
@@ -485,7 +485,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(265),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 11,
                                                 base,
                                                 1,
@@ -494,7 +494,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(266),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 13,
                                                 base,
                                                 1,
@@ -503,7 +503,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(267),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 15,
                                                 base,
                                                 1,
@@ -512,7 +512,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(268),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 17,
                                                 base,
                                                 1,
@@ -521,7 +521,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(269),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 19,
                                                 base,
                                                 2,
@@ -530,7 +530,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(270),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 23,
                                                 base,
                                                 2,
@@ -539,7 +539,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(271),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 27,
                                                 base,
                                                 2,
@@ -548,7 +548,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(272),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 31,
                                                 base,
                                                 2,
@@ -557,7 +557,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(273),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 35,
                                                 base,
                                                 3,
@@ -566,7 +566,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(274),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 43,
                                                 base,
                                                 3,
@@ -575,7 +575,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(275),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 51,
                                                 base,
                                                 3,
@@ -584,7 +584,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(276),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 59,
                                                 base,
                                                 3,
@@ -593,7 +593,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(277),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 67,
                                                 base,
                                                 4,
@@ -602,7 +602,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(278),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 83,
                                                 base,
                                                 4,
@@ -611,7 +611,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(279),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 99,
                                                 base,
                                                 4,
@@ -620,7 +620,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(280),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 115,
                                                 base,
                                                 4,
@@ -629,7 +629,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(281),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 131,
                                                 base,
                                                 5,
@@ -638,7 +638,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(282),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 163,
                                                 base,
                                                 5,
@@ -647,7 +647,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(283),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 195,
                                                 base,
                                                 5,
@@ -656,7 +656,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(284),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 227,
                                                 base,
                                                 5,
@@ -665,7 +665,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         ),
                                         (
                                             Pattern::U16(285),
-                                            format_some(length_record_fixed(
+                                            fmt_some(length_record_fixed(
                                                 258,
                                                 base,
                                                 0,
@@ -673,8 +673,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             )),
                                         ),
                                         // REVIEW - consider whether we want to use Format::Fail instead
-                                        (Pattern::Int(Bounds::new(286, 287)), format_none()),
-                                        (Pattern::Wildcard, format_none()),
+                                        (Pattern::Int(Bounds::new(286, 287)), fmt_none()),
+                                        (Pattern::Wildcard, fmt_none()),
                                     ],
                                 ),
                             ),
@@ -946,7 +946,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                         vec![
                                             (
                                                 Pattern::U16(257),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     3,
                                                     base,
                                                     0,
@@ -955,7 +955,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(258),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     4,
                                                     base,
                                                     0,
@@ -964,7 +964,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(259),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     5,
                                                     base,
                                                     0,
@@ -973,7 +973,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(260),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     6,
                                                     base,
                                                     0,
@@ -982,7 +982,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(261),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     7,
                                                     base,
                                                     0,
@@ -991,7 +991,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(262),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     8,
                                                     base,
                                                     0,
@@ -1000,7 +1000,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(263),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     9,
                                                     base,
                                                     0,
@@ -1009,7 +1009,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(264),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     10,
                                                     base,
                                                     0,
@@ -1018,7 +1018,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(265),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     11,
                                                     base,
                                                     1,
@@ -1027,7 +1027,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(266),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     13,
                                                     base,
                                                     1,
@@ -1036,7 +1036,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(267),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     15,
                                                     base,
                                                     1,
@@ -1045,7 +1045,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(268),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     17,
                                                     base,
                                                     1,
@@ -1054,7 +1054,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(269),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     19,
                                                     base,
                                                     2,
@@ -1063,7 +1063,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(270),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     23,
                                                     base,
                                                     2,
@@ -1072,7 +1072,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(271),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     27,
                                                     base,
                                                     2,
@@ -1081,7 +1081,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(272),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     31,
                                                     base,
                                                     2,
@@ -1090,7 +1090,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(273),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     35,
                                                     base,
                                                     3,
@@ -1099,7 +1099,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(274),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     43,
                                                     base,
                                                     3,
@@ -1108,7 +1108,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(275),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     51,
                                                     base,
                                                     3,
@@ -1117,7 +1117,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(276),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     59,
                                                     base,
                                                     3,
@@ -1126,7 +1126,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(277),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     67,
                                                     base,
                                                     4,
@@ -1135,7 +1135,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(278),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     83,
                                                     base,
                                                     4,
@@ -1144,7 +1144,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(279),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     99,
                                                     base,
                                                     4,
@@ -1153,7 +1153,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(280),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     115,
                                                     base,
                                                     4,
@@ -1162,7 +1162,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(281),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     131,
                                                     base,
                                                     5,
@@ -1171,7 +1171,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(282),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     163,
                                                     base,
                                                     5,
@@ -1180,7 +1180,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(283),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     195,
                                                     base,
                                                     5,
@@ -1189,7 +1189,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(284),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     227,
                                                     base,
                                                     5,
@@ -1198,7 +1198,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                             ),
                                             (
                                                 Pattern::U16(285),
-                                                format_some(length_record(
+                                                fmt_some(length_record(
                                                     258,
                                                     base,
                                                     0,
@@ -1206,8 +1206,8 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                                 )),
                                             ),
                                             // NOTE - currently no difference in behavior compared to wildcard pattern, but adds specificity/clarity, and gives us an easy hook to treat as erroneous
-                                            (Pattern::Int(Bounds::new(286, 287)), format_none()),
-                                            (Pattern::Wildcard, format_none()),
+                                            (Pattern::Int(Bounds::new(286, 287)), fmt_none()),
+                                            (Pattern::Wildcard, fmt_none()),
                                         ],
                                     ),
                                 ),

--- a/doodle-formats/src/format/elf.rs
+++ b/doodle-formats/src/format/elf.rs
@@ -676,7 +676,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                     vec![
                         (
                             pat_some(Pattern::binding("shdrs")),
-                            format_some(for_each(
+                            fmt_some(for_each(
                                 var("shdrs"),
                                 "shdr",
                                 cond_maybe(
@@ -701,7 +701,7 @@ pub fn main(module: &mut FormatModule, base: &BaseModule) -> FormatRef {
                                 ),
                             )),
                         ),
-                        (pat_none(), format_none()),
+                        (pat_none(), fmt_none()),
                     ],
                 ),
             ),

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -408,8 +408,9 @@ fn with_table(
     query_table_id: u32,
     dep_format: impl FnOnce(Expr) -> Format,
 ) -> Format {
-    // REVIEW - we assume by default that all OpenType table-directories are sorted by id
-    const TABLE_RECORDS_ARE_SORTED: bool = true;
+    // Not all fonts are actually sorted: https://github.com/harfbuzz/harfbuzz/issues/3065
+    // NOTE - while technically, we could refactor to make the sortedness a runtime-dependant parameter and check (once) whether the directory is sorted, this may yield only marginal benefits
+    const TABLE_RECORDS_ARE_SORTED: bool = false;
     let f_get_table_id = |table_record: Expr| record_proj(table_record, "table_id");
     let opt_match = find_by_key(
         TABLE_RECORDS_ARE_SORTED,

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -327,7 +327,7 @@ distance: u16
 }
 
 #[derive(Debug, Clone)]
-pub enum deflate_main_codes { literal(u8), reference(deflate_main_codes_reference) }
+pub enum deflate_main_codes__dupX1 { literal(u8), reference(deflate_main_codes_reference) }
 
 #[derive(Debug, Clone)]
 pub struct deflate_dynamic_huffman {
@@ -340,7 +340,7 @@ literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
 literal_length_alphabet_code_lengths_value: Vec<u8>,
 distance_alphabet_code_lengths_value: Vec<u8>,
 codes: Vec<deflate_dynamic_huffman_codes>,
-codes_values: Vec<deflate_main_codes>
+codes_values: Vec<deflate_main_codes__dupX1>
 }
 
 #[derive(Debug, Clone)]
@@ -360,7 +360,7 @@ extra: Option<deflate_fixed_huffman_codes_values>
 #[derive(Debug, Clone)]
 pub struct deflate_fixed_huffman {
 codes: Vec<deflate_fixed_huffman_codes>,
-codes_values: Vec<deflate_main_codes>
+codes_values: Vec<deflate_main_codes__dupX1>
 }
 
 #[derive(Debug, Clone)]
@@ -369,23 +369,23 @@ align: (),
 len: u16,
 nlen: u16,
 bytes: Vec<u8>,
-codes_values: Vec<deflate_main_codes>
+codes_values: Vec<deflate_main_codes__dupX1>
 }
 
 #[derive(Debug, Clone)]
-pub enum deflate_main_codes__dupX1 { dynamic_huffman(deflate_dynamic_huffman), fixed_huffman(deflate_fixed_huffman), uncompressed(deflate_uncompressed) }
+pub enum deflate_main_codes { dynamic_huffman(deflate_dynamic_huffman), fixed_huffman(deflate_fixed_huffman), uncompressed(deflate_uncompressed) }
 
 #[derive(Debug, Clone)]
 pub struct deflate_block {
 r#final: u8,
 r#type: u8,
-data: deflate_main_codes__dupX1
+data: deflate_main_codes
 }
 
 #[derive(Debug, Clone)]
 pub struct deflate_main {
 blocks: Vec<deflate_block>,
-codes: Vec<deflate_main_codes>,
+codes: Vec<deflate_main_codes__dupX1>,
 inflate: Vec<u8>
 }
 
@@ -4505,7 +4505,7 @@ return Err(ParseError::ExcludedBranch(658824046370133753u64));
 }))())?;
 let length = ((|| PResult::Ok((Decoder127(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_riff_subchunks(_input))?))())?;
 _input.end_slice()?;
@@ -5483,7 +5483,7 @@ accum.push((Decoder_opentype_table_record(_input))?);
 }
 accum
 }))())?;
-let table_links = ((|| PResult::Ok((Decoder_opentype_table_directory_table_links(_input, font_start.clone(), table_records.clone()))?))())?;
+let table_links = ((|| PResult::Ok((Decoder_opentype_table_directory_table_links(_input, font_start.clone(), &table_records))?))())?;
 PResult::Ok(opentype_table_directory { sfnt_version, num_tables, search_range, entry_selector, range_shift, table_records, table_links })
 }
 
@@ -5601,13 +5601,13 @@ let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
 PResult::Ok(opentype_table_record { table_id, checksum, offset, length })
 }
 
-fn Decoder_opentype_table_directory_table_links<'input>(_input: &mut Parser<'input>, start: u32, tables: Vec<opentype_table_record>) -> Result<opentype_table_directory_table_links, ParseError> {
+fn Decoder_opentype_table_directory_table_links<'input>(_input: &mut Parser<'input>, start: u32, tables: &Vec<opentype_table_record>) -> Result<opentype_table_directory_table_links, ParseError> {
 let cmap = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668112752u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_cmap_table(_input))?))())?;
 _input.end_slice()?;
@@ -5626,7 +5626,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_head_table(_input))?))())?;
 _input.end_slice()?;
@@ -5645,7 +5645,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_hhea_table(_input))?))())?;
 _input.end_slice()?;
@@ -5664,7 +5664,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_maxp_table(_input))?))())?;
 _input.end_slice()?;
@@ -5683,7 +5683,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_hmtx_table(_input, hhea.number_of_long_metrics.clone(), maxp.num_glyphs.clone()))?))())?;
 _input.end_slice()?;
@@ -5702,7 +5702,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_name_table(_input))?))())?;
 _input.end_slice()?;
@@ -5722,7 +5722,7 @@ let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
 let table_len = matching_table.length.clone();
-let sz = table_len as usize<>;
+let sz = table_len as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_os2_table(_input, table_len.clone()))?))())?;
 _input.end_slice()?;
@@ -5741,7 +5741,7 @@ Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let sz = (matching_table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_post_table(_input))?))())?;
 _input.end_slice()?;
@@ -5761,7 +5761,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -5803,7 +5803,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -5845,7 +5845,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_loca_table(_input, maxp.num_glyphs.clone(), head.index_to_loc_format.clone()))?))())?;
 _input.end_slice()?;
@@ -5867,7 +5867,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder36(_input, match loca {
 Some(ref x) => {
@@ -5897,7 +5897,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -5939,7 +5939,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_gasp_table(_input))?))())?;
 _input.end_slice()?;
@@ -5961,7 +5961,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_base_table(_input))?))())?;
 _input.end_slice()?;
@@ -5983,7 +5983,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_gdef_table(_input))?))())?;
 _input.end_slice()?;
@@ -6005,7 +6005,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_gpos_table(_input))?))())?;
 _input.end_slice()?;
@@ -6027,7 +6027,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_gsub_table(_input))?))())?;
 _input.end_slice()?;
@@ -6049,7 +6049,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_fvar_table(_input))?))())?;
 _input.end_slice()?;
@@ -6071,7 +6071,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_gvar_table(_input))?))())?;
 _input.end_slice()?;
@@ -6093,7 +6093,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_kern_table(_input))?))())?;
 _input.end_slice()?;
@@ -6115,7 +6115,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_stat_table(_input))?))())?;
 _input.end_slice()?;
@@ -6137,7 +6137,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_hhea_table(_input))?))())?;
 _input.end_slice()?;
@@ -6159,7 +6159,7 @@ let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (table.length.clone()) as usize<>;
+let sz = (table.length.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_hmtx_table(_input, match vhea {
 Some(ref x) => {
@@ -7964,13 +7964,13 @@ return Err(ParseError::FalsifiedWhere(10603707580403307601u64));
 let tgt_offset = 0u32 + table_start + (__offset_axes as u32);
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = __axes_length as usize<>;
+let sz = __axes_length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
 for _ in 0..axis_count {
 accum.push({
-let sz = axis_size as usize<>;
+let sz = axis_size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_var_variation_axis_record(_input))?))())?;
 _input.end_slice()?;
@@ -8003,7 +8003,7 @@ let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
 for _ in 0..instance_count {
 accum.push({
-let sz = instance_size as usize<>;
+let sz = instance_size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let subfamily_nameid = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8145,7 +8145,7 @@ if next_offs > this_offs {
 let tgt_offset = array_start + this_offs;
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (try_sub!(next_offs, this_offs, 11876854719037224982u64)) as usize<>;
+let sz = (try_sub!(next_offs, this_offs, 11876854719037224982u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_var_glyph_variation_data_table(_input, axis_count.clone()))?))())?;
 _input.end_slice()?;
@@ -8172,7 +8172,7 @@ if next_offs > this_offs {
 let tgt_offset = array_start + this_offs;
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (try_sub!(next_offs, this_offs, 18270091135093349626u64)) as usize<>;
+let sz = (try_sub!(next_offs, this_offs, 18270091135093349626u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_var_glyph_variation_data_table(_input, axis_count.clone()))?))())?;
 _input.end_slice()?;
@@ -9000,7 +9000,7 @@ let per_tuple_variation_data = ((|| PResult::Ok({
 let mut accum = Vec::new();
 for header in tuple_variation_headers.clone() {
 accum.push({
-let sz = (header.variation_data_size.clone()) as usize<>;
+let sz = (header.variation_data_size.clone()) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let private_point_numbers = ((|| PResult::Ok(if header.tuple_index.private_point_numbers.clone() {
@@ -14090,7 +14090,7 @@ opentype_cmap_subtable_format14_raw_raw { format }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -14134,7 +14134,7 @@ return Err(ParseError::FalsifiedWhere(14954891776835932150u64));
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14249,7 +14249,7 @@ opentype_cmap_subtable_format14_raw_raw { format }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14383,7 +14383,7 @@ opentype_cmap_subtable_format13_raw_raw { format, __reserved }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14453,7 +14453,7 @@ opentype_cmap_subtable_format13_raw_raw { format, __reserved }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14517,7 +14517,7 @@ opentype_cmap_subtable_format13_raw_raw { format, __reserved }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14580,7 +14580,7 @@ opentype_cmap_subtable_format13_raw_raw { format, __reserved }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14635,7 +14635,7 @@ opentype_cmap_subtable_format14_raw_raw { format }
 _input.close_peek_context()?;
 ret
 };
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let format = ((|| PResult::Ok({
@@ -14770,7 +14770,7 @@ PResult::Ok(opentype_types_sequential_map_record { start_char_code, end_char_cod
 
 fn Decoder_elf_header<'input>(_input: &mut Parser<'input>) -> Result<elf_header, ParseError> {
 let ident = ((|| PResult::Ok({
-let sz = 16u32 as usize<>;
+let sz = 16u32 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_elf_header_ident(_input))?))())?;
 _input.end_slice()?;
@@ -15235,18 +15235,18 @@ PResult::Ok(tar_header_with_data { header, file, __padding })
 }
 
 fn Decoder_tar_header<'input>(_input: &mut Parser<'input>) -> Result<tar_header, ParseError> {
-let sz = 512u32 as usize<>;
+let sz = 512u32 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let name = ((|| PResult::Ok({
-let sz = 100u16 as usize<>;
+let sz = 100u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_tar_ascii_string_opt0(_input))?))())?;
 _input.end_slice()?;
 ret
 }))())?;
 let mode = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15321,7 +15321,7 @@ _input.end_slice()?;
 ret
 }))())?;
 let uid = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15396,7 +15396,7 @@ _input.end_slice()?;
 ret
 }))())?;
 let gid = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15523,7 +15523,7 @@ tar_header_size_raw { oA, o9, o8, o7, o6, o5, o4, o3, o2, o1, o0, __nil, value }
 ((|rec: tar_header_size_raw| PResult::Ok(rec.value.clone()))(inner))?
 }))())?;
 let mtime = ((|| PResult::Ok({
-let sz = 12u16 as usize<>;
+let sz = 12u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15598,7 +15598,7 @@ _input.end_slice()?;
 ret
 }))())?;
 let chksum = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15674,7 +15674,7 @@ ret
 }))())?;
 let typeflag = ((|| PResult::Ok((Decoder150(_input))?))())?;
 let linkname = ((|| PResult::Ok({
-let sz = 100u16 as usize<>;
+let sz = 100u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder151(_input))?))())?;
 _input.end_slice()?;
@@ -15751,21 +15751,21 @@ return Err(ParseError::ExcludedBranch(5170050512307443704u64));
 (field0, field1)
 }))())?;
 let uname = ((|| PResult::Ok({
-let sz = 32u16 as usize<>;
+let sz = 32u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_tar_ascii_string(_input))?))())?;
 _input.end_slice()?;
 ret
 }))())?;
 let gname = ((|| PResult::Ok({
-let sz = 32u16 as usize<>;
+let sz = 32u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_tar_ascii_string(_input))?))())?;
 _input.end_slice()?;
 ret
 }))())?;
 let devmajor = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15840,7 +15840,7 @@ _input.end_slice()?;
 ret
 }))())?;
 let devminor = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
+let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let string = ((|| PResult::Ok({
@@ -15915,7 +15915,7 @@ _input.end_slice()?;
 ret
 }))())?;
 let prefix = ((|| PResult::Ok({
-let sz = 155u16 as usize<>;
+let sz = 155u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder151(_input))?))())?;
 _input.end_slice()?;
@@ -16238,7 +16238,7 @@ fn Decoder_riff_chunk<'input>(_input: &mut Parser<'input>) -> Result<riff_chunk,
 let tag = ((|| PResult::Ok((Decoder154(_input))?))())?;
 let length = ((|| PResult::Ok((Decoder127(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -16356,7 +16356,7 @@ return Err(ParseError::FalsifiedWhere(14903563845775542749u64));
 }))())?;
 let tag = ((|| PResult::Ok((Decoder203(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_png_ihdr_data(_input))?))())?;
 _input.end_slice()?;
@@ -16400,7 +16400,7 @@ accum.push((Decoder174(_input))?);
 accum
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match tag.as_slice() {
 [80u8, 76u8, 84u8, 69u8] => {
@@ -16521,7 +16521,7 @@ return Err(ParseError::FalsifiedWhere(7281717462557989541u64));
 }))())?;
 let tag = ((|| PResult::Ok((Decoder172(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder173(_input))?))())?;
 _input.end_slice()?;
@@ -16579,7 +16579,7 @@ return Err(ParseError::FalsifiedWhere(14681668243282477517u64));
 }))())?;
 let tag = ((|| PResult::Ok((Decoder162(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = length as usize<>;
+let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder163(_input))?))())?;
 _input.end_slice()?;
@@ -16644,26 +16644,26 @@ accum.push(elem);
 accum
 }))())?;
 let codes = ((|| PResult::Ok((try_flat_map_vec(blocks.iter().cloned(), |x: deflate_block| PResult::Ok(match x.data.clone() {
-deflate_main_codes__dupX1::uncompressed(ref y) => {
+deflate_main_codes::uncompressed(ref y) => {
 y.codes_values.clone()
 },
 
-deflate_main_codes__dupX1::fixed_huffman(ref y) => {
+deflate_main_codes::fixed_huffman(ref y) => {
 y.codes_values.clone()
 },
 
-deflate_main_codes__dupX1::dynamic_huffman(ref y) => {
+deflate_main_codes::dynamic_huffman(ref y) => {
 y.codes_values.clone()
 }
 })))?))())?;
-let inflate = ((|| PResult::Ok((try_flat_map_append_vec(codes.iter().cloned(), |tuple_var: (&Vec<u8>, deflate_main_codes)| PResult::Ok(match tuple_var {
+let inflate = ((|| PResult::Ok((try_flat_map_append_vec(codes.iter().cloned(), |tuple_var: (&Vec<u8>, deflate_main_codes__dupX1)| PResult::Ok(match tuple_var {
 (buffer, symbol) => {
 match symbol {
-deflate_main_codes::literal(b) => {
+deflate_main_codes__dupX1::literal(b) => {
 [b].to_vec()
 },
 
-deflate_main_codes::reference(r) => {
+deflate_main_codes__dupX1::reference(r) => {
 {
 let ix = (try_sub!((buffer.len()) as u32, (r.distance.clone()) as u32, 9851243859021733611u64)) as usize;
 (slice_ext(&buffer, ix..ix + (((r.length.clone()) as u32) as usize))).to_vec()
@@ -16688,17 +16688,17 @@ let field1 = ((|| PResult::Ok((Decoder166(_input))?))())?;
 let data = ((|| PResult::Ok(match r#type {
 0u8 => {
 let inner = (Decoder_deflate_uncompressed(_input))?;
-deflate_main_codes__dupX1::uncompressed(inner)
+deflate_main_codes::uncompressed(inner)
 },
 
 1u8 => {
 let inner = (Decoder_deflate_fixed_huffman(_input))?;
-deflate_main_codes__dupX1::fixed_huffman(inner)
+deflate_main_codes::fixed_huffman(inner)
 },
 
 2u8 => {
 let inner = (Decoder_deflate_dynamic_huffman(_input))?;
-deflate_main_codes__dupX1::dynamic_huffman(inner)
+deflate_main_codes::dynamic_huffman(inner)
 },
 
 _other => {
@@ -16779,7 +16779,7 @@ let field7 = ((|| PResult::Ok((Decoder166(_input))?))())?;
 }
 accum
 }))())?;
-let codes_values = ((|| PResult::Ok((try_flat_map_vec(bytes.iter().cloned(), |x: u8| PResult::Ok([deflate_main_codes::literal(x)].to_vec())))?))())?;
+let codes_values = ((|| PResult::Ok((try_flat_map_vec(bytes.iter().cloned(), |x: u8| PResult::Ok([deflate_main_codes__dupX1::literal(x)].to_vec())))?))())?;
 PResult::Ok(deflate_uncompressed { align, len, nlen, bytes, codes_values })
 }
 
@@ -17558,7 +17558,7 @@ let codes_values = ((|| PResult::Ok((try_flat_map_vec(codes.iter().cloned(), |x:
 257u16..=285u16 => {
 match x.extra.clone() {
 Some(ref rec) => {
-[deflate_main_codes::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
+[deflate_main_codes__dupX1::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
 },
 
 _ => {
@@ -17572,7 +17572,7 @@ return Err(ParseError::ExcludedBranch(5357406925723651718u64));
 },
 
 _ => {
-[deflate_main_codes::literal((x.code.clone()) as u8)].to_vec()
+[deflate_main_codes__dupX1::literal((x.code.clone()) as u8)].to_vec()
 }
 })))?))())?;
 PResult::Ok(deflate_fixed_huffman { codes, codes_values })
@@ -18258,7 +18258,7 @@ let codes_values = ((|| PResult::Ok((try_flat_map_vec(codes.iter().cloned(), |x:
 257u16..=285u16 => {
 match x.extra.clone() {
 Some(ref rec) => {
-[deflate_main_codes::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
+[deflate_main_codes__dupX1::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
 },
 
 _ => {
@@ -18272,7 +18272,7 @@ return Err(ParseError::ExcludedBranch(3673300442962989464u64));
 },
 
 _ => {
-[deflate_main_codes::literal((x.code.clone()) as u8)].to_vec()
+[deflate_main_codes__dupX1::literal((x.code.clone()) as u8)].to_vec()
 }
 })))?))())?;
 PResult::Ok(deflate_dynamic_huffman { hlit, hdist, hclen, code_length_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths_value, literal_length_alphabet_code_lengths_value, distance_alphabet_code_lengths_value, codes, codes_values })
@@ -24981,7 +24981,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (102u8, 116u8, 121u8, 112u8) => {
@@ -25130,7 +25130,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (100u8, 105u8, 110u8, 102u8) => {
@@ -25279,7 +25279,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let from_item_ID = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -25340,7 +25340,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let from_item_ID = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -25622,7 +25622,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (109u8, 118u8, 104u8, 100u8) => {
@@ -25788,7 +25788,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (116u8, 107u8, 104u8, 100u8) => {
@@ -25951,7 +25951,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (109u8, 101u8, 116u8, 97u8) => {
@@ -26029,7 +26029,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (101u8, 108u8, 115u8, 116u8) => {
@@ -26108,7 +26108,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (104u8, 100u8, 108u8, 114u8) => {
@@ -26300,7 +26300,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (118u8, 109u8, 104u8, 100u8) => {
@@ -26440,7 +26440,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (100u8, 114u8, 101u8, 102u8) => {
@@ -26484,7 +26484,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -26573,7 +26573,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (115u8, 116u8, 115u8, 100u8) => {
@@ -26607,7 +26607,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -26936,7 +26936,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (105u8, 110u8, 102u8, 101u8) => {
@@ -27056,7 +27056,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (169u8, 116u8, 111u8, 111u8) => {
@@ -27133,7 +27133,7 @@ _ => {
 }
 }))())?;
 let data = ((|| PResult::Ok({
-let sz = size as usize<>;
+let sz = size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok(match r#type {
 (100u8, 97u8, 116u8, 97u8) => {
@@ -27986,7 +27986,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 6569230515699692699u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 6569230515699692699u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_app0_data(_input))?))())?;
 _input.end_slice()?;
@@ -28017,7 +28017,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15682767706885925172u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15682767706885925172u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_app1_data(_input))?))())?;
 _input.end_slice()?;
@@ -28530,7 +28530,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 2946338368865429585u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 2946338368865429585u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dnl_data(_input))?))())?;
 _input.end_slice()?;
@@ -28685,7 +28685,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 466150863659326234u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 466150863659326234u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sos_data(_input))?))())?;
 _input.end_slice()?;
@@ -29654,7 +29654,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 11988854374464943326u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 11988854374464943326u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29685,7 +29685,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 7620281735474506525u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7620281735474506525u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29716,7 +29716,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 11599300513837427027u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 11599300513837427027u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29747,7 +29747,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 950046280632689001u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 950046280632689001u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29778,7 +29778,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5625702265340316943u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5625702265340316943u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29809,7 +29809,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 4260205764162136487u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 4260205764162136487u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29840,7 +29840,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5712308626808297759u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5712308626808297759u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29871,7 +29871,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 8638089167112501923u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 8638089167112501923u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29902,7 +29902,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1453530207670075215u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1453530207670075215u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29933,7 +29933,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15915510438164744429u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15915510438164744429u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29964,7 +29964,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1542992798780655146u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1542992798780655146u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29995,7 +29995,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 7028560493922100069u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7028560493922100069u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30026,7 +30026,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 2649783168072194737u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 2649783168072194737u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30113,7 +30113,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 8253205784254894771u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 8253205784254894771u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30168,7 +30168,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1225514472166157741u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1225514472166157741u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dht_data(_input))?))())?;
 _input.end_slice()?;
@@ -30199,7 +30199,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1224415506115142500u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1224415506115142500u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dac_data(_input))?))())?;
 _input.end_slice()?;
@@ -30230,7 +30230,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 16859485491091215361u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 16859485491091215361u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dri_data(_input))?))())?;
 _input.end_slice()?;
@@ -30261,7 +30261,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 14898840355839773829u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 14898840355839773829u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30312,7 +30312,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 9453951600195794313u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 9453951600195794313u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30363,7 +30363,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10036157788440812915u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10036157788440812915u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30414,7 +30414,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 6349531732377484771u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 6349531732377484771u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30465,7 +30465,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 13785646910930464515u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 13785646910930464515u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30516,7 +30516,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5323644471994966730u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5323644471994966730u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30567,7 +30567,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 13278122992382147879u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 13278122992382147879u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30618,7 +30618,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 18159646757349796721u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 18159646757349796721u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30669,7 +30669,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 7124606020426797957u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7124606020426797957u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30720,7 +30720,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15116592996336247086u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15116592996336247086u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30771,7 +30771,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10346499338674982396u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10346499338674982396u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30822,7 +30822,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10951432197815892834u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10951432197815892834u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30873,7 +30873,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 14864597187136898256u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 14864597187136898256u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30924,7 +30924,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15238960955167157760u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15238960955167157760u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30975,7 +30975,7 @@ jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 17527274083228188873u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 17527274083228188873u64)) as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31419,7 +31419,7 @@ PResult::Ok(gzip_header { magic, method, file_flags, timestamp, compression_flag
 fn Decoder_gzip_fextra<'input>(_input: &mut Parser<'input>) -> Result<gzip_fextra, ParseError> {
 let xlen = ((|| PResult::Ok((Decoder139(_input))?))())?;
 let subfields = ((|| PResult::Ok({
-let sz = xlen as usize<>;
+let sz = xlen as usize;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -327,7 +327,7 @@ distance: u16
 }
 
 #[derive(Debug, Clone)]
-pub enum deflate_main_codes__dupX1 { literal(u8), reference(deflate_main_codes_reference) }
+pub enum deflate_main_codes { literal(u8), reference(deflate_main_codes_reference) }
 
 #[derive(Debug, Clone)]
 pub struct deflate_dynamic_huffman {
@@ -340,7 +340,7 @@ literal_length_distance_alphabet_code_lengths_value: Vec<u8>,
 literal_length_alphabet_code_lengths_value: Vec<u8>,
 distance_alphabet_code_lengths_value: Vec<u8>,
 codes: Vec<deflate_dynamic_huffman_codes>,
-codes_values: Vec<deflate_main_codes__dupX1>
+codes_values: Vec<deflate_main_codes>
 }
 
 #[derive(Debug, Clone)]
@@ -360,7 +360,7 @@ extra: Option<deflate_fixed_huffman_codes_values>
 #[derive(Debug, Clone)]
 pub struct deflate_fixed_huffman {
 codes: Vec<deflate_fixed_huffman_codes>,
-codes_values: Vec<deflate_main_codes__dupX1>
+codes_values: Vec<deflate_main_codes>
 }
 
 #[derive(Debug, Clone)]
@@ -369,23 +369,23 @@ align: (),
 len: u16,
 nlen: u16,
 bytes: Vec<u8>,
-codes_values: Vec<deflate_main_codes__dupX1>
+codes_values: Vec<deflate_main_codes>
 }
 
 #[derive(Debug, Clone)]
-pub enum deflate_main_codes { dynamic_huffman(deflate_dynamic_huffman), fixed_huffman(deflate_fixed_huffman), uncompressed(deflate_uncompressed) }
+pub enum deflate_main_codes__dupX1 { dynamic_huffman(deflate_dynamic_huffman), fixed_huffman(deflate_fixed_huffman), uncompressed(deflate_uncompressed) }
 
 #[derive(Debug, Clone)]
 pub struct deflate_block {
 r#final: u8,
 r#type: u8,
-data: deflate_main_codes
+data: deflate_main_codes__dupX1
 }
 
 #[derive(Debug, Clone)]
 pub struct deflate_main {
 blocks: Vec<deflate_block>,
-codes: Vec<deflate_main_codes__dupX1>,
+codes: Vec<deflate_main_codes>,
 inflate: Vec<u8>
 }
 
@@ -4042,7 +4042,7 @@ let ret = match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6223008304848233301u64));
+return Err(ParseError::ExcludedBranch(11054356281452530428u64));
 }
 };
 _input.close_peek_context()?;
@@ -4055,7 +4055,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11460567998186064482u64));
+return Err(ParseError::ExcludedBranch(17855530393917176367u64));
 }
 };
 accum.push(next_elem);
@@ -4070,7 +4070,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14550754927305275517u64));
+return Err(ParseError::ExcludedBranch(17406968167054271466u64));
 }
 }))())?;
 let here = ((|| PResult::Ok(_input.get_offset_u64()))())?;
@@ -4083,7 +4083,7 @@ let b = _input.read_byte()?;
 if b == 87 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10197098993763395417u64));
+return Err(ParseError::ExcludedBranch(11100042044514704042u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -4091,7 +4091,7 @@ let b = _input.read_byte()?;
 if b == 97 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15631554783732883240u64));
+return Err(ParseError::ExcludedBranch(5409189036752851054u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -4099,7 +4099,7 @@ let b = _input.read_byte()?;
 if b == 108 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2391834656526534993u64));
+return Err(ParseError::ExcludedBranch(4726315105662630465u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -4107,7 +4107,7 @@ let b = _input.read_byte()?;
 if b == 100 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9422510723961972169u64));
+return Err(ParseError::ExcludedBranch(10036638040555853769u64));
 }
 }))())?;
 let field4 = ((|| PResult::Ok({
@@ -4115,7 +4115,7 @@ let b = _input.read_byte()?;
 if b == 111 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10940017698627680568u64));
+return Err(ParseError::ExcludedBranch(13230337088401352826u64));
 }
 }))())?;
 (field0, field1, field2, field3, field4)
@@ -4144,7 +4144,7 @@ let ret = match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(179268011689651936u64));
+return Err(ParseError::ExcludedBranch(11460567998186064482u64));
 }
 };
 _input.close_peek_context()?;
@@ -4189,7 +4189,7 @@ let ret = match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9665974566873665536u64));
+return Err(ParseError::ExcludedBranch(6223008304848233301u64));
 }
 };
 _input.close_peek_context()?;
@@ -4334,7 +4334,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 1
 } else {
-return Err(ParseError::ExcludedBranch(374064178837027275u64));
+return Err(ParseError::ExcludedBranch(14550754927305275517u64));
 }
 },
 
@@ -4343,7 +4343,7 @@ tmp if ((ByteSet::from_bits([18446744069414594048, 18446744073709551103, 0, 0]))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(658824046370133753u64));
+return Err(ParseError::ExcludedBranch(10197098993763395417u64));
 }
 };
 _input.close_peek_context()?;
@@ -4385,7 +4385,7 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3725673472712527969u64));
+return Err(ParseError::ExcludedBranch(15631554783732883240u64));
 }
 }
 },
@@ -4395,7 +4395,7 @@ tmp if ((ByteSet::from_bits([18446744069414594048, 18446744073709551103, 0, 0]))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12728843535195535635u64));
+return Err(ParseError::ExcludedBranch(2391834656526534993u64));
 }
 };
 _input.close_peek_context()?;
@@ -4438,7 +4438,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 1
 } else {
-return Err(ParseError::ExcludedBranch(15741082764016749161u64));
+return Err(ParseError::ExcludedBranch(9422510723961972169u64));
 }
 },
 
@@ -4447,7 +4447,7 @@ tmp if ((ByteSet::from_bits([18446744069414594048, 18446744073709551103, 0, 0]))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9967703502401950260u64));
+return Err(ParseError::ExcludedBranch(10940017698627680568u64));
 }
 };
 _input.close_peek_context()?;
@@ -4474,7 +4474,7 @@ let b = _input.read_byte()?;
 if b == 82 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8376883036401934317u64));
+return Err(ParseError::ExcludedBranch(179268011689651936u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -4482,7 +4482,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9069368457806005425u64));
+return Err(ParseError::ExcludedBranch(9665974566873665536u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -4490,7 +4490,7 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3179861450314844647u64));
+return Err(ParseError::ExcludedBranch(374064178837027275u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -4498,7 +4498,7 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15080388466336998873u64));
+return Err(ParseError::ExcludedBranch(658824046370133753u64));
 }
 }))())?;
 (field0, field1, field2, field3)
@@ -4516,7 +4516,7 @@ let b = _input.read_byte()?;
 Some(if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6070260202873699214u64));
+return Err(ParseError::ExcludedBranch(3725673472712527969u64));
 })
 } else {
 None
@@ -4544,7 +4544,7 @@ let ret = match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9220862562374507822u64));
+return Err(ParseError::ExcludedBranch(9069368457806005425u64));
 }
 };
 _input.close_peek_context()?;
@@ -4558,7 +4558,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8986322043713516692u64));
+return Err(ParseError::ExcludedBranch(12728843535195535635u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -4566,7 +4566,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11786939113783016634u64));
+return Err(ParseError::ExcludedBranch(15741082764016749161u64));
 }
 }))())?;
 tiff_main_byte_order::le(field0, field1)
@@ -4578,7 +4578,7 @@ let b = _input.read_byte()?;
 if b == 77 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3852079030227774582u64));
+return Err(ParseError::ExcludedBranch(9967703502401950260u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -4586,14 +4586,14 @@ let b = _input.read_byte()?;
 if b == 77 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5176232487486782188u64));
+return Err(ParseError::ExcludedBranch(8376883036401934317u64));
 }
 }))())?;
 tiff_main_byte_order::be(field0, field1)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8772793160380380086u64));
+return Err(ParseError::ExcludedBranch(3179861450314844647u64));
 }
 }
 }))())?;
@@ -4723,7 +4723,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2605623462625042002u64));
+return Err(ParseError::ExcludedBranch(15080388466336998873u64));
 }
 };
 _input.close_peek_context()?;
@@ -4751,7 +4751,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18164850183020044607u64));
+return Err(ParseError::ExcludedBranch(6070260202873699214u64));
 }
 });
 }
@@ -4779,7 +4779,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10688770705819276010u64));
+return Err(ParseError::ExcludedBranch(8986322043713516692u64));
 }
 };
 accum.push(next_elem);
@@ -4930,7 +4930,7 @@ opentype_main_directory::TableDirectory(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(10416240583538343445u64));
+return Err(ParseError::FailToken(11786939113783016634u64));
 }
 }))())?;
 PResult::Ok(opentype_main { file_start, magic, directory })
@@ -4989,7 +4989,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1457499133218925748u64));
+return Err(ParseError::ExcludedBranch(3852079030227774582u64));
 }
 };
 _input.close_peek_context()?;
@@ -5053,7 +5053,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5584166819955891466u64));
+return Err(ParseError::ExcludedBranch(9220862562374507822u64));
 }
 };
 _input.close_peek_context()?;
@@ -5067,7 +5067,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14215639860155940137u64));
+return Err(ParseError::ExcludedBranch(5176232487486782188u64));
 }
 };
 ((|_: u8| PResult::Ok((char::from_u32(0u32)).unwrap()))(inner))?
@@ -5078,7 +5078,7 @@ return Err(ParseError::ExcludedBranch(14215639860155940137u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11133239979815295357u64));
+return Err(ParseError::ExcludedBranch(8772793160380380086u64));
 }
 })
 }
@@ -5127,7 +5127,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(908377722732597655u64));
+return Err(ParseError::ExcludedBranch(12652804269632162478u64));
 }
 };
 _input.close_peek_context()?;
@@ -5141,7 +5141,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744073709551614, 18446744073709551615, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1275286460638129217u64));
+return Err(ParseError::ExcludedBranch(2605623462625042002u64));
 }
 };
 ((|byte: u8| PResult::Ok(byte as u32))(inner))?
@@ -5155,7 +5155,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 0, 4294967292])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(386759067598651566u64));
+return Err(ParseError::ExcludedBranch(18164850183020044607u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 31u8))(inner))?
@@ -5194,7 +5194,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3743786174148899814u64));
+return Err(ParseError::ExcludedBranch(1275286460638129217u64));
 }
 };
 _input.close_peek_context()?;
@@ -5209,7 +5209,7 @@ let b = _input.read_byte()?;
 if b == 224 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13527164188224560282u64));
+return Err(ParseError::ExcludedBranch(10688770705819276010u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 15u8))(inner))?
@@ -5220,7 +5220,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 18446744069414584320, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(240888096670347429u64));
+return Err(ParseError::ExcludedBranch(10416240583538343445u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 63u8))(inner))?
@@ -5236,7 +5236,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 0, 35175782154240])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11936787736236307191u64));
+return Err(ParseError::ExcludedBranch(1457499133218925748u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 15u8))(inner))?
@@ -5253,7 +5253,7 @@ let b = _input.read_byte()?;
 if b == 237 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5215619712890029856u64));
+return Err(ParseError::ExcludedBranch(14215639860155940137u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 15u8))(inner))?
@@ -5264,7 +5264,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 4294967295, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3167775832820164678u64));
+return Err(ParseError::ExcludedBranch(5584166819955891466u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 63u8))(inner))?
@@ -5280,7 +5280,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 0, 211106232532992])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7215050775822222282u64));
+return Err(ParseError::ExcludedBranch(11133239979815295357u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 15u8))(inner))?
@@ -5291,7 +5291,7 @@ let field2 = ((|| PResult::Ok((Decoder19(_input))?))())?;
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12652804269632162478u64));
+return Err(ParseError::ExcludedBranch(386759067598651566u64));
 }
 }
 };
@@ -5322,7 +5322,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4762692522317026931u64));
+return Err(ParseError::ExcludedBranch(7215050775822222282u64));
 }
 };
 _input.close_peek_context()?;
@@ -5337,7 +5337,7 @@ let b = _input.read_byte()?;
 if b == 240 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18134882366868794706u64));
+return Err(ParseError::ExcludedBranch(13527164188224560282u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 7u8))(inner))?
@@ -5348,7 +5348,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 18446744073709486080, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7155653122005708978u64));
+return Err(ParseError::ExcludedBranch(240888096670347429u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 63u8))(inner))?
@@ -5365,7 +5365,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17920584887603040596u64));
+return Err(ParseError::ExcludedBranch(11936787736236307191u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 7u8))(inner))?
@@ -5383,7 +5383,7 @@ let b = _input.read_byte()?;
 if b == 244 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5673845796627816005u64));
+return Err(ParseError::ExcludedBranch(5215619712890029856u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 7u8))(inner))?
@@ -5394,7 +5394,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 65535, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14591018267292443527u64));
+return Err(ParseError::ExcludedBranch(3167775832820164678u64));
 }
 };
 ((|raw: u8| PResult::Ok(raw & 63u8))(inner))?
@@ -5405,7 +5405,7 @@ let field3 = ((|| PResult::Ok((Decoder19(_input))?))())?;
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9630069758457681762u64));
+return Err(ParseError::ExcludedBranch(3743786174148899814u64));
 }
 }
 };
@@ -5417,7 +5417,7 @@ return Err(ParseError::ExcludedBranch(9630069758457681762u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3203034260088513018u64));
+return Err(ParseError::ExcludedBranch(18134882366868794706u64));
 }
 }
 };
@@ -5430,7 +5430,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 18446744073709551615, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14677505873656710393u64));
+return Err(ParseError::ExcludedBranch(7155653122005708978u64));
 }
 };
 PResult::Ok(((|raw: u8| PResult::Ok(raw & 63u8))(inner))?)
@@ -5469,7 +5469,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10102114574336663273u64));
+return Err(ParseError::FalsifiedWhere(17920584887603040596u64));
 }
 }))())?;
 let num_tables = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -5493,7 +5493,7 @@ let inner = (Decoder20(_input))?;
 if ((|tag: u32| PResult::Ok(tag == 1953784678u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4386762582485017400u64));
+return Err(ParseError::FalsifiedWhere(5673845796627816005u64));
 }
 }))())?;
 let major_version = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -5602,25 +5602,8 @@ PResult::Ok(opentype_table_record { table_id, checksum, offset, length })
 }
 
 fn Decoder_opentype_table_directory_table_links<'input>(_input: &mut Parser<'input>, start: u32, tables: Vec<opentype_table_record>) -> Result<opentype_table_directory_table_links, ParseError> {
-let cmap = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1668112752u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2206609067086327257u64));
-}
-};
+let cmap = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668112752u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5632,26 +5615,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let head = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1751474532u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11876854719037224982u64));
-}
-};
+let head = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751474532u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5663,26 +5634,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let hhea = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1751672161u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18270091135093349626u64));
-}
-};
+let hhea = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751672161u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5694,26 +5653,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let maxp = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1835104368u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6185506036438099345u64));
-}
-};
+let maxp = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1835104368u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5725,26 +5672,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let hmtx = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1752003704u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15794382300316794652u64));
-}
-};
+let hmtx = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1752003704u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5756,26 +5691,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let name = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1851878757u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18147521187885925800u64));
-}
-};
+let name = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1851878757u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5787,57 +5710,34 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let os2 = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1330851634u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7364705619221056123u64));
-}
-};
+let os2 = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1330851634u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (matching_table.length.clone()) as usize<>;
+let table_len = matching_table.length.clone();
+let sz = table_len as usize<>;
 _input.start_slice(sz)?;
-let ret = ((|| PResult::Ok((Decoder_opentype_os2_table(_input, matching_table.length.clone()))?))())?;
+let ret = ((|| PResult::Ok((Decoder_opentype_os2_table(_input, table_len.clone()))?))())?;
 _input.end_slice()?;
 ret
 }))())?;
 _input.close_peek_context()?;
 ret
+},
+
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
+}
 }))())?;
-let post = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1886352244u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-let matching_table = match table_matches.as_slice() {
-[x] => {
-x.clone()
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2404222719611925354u64));
-}
-};
+let post = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886352244u32, tables)).cloned() {
+Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
@@ -5849,20 +5749,14 @@ ret
 }))())?;
 _input.close_peek_context()?;
 ret
-}))())?;
-let cvt = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1668707360u32 {
-true => {
-[table.clone()].to_vec()
 },
 
-false => {
-[].to_vec()
+_other => {
+unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+}))())?;
+let cvt = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668707360u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5899,24 +5793,12 @@ ret
 ((|val: Vec<u16>| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let fpgm = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1718642541u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let fpgm = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1718642541u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5953,24 +5835,12 @@ ret
 ((|val: Vec<u8>| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let loca = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1819239265u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let loca = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1819239265u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5987,24 +5857,12 @@ ret
 ((|val: opentype_loca_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let glyf = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1735162214u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let glyf = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735162214u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6029,24 +5887,12 @@ ret
 ((|val: Vec<opentype_glyf_table>| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let prep = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1886545264u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let prep = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886545264u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6083,24 +5929,12 @@ ret
 ((|val: Vec<u8>| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let gasp = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1734439792u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let gasp = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1734439792u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6117,24 +5951,12 @@ ret
 ((|val: opentype_gasp_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let base = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1111577413u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let base = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1111577413u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6151,24 +5973,12 @@ ret
 ((|val: opentype_base_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let gdef = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1195656518u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let gdef = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1195656518u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6185,24 +5995,12 @@ ret
 ((|val: opentype_gdef_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let gpos = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1196445523u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let gpos = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196445523u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6219,24 +6017,12 @@ ret
 ((|val: opentype_gpos_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let gsub = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1196643650u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let gsub = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196643650u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6253,24 +6039,12 @@ ret
 ((|val: opentype_gsub_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let fvar = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1719034226u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let fvar = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1719034226u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6287,24 +6061,12 @@ ret
 ((|val: opentype_fvar_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let gvar = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1735811442u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let gvar = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735811442u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6321,24 +6083,12 @@ ret
 ((|val: opentype_gvar_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let kern = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1801810542u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let kern = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1801810542u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6355,24 +6105,12 @@ ret
 ((|val: opentype_kern_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let stat = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1398030676u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let stat = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1398030676u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6389,24 +6127,12 @@ ret
 ((|val: opentype_stat_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let vhea = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1986553185u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let vhea = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986553185u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6423,24 +6149,12 @@ ret
 ((|val: opentype_hhea_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
 }
-}
 }))())?;
-let vmtx = ((|| PResult::Ok({
-let table_matches = (try_flat_map_vec(tables.iter().cloned(), |table: opentype_table_record| PResult::Ok(match table.table_id.clone() == 1986884728u32 {
-true => {
-[table.clone()].to_vec()
-},
-
-false => {
-[].to_vec()
-}
-})))?;
-match table_matches.as_slice() {
-[x] => {
-let table = x.clone();
+let vmtx = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986884728u32, tables)).cloned() {
+Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -6453,7 +6167,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8893850231119365992u64));
+return Err(ParseError::ExcludedBranch(14591018267292443527u64));
 }
 }.number_of_long_metrics, maxp.num_glyphs.clone()))?))())?;
 _input.end_slice()?;
@@ -6465,9 +6179,8 @@ ret
 ((|val: opentype_hmtx_table| PResult::Ok(Some(val)))(inner))?
 },
 
-_ => {
+None => {
 None
-}
 }
 }))())?;
 let __skip = ((|| PResult::Ok(_input.skip_remainder()))())?;
@@ -6497,7 +6210,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7659860344311718435u64));
+return Err(ParseError::FalsifiedWhere(4762692522317026931u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -6505,7 +6218,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11052099086134529863u64));
+return Err(ParseError::FalsifiedWhere(9630069758457681762u64));
 }
 }))())?;
 let font_revision = ((|| PResult::Ok({
@@ -6519,7 +6232,7 @@ let b = _input.read_byte()?;
 if b == 95 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1079884235207081886u64));
+return Err(ParseError::ExcludedBranch(908377722732597655u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -6527,7 +6240,7 @@ let b = _input.read_byte()?;
 if b == 15 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(980800817911480223u64));
+return Err(ParseError::ExcludedBranch(3203034260088513018u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -6535,7 +6248,7 @@ let b = _input.read_byte()?;
 if b == 60 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9042484249406774160u64));
+return Err(ParseError::ExcludedBranch(14677505873656710393u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -6543,7 +6256,7 @@ let b = _input.read_byte()?;
 if b == 245 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7801539417877429212u64));
+return Err(ParseError::ExcludedBranch(10102114574336663273u64));
 }
 }))())?;
 (field0, field1, field2, field3)
@@ -6554,7 +6267,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok((x >= 16u16) && (x <= 16384u16)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14931240509007516758u64));
+return Err(ParseError::FalsifiedWhere(4386762582485017400u64));
 }
 }))())?;
 let created = ((|| PResult::Ok((Decoder98(_input))?))())?;
@@ -6590,7 +6303,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x <= 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11328034188734904930u64));
+return Err(ParseError::FalsifiedWhere(8893850231119365992u64));
 }
 }))())?;
 let glyph_data_format = ((|| PResult::Ok({
@@ -6598,7 +6311,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1338347005175300217u64));
+return Err(ParseError::FalsifiedWhere(7659860344311718435u64));
 }
 }))())?;
 PResult::Ok(opentype_head_table { major_version, minor_version, font_revision, checksum_adjustment, magic_number, flags, units_per_em, created, modified, glyph_extents, mac_style, lowest_rec_ppem, font_direction_hint, index_to_loc_format, glyph_data_format })
@@ -6610,7 +6323,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15432825464810477099u64));
+return Err(ParseError::FalsifiedWhere(11052099086134529863u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -6630,7 +6343,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8987822076696059625u64));
+return Err(ParseError::FalsifiedWhere(1079884235207081886u64));
 }
 }))())?;
 let ascent = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -6652,7 +6365,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10078755145706786000u64));
+return Err(ParseError::FalsifiedWhere(980800817911480223u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -6660,7 +6373,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1977899765720151190u64));
+return Err(ParseError::FalsifiedWhere(9042484249406774160u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -6668,7 +6381,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7343323033370781545u64));
+return Err(ParseError::FalsifiedWhere(7801539417877429212u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -6676,7 +6389,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12890902517277365935u64));
+return Err(ParseError::FalsifiedWhere(14931240509007516758u64));
 }
 }))())?;
 (field0, field1, field2, field3)
@@ -6686,7 +6399,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13049534979177835905u64));
+return Err(ParseError::FalsifiedWhere(11328034188734904930u64));
 }
 }))())?;
 let number_of_long_metrics = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -6728,7 +6441,7 @@ accum
 }))())?;
 let left_side_bearings = ((|| PResult::Ok({
 let mut accum = Vec::new();
-for _ in 0..try_sub!(num_glyphs, num_long_metrics, 13091357170910775568u64) {
+for _ in 0..try_sub!(num_glyphs, num_long_metrics, 2206609067086327257u64) {
 accum.push((Decoder23(_input))?);
 }
 accum
@@ -7127,7 +6840,7 @@ opentype_gasp_table_gasp_ranges_range_gasp_behavior::Version1(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(9011855507994367971u64));
+return Err(ParseError::FailToken(1338347005175300217u64));
 }
 }))())?;
 opentype_gasp_table_gasp_ranges { range_max_ppem, range_gasp_behavior }
@@ -7148,7 +6861,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14796083725261108356u64));
+return Err(ParseError::FalsifiedWhere(15432825464810477099u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -7156,7 +6869,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x <= 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2879885114680241844u64));
+return Err(ParseError::FalsifiedWhere(8987822076696059625u64));
 }
 }))())?;
 let horiz_axis_offset = ((|| PResult::Ok({
@@ -7244,7 +6957,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14009314771729697611u64));
+return Err(ParseError::FalsifiedWhere(10078755145706786000u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -7504,7 +7217,7 @@ opentype_gdef_table_lig_caret_list_link_lig_glyph_offsets_link_caret_values_link
 },
 
 _ => {
-return Err(ParseError::FailToken(10973085168168570837u64));
+return Err(ParseError::FailToken(1977899765720151190u64));
 }
 }))())?;
 opentype_gdef_table_lig_caret_list_link_lig_glyph_offsets_link_caret_values_link { table_start, caret_value_format, data }
@@ -7589,7 +7302,7 @@ opentype_gdef_table_data::Version1_0
 },
 
 1u16 => {
-return Err(ParseError::FailToken(10603707580403307601u64));
+return Err(ParseError::FailToken(7343323033370781545u64));
 },
 
 2u16 => {
@@ -7741,7 +7454,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18065118697073160549u64));
+return Err(ParseError::FalsifiedWhere(12890902517277365935u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -7969,7 +7682,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10686389193617118447u64));
+return Err(ParseError::FalsifiedWhere(13049534979177835905u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8197,7 +7910,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16128388243093908143u64));
+return Err(ParseError::FalsifiedWhere(9011855507994367971u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -8205,7 +7918,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2818918064991511645u64));
+return Err(ParseError::FalsifiedWhere(14796083725261108356u64));
 }
 }))())?;
 let __offset_axes = ((|| PResult::Ok({
@@ -8213,7 +7926,7 @@ let inner = (Decoder23(_input))?;
 if ((|raw: u16| PResult::Ok(raw > 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14082539304789607227u64));
+return Err(ParseError::FalsifiedWhere(2879885114680241844u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -8221,7 +7934,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 2u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11072034178440885507u64));
+return Err(ParseError::FalsifiedWhere(14009314771729697611u64));
 }
 }))())?;
 let axis_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8230,7 +7943,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 20u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4608405370414018463u64));
+return Err(ParseError::FalsifiedWhere(10973085168168570837u64));
 }
 }))())?;
 let instance_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8245,7 +7958,7 @@ let inner = _input.get_offset_u64();
 if ((|__here: u32| PResult::Ok(table_start + (__offset_axes as u32) >= __here))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4418518334087228745u64));
+return Err(ParseError::FalsifiedWhere(10603707580403307601u64));
 }
 };
 let tgt_offset = 0u32 + table_start + (__offset_axes as u32);
@@ -8281,7 +7994,7 @@ let inner = _input.get_offset_u64();
 if ((|__here: u32| PResult::Ok(table_start + ((__offset_axes + __axes_length) as u32) >= __here))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7086880279337729577u64));
+return Err(ParseError::FalsifiedWhere(18065118697073160549u64));
 }
 };
 let tgt_offset = 0u32 + table_start + ((__offset_axes + __axes_length) as u32);
@@ -8299,7 +8012,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7511456693437940214u64));
+return Err(ParseError::FalsifiedWhere(10686389193617118447u64));
 }
 }))())?;
 let coordinates = ((|| PResult::Ok((Decoder_opentype_var_user_tuple(_input, axis_count.clone()))?))())?;
@@ -8332,7 +8045,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(973408085875818710u64));
+return Err(ParseError::FalsifiedWhere(16128388243093908143u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -8340,7 +8053,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15557503981608772456u64));
+return Err(ParseError::FalsifiedWhere(2818918064991511645u64));
 }
 }))())?;
 let axis_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8432,7 +8145,7 @@ if next_offs > this_offs {
 let tgt_offset = array_start + this_offs;
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (try_sub!(next_offs, this_offs, 17170585774888887431u64)) as usize<>;
+let sz = (try_sub!(next_offs, this_offs, 11876854719037224982u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_var_glyph_variation_data_table(_input, axis_count.clone()))?))())?;
 _input.end_slice()?;
@@ -8459,7 +8172,7 @@ if next_offs > this_offs {
 let tgt_offset = array_start + this_offs;
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
 let ret = ((|| PResult::Ok({
-let sz = (try_sub!(next_offs, this_offs, 1548601315919054830u64)) as usize<>;
+let sz = (try_sub!(next_offs, this_offs, 18270091135093349626u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_opentype_var_glyph_variation_data_table(_input, axis_count.clone()))?))())?;
 _input.end_slice()?;
@@ -8489,7 +8202,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2154669163482751322u64));
+return Err(ParseError::FalsifiedWhere(14082539304789607227u64));
 }
 }))())?;
 let n_tables = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8502,7 +8215,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10263667190582992611u64));
+return Err(ParseError::FalsifiedWhere(11072034178440885507u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8645,7 +8358,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9339905250237811640u64));
+return Err(ParseError::ExcludedBranch(6185506036438099345u64));
 }
 }.n_glyphs {
 accum.push({
@@ -8656,7 +8369,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6039633234730737119u64));
+return Err(ParseError::ExcludedBranch(15794382300316794652u64));
 }
 }.n_glyphs {
 accum.push((Decoder23(_input))?);
@@ -8685,7 +8398,7 @@ opentype_kern_table_subtables_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(5482396765248532989u64));
+return Err(ParseError::FailToken(4608405370414018463u64));
 }
 }))())?;
 opentype_kern_table_subtables { version, length, coverage, data }
@@ -8706,7 +8419,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12275201028130973875u64));
+return Err(ParseError::FalsifiedWhere(4418518334087228745u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -8726,7 +8439,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16097120758067046920u64));
+return Err(ParseError::FalsifiedWhere(7086880279337729577u64));
 }
 }))())?;
 let design_axis_size = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -8818,7 +8531,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9331632426086095927u64));
+return Err(ParseError::FalsifiedWhere(7511456693437940214u64));
 }
 }))())?;
 let data = ((|| PResult::Ok(match format {
@@ -9049,7 +8762,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14959848987246965519u64));
+return Err(ParseError::FalsifiedWhere(973408085875818710u64));
 }
 }))())?;
 let tuple_variation_headers = ((|| PResult::Ok({
@@ -9100,7 +8813,7 @@ let inner = _input.get_offset_u64();
 if ((|__here: u32| PResult::Ok(table_start + (__data_offset as u32) >= __here))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9092905213558799443u64));
+return Err(ParseError::FalsifiedWhere(15557503981608772456u64));
 }
 };
 let tgt_offset = 0u32 + table_start + (__data_offset as u32);
@@ -9125,7 +8838,7 @@ tmp if ((ByteSet::from_bits([0, 0, 18446744073709551615, 18446744073709551615]))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5322124757500927073u64));
+return Err(ParseError::ExcludedBranch(12275201028130973875u64));
 }
 };
 _input.close_peek_context()?;
@@ -9139,7 +8852,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17544092807091201u64));
+return Err(ParseError::ExcludedBranch(2154669163482751322u64));
 }
 };
 ((|_: u8| PResult::Ok((0u16, [].to_vec())))(inner))?
@@ -9151,7 +8864,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744073709551614, 18446744073709551615, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10502127387712395480u64));
+return Err(ParseError::ExcludedBranch(10263667190582992611u64));
 }
 };
 let mut seq = Vec::new();
@@ -9216,7 +8929,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 18446744073709551615, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14454034443522724586u64));
+return Err(ParseError::ExcludedBranch(5482396765248532989u64));
 }
 };
 let lo = (Decoder24(_input))?;
@@ -9277,7 +8990,7 @@ acc + (succ((run.control.point_run_count.clone()) as u16))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17869550927478639832u64));
+return Err(ParseError::ExcludedBranch(16097120758067046920u64));
 }
 })
 } else {
@@ -9309,7 +9022,7 @@ tmp if ((ByteSet::from_bits([0, 0, 18446744073709551615, 18446744073709551615]))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14751251992141172493u64));
+return Err(ParseError::ExcludedBranch(17544092807091201u64));
 }
 };
 _input.close_peek_context()?;
@@ -9323,7 +9036,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13431462572241034712u64));
+return Err(ParseError::ExcludedBranch(9331632426086095927u64));
 }
 };
 ((|_: u8| PResult::Ok((0u16, [].to_vec())))(inner))?
@@ -9335,7 +9048,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744073709551614, 18446744073709551615, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3433937857563719729u64));
+return Err(ParseError::ExcludedBranch(14959848987246965519u64));
 }
 };
 let mut seq = Vec::new();
@@ -9400,7 +9113,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0, 0, 18446744073709551615, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13516986665125759073u64));
+return Err(ParseError::ExcludedBranch(9092905213558799443u64));
 }
 };
 let lo = (Decoder24(_input))?;
@@ -9461,7 +9174,7 @@ acc + (succ((run.control.point_run_count.clone()) as u16))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5733880678136728614u64));
+return Err(ParseError::ExcludedBranch(10502127387712395480u64));
 }
 })
 } else {
@@ -9480,7 +9193,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1654541969082323602u64));
+return Err(ParseError::ExcludedBranch(18147521187885925800u64));
 }
 }
 }
@@ -9712,7 +9425,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8997881400116719018u64));
+return Err(ParseError::FalsifiedWhere(14454034443522724586u64));
 }
 }))())?;
 let extension_lookup_type = ((|| PResult::Ok({
@@ -9732,7 +9445,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13614619987783239962u64));
+return Err(ParseError::FalsifiedWhere(5322124757500927073u64));
 }
 }))())?;
 let extension_offset = ((|| PResult::Ok({
@@ -9796,11 +9509,11 @@ opentype_layout_ground_subst::ReverseChainSingleSubst(inner)
 },
 
 7u16 => {
-return Err(ParseError::FailToken(6915530142412472120u64));
+return Err(ParseError::FailToken(17869550927478639832u64));
 },
 
 _ => {
-return Err(ParseError::FailToken(6949960292533894002u64));
+return Err(ParseError::FailToken(13431462572241034712u64));
 }
 })
 }
@@ -9815,7 +9528,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1347174710810305478u64));
+return Err(ParseError::FalsifiedWhere(3433937857563719729u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -9823,7 +9536,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8958899994948144829u64));
+return Err(ParseError::FalsifiedWhere(13516986665125759073u64));
 }
 }))())?;
 let feature_variation_record_count = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -9860,7 +9573,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15803403730818557393u64));
+return Err(ParseError::FalsifiedWhere(14751251992141172493u64));
 }
 }))())?;
 let axis_index = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -9920,7 +9633,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8390724546948265409u64));
+return Err(ParseError::FalsifiedWhere(5733880678136728614u64));
 }
 }))())?;
 let minor_version = ((|| PResult::Ok({
@@ -9928,7 +9641,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6347242493551283856u64));
+return Err(ParseError::FalsifiedWhere(8997881400116719018u64));
 }
 }))())?;
 let substitution_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -10082,7 +9795,7 @@ opentype_layout_single_subst_subst::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(4251627061094365437u64));
+return Err(ParseError::FailToken(13614619987783239962u64));
 }
 }))())?;
 PResult::Ok(opentype_layout_single_subst { table_start, subst_format, subst })
@@ -10186,7 +9899,7 @@ let inner = (Decoder23(_input))?;
 if ((|subst_format: u16| PResult::Ok(subst_format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11915580511665106140u64));
+return Err(ParseError::FalsifiedWhere(6915530142412472120u64));
 }
 }))())?;
 let coverage = ((|| PResult::Ok({
@@ -10269,7 +9982,7 @@ let inner = (Decoder23(_input))?;
 if ((|subst_format: u16| PResult::Ok(subst_format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17324980155911269375u64));
+return Err(ParseError::FalsifiedWhere(6949960292533894002u64));
 }
 }))())?;
 let coverage = ((|| PResult::Ok({
@@ -10456,7 +10169,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17670535809278048255u64));
+return Err(ParseError::FalsifiedWhere(1347174710810305478u64));
 }
 }))())?;
 let seq_lookup_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -10608,7 +10321,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2444204717155307095u64));
+return Err(ParseError::FalsifiedWhere(8958899994948144829u64));
 }
 }))())?;
 let seq_lookup_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -10715,7 +10428,7 @@ opentype_common_sequence_context_subst::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(1278184758971178969u64));
+return Err(ParseError::FailToken(15803403730818557393u64));
 }
 }))())?;
 PResult::Ok(opentype_common_sequence_context { table_start, format, subst })
@@ -11187,7 +10900,7 @@ opentype_common_chained_sequence_context_subst::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(4480225125687487743u64));
+return Err(ParseError::FailToken(8390724546948265409u64));
 }
 }))())?;
 PResult::Ok(opentype_common_chained_sequence_context { table_start, format, subst })
@@ -11203,7 +10916,7 @@ let inner = (Decoder23(_input))?;
 if ((|subst_format: u16| PResult::Ok(subst_format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12879845237981630531u64));
+return Err(ParseError::FalsifiedWhere(6347242493551283856u64));
 }
 }))())?;
 let coverage = ((|| PResult::Ok({
@@ -11345,7 +11058,7 @@ opentype_coverage_table_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(3426398976290336157u64));
+return Err(ParseError::FailToken(4251627061094365437u64));
 }
 }))())?;
 PResult::Ok(opentype_coverage_table { coverage_format, data })
@@ -11397,7 +11110,7 @@ opentype_class_def_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(11250208753083412758u64));
+return Err(ParseError::FailToken(11915580511665106140u64));
 }
 }))())?;
 PResult::Ok(opentype_class_def { class_format, data })
@@ -11478,7 +11191,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17349123374714965876u64));
+return Err(ParseError::FalsifiedWhere(17324980155911269375u64));
 }
 }))())?;
 let required_feature_index = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -11503,7 +11216,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2153064741293804702u64));
+return Err(ParseError::FalsifiedWhere(17670535809278048255u64));
 }
 }))())?;
 let extension_lookup_type = ((|| PResult::Ok({
@@ -11519,7 +11232,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1588651938759015246u64));
+return Err(ParseError::FalsifiedWhere(2444204717155307095u64));
 }
 }))())?;
 let extension_offset = ((|| PResult::Ok({
@@ -11588,11 +11301,11 @@ opentype_layout_ground_pos::ChainedSequenceContext(inner)
 },
 
 9u16 => {
-return Err(ParseError::FailToken(3249387167439447765u64));
+return Err(ParseError::FailToken(1278184758971178969u64));
 },
 
 _ => {
-return Err(ParseError::FailToken(7744051144774795087u64));
+return Err(ParseError::FailToken(4480225125687487743u64));
 }
 })
 }
@@ -11680,7 +11393,7 @@ opentype_layout_single_pos_subtable::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(8700288293163706751u64));
+return Err(ParseError::FailToken(12879845237981630531u64));
 }
 }))())?;
 PResult::Ok(opentype_layout_single_pos { table_start, pos_format, subtable })
@@ -11901,7 +11614,7 @@ opentype_layout_pair_pos_subtable::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(16771529512960957239u64));
+return Err(ParseError::FailToken(3426398976290336157u64));
 }
 }))())?;
 PResult::Ok(opentype_layout_pair_pos { table_start, pos_format, subtable })
@@ -11917,7 +11630,7 @@ let inner = (Decoder23(_input))?;
 if ((|pos_format: u16| PResult::Ok(pos_format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13846498452079501214u64));
+return Err(ParseError::FalsifiedWhere(11250208753083412758u64));
 }
 }))())?;
 let coverage = ((|| PResult::Ok({
@@ -12018,7 +11731,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9798710097031164942u64));
+return Err(ParseError::FalsifiedWhere(17349123374714965876u64));
 }
 }))())?;
 let mark_coverage_offset = ((|| PResult::Ok({
@@ -12182,7 +11895,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9819345728844658158u64));
+return Err(ParseError::FalsifiedWhere(2153064741293804702u64));
 }
 }))())?;
 let mark_coverage_offset = ((|| PResult::Ok({
@@ -12384,7 +12097,7 @@ let inner = (Decoder23(_input))?;
 if ((|format: u16| PResult::Ok(format == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18279137173405083757u64));
+return Err(ParseError::FalsifiedWhere(1588651938759015246u64));
 }
 }))())?;
 let mark1_coverage_offset = ((|| PResult::Ok({
@@ -12668,7 +12381,7 @@ opentype_common_anchor_table_table::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(14954891776835932150u64));
+return Err(ParseError::FailToken(3249387167439447765u64));
 }
 }))())?;
 PResult::Ok(opentype_common_anchor_table { table_start, anchor_format, table })
@@ -12698,37 +12411,37 @@ let delta_values = ((|| PResult::Ok({
 let mut accum = Vec::new();
 for _ in 0..match delta_format {
 1u16 => {
-match ((succ(try_sub!(end_size, start_size, 1272171534487716374u64))) / 8u16) * 8u16 < (succ(try_sub!(end_size, start_size, 7000022209644146403u64))) {
+match ((succ(try_sub!(end_size, start_size, 7364705619221056123u64))) / 8u16) * 8u16 < (succ(try_sub!(end_size, start_size, 2404222719611925354u64))) {
 true => {
-succ((succ(try_sub!(end_size, start_size, 8451221290566481190u64))) / 8u16)
+succ((succ(try_sub!(end_size, start_size, 13091357170910775568u64))) / 8u16)
 },
 
 false => {
-(succ(try_sub!(end_size, start_size, 7283163102885684771u64))) / 8u16
+(succ(try_sub!(end_size, start_size, 17170585774888887431u64))) / 8u16
 }
 }
 },
 
 2u16 => {
-match ((succ(try_sub!(end_size, start_size, 5100077783044507986u64))) / 4u16) * 4u16 < (succ(try_sub!(end_size, start_size, 16200207902741715318u64))) {
+match ((succ(try_sub!(end_size, start_size, 1548601315919054830u64))) / 4u16) * 4u16 < (succ(try_sub!(end_size, start_size, 9339905250237811640u64))) {
 true => {
-succ((succ(try_sub!(end_size, start_size, 5576343694315527798u64))) / 4u16)
+succ((succ(try_sub!(end_size, start_size, 6039633234730737119u64))) / 4u16)
 },
 
 false => {
-(succ(try_sub!(end_size, start_size, 4672672775256824980u64))) / 4u16
+(succ(try_sub!(end_size, start_size, 1654541969082323602u64))) / 4u16
 }
 }
 },
 
 3u16 => {
-match ((succ(try_sub!(end_size, start_size, 98102193810481173u64))) / 2u16) * 2u16 < (succ(try_sub!(end_size, start_size, 734991270787736827u64))) {
+match ((succ(try_sub!(end_size, start_size, 1272171534487716374u64))) / 2u16) * 2u16 < (succ(try_sub!(end_size, start_size, 7000022209644146403u64))) {
 true => {
-succ((succ(try_sub!(end_size, start_size, 18167425999583150549u64))) / 2u16)
+succ((succ(try_sub!(end_size, start_size, 8451221290566481190u64))) / 2u16)
 },
 
 false => {
-(succ(try_sub!(end_size, start_size, 1644793874183523166u64))) / 2u16
+(succ(try_sub!(end_size, start_size, 7283163102885684771u64))) / 2u16
 }
 }
 },
@@ -12756,7 +12469,7 @@ let b = _input.read_byte()?;
 if b == 128 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11046436797737227751u64));
+return Err(ParseError::ExcludedBranch(7744051144774795087u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -12764,7 +12477,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14984809111992638634u64));
+return Err(ParseError::ExcludedBranch(8700288293163706751u64));
 }
 }))())?;
 (field0, field1)
@@ -13342,7 +13055,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 1u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9342187932533045817u64));
+return Err(ParseError::FalsifiedWhere(16771529512960957239u64));
 }
 }))())?;
 let mark_glyph_set_count = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -13797,7 +13510,7 @@ opentype_layout_base_coord_hint::DeviceHint(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(13404710972790825894u64));
+return Err(ParseError::FailToken(13846498452079501214u64));
 }
 }))())?;
 PResult::Ok(opentype_layout_base_coord { table_start, format, coordinate, hint })
@@ -13900,7 +13613,7 @@ match abs {
 },
 
 n => {
-try_sub!(65535u16, pred(n as u16), 16396082708135795071u64)
+try_sub!(65535u16, pred(n as u16), 5100077783044507986u64)
 }
 }
 }
@@ -13940,7 +13653,7 @@ match abs {
 },
 
 n => {
-try_sub!(65535u16, pred(n as u16), 5546123200965512193u64)
+try_sub!(65535u16, pred(n as u16), 16200207902741715318u64)
 }
 }
 }
@@ -14234,7 +13947,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok((x >= 1u16) && (x <= 2u16)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2688427941405105545u64));
+return Err(ParseError::FalsifiedWhere(9798710097031164942u64));
 }
 }))())?;
 let max_twilight_points = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -14249,7 +13962,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x <= 16u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6279463968646665849u64));
+return Err(ParseError::FalsifiedWhere(9819345728844658158u64));
 }
 }))())?;
 PResult::Ok(opentype_maxp_table_version1 { max_points, max_contours, max_composite_points, max_composite_contours, max_zones, max_twilight_points, max_storage, max_function_defs, max_instruction_defs, max_stack_elements, max_size_of_instructions, max_component_elements, max_component_depth })
@@ -14406,7 +14119,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 2u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10875553067752207222u64));
+return Err(ParseError::FalsifiedWhere(18279137173405083757u64));
 }
 }))())?;
 opentype_cmap_subtable_format14_raw_raw { format }
@@ -14415,7 +14128,7 @@ let inner = (Decoder23(_input))?;
 if ((|l: u16| PResult::Ok((l >= 518u16) && (l % 2u16 == 0u16)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11323981950571132721u64));
+return Err(ParseError::FalsifiedWhere(14954891776835932150u64));
 }
 }))())?;
 _input.close_peek_context()?;
@@ -14429,7 +14142,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 2u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1179945139148562335u64));
+return Err(ParseError::FalsifiedWhere(11046436797737227751u64));
 }
 }))())?;
 let length = ((|| PResult::Ok({
@@ -14437,7 +14150,7 @@ let inner = (Decoder23(_input))?;
 if ((|l: u16| PResult::Ok((l >= 518u16) && (l % 2u16 == 0u16)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3270685119814653163u64));
+return Err(ParseError::FalsifiedWhere(14984809111992638634u64));
 }
 }))())?;
 let language = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -14476,7 +14189,7 @@ x
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9403121491749669432u64));
+return Err(ParseError::ExcludedBranch(5576343694315527798u64));
 }
 }) {
 accum.push({
@@ -14526,7 +14239,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 4u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6821845925776570829u64));
+return Err(ParseError::FalsifiedWhere(9342187932533045817u64));
 }
 }))())?;
 opentype_cmap_subtable_format14_raw_raw { format }
@@ -14544,7 +14257,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 4u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15898809900392744567u64));
+return Err(ParseError::FalsifiedWhere(13404710972790825894u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -14568,7 +14281,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5653230390980289841u64));
+return Err(ParseError::FalsifiedWhere(2688427941405105545u64));
 }
 }))())?;
 let start_code = ((|| PResult::Ok({
@@ -14625,7 +14338,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 6u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9179996462972575343u64));
+return Err(ParseError::FalsifiedWhere(6279463968646665849u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -14652,7 +14365,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 8u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3675496117133668659u64));
+return Err(ParseError::FalsifiedWhere(10875553067752207222u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14660,7 +14373,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6495907546257147840u64));
+return Err(ParseError::FalsifiedWhere(11323981950571132721u64));
 }
 }))())?;
 opentype_cmap_subtable_format13_raw_raw { format, __reserved }
@@ -14678,7 +14391,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 8u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8327471529801851430u64));
+return Err(ParseError::FalsifiedWhere(1179945139148562335u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14686,7 +14399,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10310785543736156275u64));
+return Err(ParseError::FalsifiedWhere(3270685119814653163u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -14722,7 +14435,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 10u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16594239496794104967u64));
+return Err(ParseError::FalsifiedWhere(6821845925776570829u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14730,7 +14443,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16529910322175208638u64));
+return Err(ParseError::FalsifiedWhere(15898809900392744567u64));
 }
 }))())?;
 opentype_cmap_subtable_format13_raw_raw { format, __reserved }
@@ -14748,7 +14461,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 10u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12187643960709778443u64));
+return Err(ParseError::FalsifiedWhere(5653230390980289841u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14756,7 +14469,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8766708729375264031u64));
+return Err(ParseError::FalsifiedWhere(9179996462972575343u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -14786,7 +14499,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 12u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1369437808023015077u64));
+return Err(ParseError::FalsifiedWhere(3675496117133668659u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14794,7 +14507,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(163858356033350300u64));
+return Err(ParseError::FalsifiedWhere(6495907546257147840u64));
 }
 }))())?;
 opentype_cmap_subtable_format13_raw_raw { format, __reserved }
@@ -14812,7 +14525,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 12u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(888161872995526095u64));
+return Err(ParseError::FalsifiedWhere(8327471529801851430u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14820,7 +14533,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4770836931378141069u64));
+return Err(ParseError::FalsifiedWhere(10310785543736156275u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -14849,7 +14562,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 13u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9976720501248819272u64));
+return Err(ParseError::FalsifiedWhere(16594239496794104967u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14857,7 +14570,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3595277668730903043u64));
+return Err(ParseError::FalsifiedWhere(16529910322175208638u64));
 }
 }))())?;
 opentype_cmap_subtable_format13_raw_raw { format, __reserved }
@@ -14875,7 +14588,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 13u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5446531490235636452u64));
+return Err(ParseError::FalsifiedWhere(12187643960709778443u64));
 }
 }))())?;
 let __reserved = ((|| PResult::Ok({
@@ -14883,7 +14596,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12530712830475607577u64));
+return Err(ParseError::FalsifiedWhere(8766708729375264031u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -14912,7 +14625,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 14u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1386817607731947864u64));
+return Err(ParseError::FalsifiedWhere(1369437808023015077u64));
 }
 }))())?;
 opentype_cmap_subtable_format14_raw_raw { format }
@@ -14930,7 +14643,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x == 14u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4795509455376621436u64));
+return Err(ParseError::FalsifiedWhere(163858356033350300u64));
 }
 }))())?;
 let length = ((|| PResult::Ok((Decoder20(_input))?))())?;
@@ -15155,7 +14868,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3923207427992258326u64));
+return Err(ParseError::FalsifiedWhere(888161872995526095u64));
 })
 }
 
@@ -15344,7 +15057,7 @@ let b = _input.read_byte()?;
 if b == 127 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5174369311102857850u64));
+return Err(ParseError::ExcludedBranch(4770836931378141069u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -15352,7 +15065,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15995337135637623051u64));
+return Err(ParseError::ExcludedBranch(9976720501248819272u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -15360,7 +15073,7 @@ let b = _input.read_byte()?;
 if b == 76 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4063460887563813446u64));
+return Err(ParseError::ExcludedBranch(3595277668730903043u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -15368,7 +15081,7 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10243418979491025991u64));
+return Err(ParseError::ExcludedBranch(5446531490235636452u64));
 }
 }))())?;
 (field0, field1, field2, field3)
@@ -15400,7 +15113,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6726475111737435495u64));
+return Err(ParseError::ExcludedBranch(12530712830475607577u64));
 }
 };
 accum.push(next_elem);
@@ -15434,7 +15147,7 @@ false
 }))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3702191162545267776u64));
+return Err(ParseError::FalsifiedWhere(1386817607731947864u64));
 })
 }
 
@@ -15447,7 +15160,7 @@ let inner = (Decoder118(_input, is_be.clone()))?;
 PResult::Ok(if ((|x: u32| PResult::Ok(x <= 1u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14926982082392674388u64));
+return Err(ParseError::FalsifiedWhere(4795509455376621436u64));
 })
 }
 
@@ -15478,7 +15191,7 @@ let inner = (Decoder24(_input))?;
 PResult::Ok(if ((|x: u8| PResult::Ok(x <= 2u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13281230340934385869u64));
+return Err(ParseError::FalsifiedWhere(3923207427992258326u64));
 })
 }
 
@@ -15487,7 +15200,7 @@ let inner = (Decoder24(_input))?;
 PResult::Ok(if ((|x: u8| PResult::Ok(x <= 2u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2229770659268432585u64));
+return Err(ParseError::FalsifiedWhere(5174369311102857850u64));
 })
 }
 
@@ -15496,7 +15209,7 @@ let inner = (Decoder24(_input))?;
 PResult::Ok(if ((|x: u8| PResult::Ok(x <= 1u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8862619478422395719u64));
+return Err(ParseError::FalsifiedWhere(15995337135637623051u64));
 })
 }
 
@@ -15533,6 +15246,358 @@ _input.end_slice()?;
 ret
 }))())?;
 let mode = ((|| PResult::Ok({
+let sz = 8u16 as usize<>;
+_input.start_slice(sz)?;
+let ret = ((|| PResult::Ok({
+let string = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = match b {
+tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
+0
+},
+
+tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4063460887563813446u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = (Decoder148(_input))?;
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
+let __padding = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(10243418979491025991u64));
+}
+};
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+tar_header_uid { string, __nul_or_wsp, __padding }
+}))())?;
+_input.end_slice()?;
+ret
+}))())?;
+let uid = ((|| PResult::Ok({
+let sz = 8u16 as usize<>;
+_input.start_slice(sz)?;
+let ret = ((|| PResult::Ok({
+let string = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = match b {
+tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
+0
+},
+
+tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6726475111737435495u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = (Decoder148(_input))?;
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
+let __padding = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(3702191162545267776u64));
+}
+};
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+tar_header_uid { string, __nul_or_wsp, __padding }
+}))())?;
+_input.end_slice()?;
+ret
+}))())?;
+let gid = ((|| PResult::Ok({
+let sz = 8u16 as usize<>;
+_input.start_slice(sz)?;
+let ret = ((|| PResult::Ok({
+let string = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = match b {
+tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
+0
+},
+
+tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14926982082392674388u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = (Decoder148(_input))?;
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
+let __padding = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(13281230340934385869u64));
+}
+};
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+tar_header_uid { string, __nul_or_wsp, __padding }
+}))())?;
+_input.end_slice()?;
+ret
+}))())?;
+let size = ((|| PResult::Ok({
+let inner = {
+let oA = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 4672672775256824980u64)))(inner))?
+}))())?;
+let o9 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 98102193810481173u64)))(inner))?
+}))())?;
+let o8 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 734991270787736827u64)))(inner))?
+}))())?;
+let o7 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 18167425999583150549u64)))(inner))?
+}))())?;
+let o6 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 1644793874183523166u64)))(inner))?
+}))())?;
+let o5 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 16396082708135795071u64)))(inner))?
+}))())?;
+let o4 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 5546123200965512193u64)))(inner))?
+}))())?;
+let o3 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 9403121491749669432u64)))(inner))?
+}))())?;
+let o2 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 7981520858864097140u64)))(inner))?
+}))())?;
+let o1 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 17948395312093823900u64)))(inner))?
+}))())?;
+let o0 = ((|| PResult::Ok({
+let inner = (Decoder148(_input))?;
+((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 7370180348639650351u64)))(inner))?
+}))())?;
+let __nil = ((|| PResult::Ok((Decoder149(_input))?))())?;
+let value = ((|| PResult::Ok((((0u8 as u32) << 3u32 | (oA as u32)) << 6u32 | (o9 as u32) << 3u32 | (o8 as u32)) << 24u32 | (((o7 as u32) << 3u32 | (o6 as u32)) << 6u32 | (o5 as u32) << 3u32 | (o4 as u32)) << 12u32 | ((o3 as u32) << 3u32 | (o2 as u32)) << 6u32 | (o1 as u32) << 3u32 | (o0 as u32)))())?;
+tar_header_size_raw { oA, o9, o8, o7, o6, o5, o4, o3, o2, o1, o0, __nil, value }
+};
+((|rec: tar_header_size_raw| PResult::Ok(rec.value.clone()))(inner))?
+}))())?;
+let mtime = ((|| PResult::Ok({
+let sz = 12u16 as usize<>;
+_input.start_slice(sz)?;
+let ret = ((|| PResult::Ok({
+let string = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = match b {
+tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
+0
+},
+
+tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2229770659268432585u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = (Decoder148(_input))?;
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
+let __padding = ((|| PResult::Ok({
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(8862619478422395719u64));
+}
+};
+accum.push(next_elem);
+} else {
+break
+}
+}
+accum
+}))())?;
+tar_header_uid { string, __nul_or_wsp, __padding }
+}))())?;
+_input.end_slice()?;
+ret
+}))())?;
+let chksum = ((|| PResult::Ok({
 let sz = 8u16 as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
@@ -15607,358 +15672,6 @@ tar_header_uid { string, __nul_or_wsp, __padding }
 _input.end_slice()?;
 ret
 }))())?;
-let uid = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
-_input.start_slice(sz)?;
-let ret = ((|| PResult::Ok({
-let string = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = match b {
-tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
-0
-},
-
-tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13264741506377240721u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = (Decoder148(_input))?;
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
-let __padding = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(16152968816646114000u64));
-}
-};
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-tar_header_uid { string, __nul_or_wsp, __padding }
-}))())?;
-_input.end_slice()?;
-ret
-}))())?;
-let gid = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
-_input.start_slice(sz)?;
-let ret = ((|| PResult::Ok({
-let string = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = match b {
-tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
-0
-},
-
-tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12815986247090051214u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = (Decoder148(_input))?;
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
-let __padding = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(2508979988921372290u64));
-}
-};
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-tar_header_uid { string, __nul_or_wsp, __padding }
-}))())?;
-_input.end_slice()?;
-ret
-}))())?;
-let size = ((|| PResult::Ok({
-let inner = {
-let oA = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 7981520858864097140u64)))(inner))?
-}))())?;
-let o9 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 17948395312093823900u64)))(inner))?
-}))())?;
-let o8 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 7370180348639650351u64)))(inner))?
-}))())?;
-let o7 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 9851243859021733611u64)))(inner))?
-}))())?;
-let o6 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 5357406925723651718u64)))(inner))?
-}))())?;
-let o5 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 12318721104400761032u64)))(inner))?
-}))())?;
-let o4 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 3320665455366264189u64)))(inner))?
-}))())?;
-let o3 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 3673300442962989464u64)))(inner))?
-}))())?;
-let o2 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 8970999014112821604u64)))(inner))?
-}))())?;
-let o1 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 17089130856162883194u64)))(inner))?
-}))())?;
-let o0 = ((|| PResult::Ok({
-let inner = (Decoder148(_input))?;
-((|bit: u8| PResult::Ok(try_sub!(bit as u8, 48u8, 13537165373980795457u64)))(inner))?
-}))())?;
-let __nil = ((|| PResult::Ok((Decoder149(_input))?))())?;
-let value = ((|| PResult::Ok((((0u8 as u32) << 3u32 | (oA as u32)) << 6u32 | (o9 as u32) << 3u32 | (o8 as u32)) << 24u32 | (((o7 as u32) << 3u32 | (o6 as u32)) << 6u32 | (o5 as u32) << 3u32 | (o4 as u32)) << 12u32 | ((o3 as u32) << 3u32 | (o2 as u32)) << 6u32 | (o1 as u32) << 3u32 | (o0 as u32)))())?;
-tar_header_size_raw { oA, o9, o8, o7, o6, o5, o4, o3, o2, o1, o0, __nil, value }
-};
-((|rec: tar_header_size_raw| PResult::Ok(rec.value.clone()))(inner))?
-}))())?;
-let mtime = ((|| PResult::Ok({
-let sz = 12u16 as usize<>;
-_input.start_slice(sz)?;
-let ret = ((|| PResult::Ok({
-let string = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = match b {
-tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
-0
-},
-
-tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10057441536650509049u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = (Decoder148(_input))?;
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
-let __padding = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(11815677057767015929u64));
-}
-};
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-tar_header_uid { string, __nul_or_wsp, __padding }
-}))())?;
-_input.end_slice()?;
-ret
-}))())?;
-let chksum = ((|| PResult::Ok({
-let sz = 8u16 as usize<>;
-_input.start_slice(sz)?;
-let ret = ((|| PResult::Ok({
-let string = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = match b {
-tmp if ((ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(tmp)) => {
-0
-},
-
-tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(829032137919921844u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = (Decoder148(_input))?;
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-let __nul_or_wsp = ((|| PResult::Ok((Decoder149(_input))?))())?;
-let __padding = ((|| PResult::Ok({
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(5170050512307443704u64));
-}
-};
-accum.push(next_elem);
-} else {
-break
-}
-}
-accum
-}))())?;
-tar_header_uid { string, __nul_or_wsp, __padding }
-}))())?;
-_input.end_slice()?;
-ret
-}))())?;
 let typeflag = ((|| PResult::Ok((Decoder150(_input))?))())?;
 let linkname = ((|| PResult::Ok({
 let sz = 100u16 as usize<>;
@@ -15973,7 +15686,7 @@ let b = _input.read_byte()?;
 if b == 117 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18440348483137307888u64));
+return Err(ParseError::ExcludedBranch(13264741506377240721u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -15981,7 +15694,7 @@ let b = _input.read_byte()?;
 if b == 115 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11309019127259385425u64));
+return Err(ParseError::ExcludedBranch(16152968816646114000u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -15989,7 +15702,7 @@ let b = _input.read_byte()?;
 if b == 116 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5159371628350638829u64));
+return Err(ParseError::ExcludedBranch(12815986247090051214u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -15997,7 +15710,7 @@ let b = _input.read_byte()?;
 if b == 97 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7762269623995317946u64));
+return Err(ParseError::ExcludedBranch(2508979988921372290u64));
 }
 }))())?;
 let field4 = ((|| PResult::Ok({
@@ -16005,7 +15718,7 @@ let b = _input.read_byte()?;
 if b == 114 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16134612799304961491u64));
+return Err(ParseError::ExcludedBranch(10057441536650509049u64));
 }
 }))())?;
 let field5 = ((|| PResult::Ok({
@@ -16013,7 +15726,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5308477118997970057u64));
+return Err(ParseError::ExcludedBranch(11815677057767015929u64));
 }
 }))())?;
 (field0, field1, field2, field3, field4, field5)
@@ -16024,7 +15737,7 @@ let b = _input.read_byte()?;
 if b == 48 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16190528142421852545u64));
+return Err(ParseError::ExcludedBranch(829032137919921844u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -16032,7 +15745,7 @@ let b = _input.read_byte()?;
 if b == 48 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(173922233423713068u64));
+return Err(ParseError::ExcludedBranch(5170050512307443704u64));
 }
 }))())?;
 (field0, field1)
@@ -16072,7 +15785,7 @@ tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12540117573097456360u64));
+return Err(ParseError::ExcludedBranch(18440348483137307888u64));
 }
 };
 _input.close_peek_context()?;
@@ -16111,7 +15824,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(515819609734101411u64));
+return Err(ParseError::ExcludedBranch(11309019127259385425u64));
 }
 };
 accum.push(next_elem);
@@ -16147,7 +15860,7 @@ tmp if ((ByteSet::from_bits([4294967297, 0, 0, 0])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9277543013594125416u64));
+return Err(ParseError::ExcludedBranch(5159371628350638829u64));
 }
 };
 _input.close_peek_context()?;
@@ -16186,7 +15899,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5955168674639093440u64));
+return Err(ParseError::ExcludedBranch(7762269623995317946u64));
 }
 };
 accum.push(next_elem);
@@ -16216,7 +15929,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4471438437047399494u64));
+return Err(ParseError::ExcludedBranch(16134612799304961491u64));
 }
 });
 }
@@ -16246,7 +15959,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(824589811577025210u64));
+return Err(ParseError::ExcludedBranch(16190528142421852545u64));
 }
 };
 _input.close_peek_context()?;
@@ -16265,7 +15978,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13319523888327217639u64));
+return Err(ParseError::ExcludedBranch(5308477118997970057u64));
 }
 };
 accum.push(next_elem);
@@ -16295,7 +16008,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4649034608147552416u64));
+return Err(ParseError::ExcludedBranch(173922233423713068u64));
 }
 };
 accum.push(next_elem);
@@ -16313,7 +16026,7 @@ let b = _input.read_byte()?;
 PResult::Ok(if (ByteSet::from_bits([71776119061217280, 0, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16096650375442290768u64));
+return Err(ParseError::ExcludedBranch(12540117573097456360u64));
 })
 }
 
@@ -16322,7 +16035,7 @@ let b = _input.read_byte()?;
 PResult::Ok(if (ByteSet::from_bits([4294967297, 0, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14339975513692068616u64));
+return Err(ParseError::ExcludedBranch(515819609734101411u64));
 })
 }
 
@@ -16349,7 +16062,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1479153625485860551u64));
+return Err(ParseError::ExcludedBranch(5955168674639093440u64));
 }
 };
 _input.close_peek_context()?;
@@ -16362,7 +16075,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16299205781335471965u64));
+return Err(ParseError::ExcludedBranch(9277543013594125416u64));
 }
 };
 accum.push(next_elem);
@@ -16394,7 +16107,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12668500753644823654u64));
+return Err(ParseError::ExcludedBranch(4471438437047399494u64));
 }
 };
 accum.push(next_elem);
@@ -16425,7 +16138,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1844274570107701975u64));
+return Err(ParseError::ExcludedBranch(824589811577025210u64));
 }
 };
 _input.close_peek_context()?;
@@ -16438,7 +16151,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8094248233631264621u64));
+return Err(ParseError::ExcludedBranch(13319523888327217639u64));
 }
 };
 accum.push(next_elem);
@@ -16476,7 +16189,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4839194687019048322u64));
+return Err(ParseError::ExcludedBranch(4649034608147552416u64));
 }
 };
 accum.push(next_elem);
@@ -16556,7 +16269,7 @@ let b = _input.read_byte()?;
 Some(if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7230273548678969972u64));
+return Err(ParseError::ExcludedBranch(16096650375442290768u64));
 })
 } else {
 None
@@ -16570,7 +16283,7 @@ let b = _input.read_byte()?;
 if b == 137 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14903563845775542749u64));
+return Err(ParseError::ExcludedBranch(14339975513692068616u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -16578,7 +16291,7 @@ let b = _input.read_byte()?;
 if b == 80 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1969670610881234889u64));
+return Err(ParseError::ExcludedBranch(16299205781335471965u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -16586,7 +16299,7 @@ let b = _input.read_byte()?;
 if b == 78 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9038350950373664822u64));
+return Err(ParseError::ExcludedBranch(1479153625485860551u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -16594,7 +16307,7 @@ let b = _input.read_byte()?;
 if b == 71 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7281717462557989541u64));
+return Err(ParseError::ExcludedBranch(12668500753644823654u64));
 }
 }))())?;
 let field4 = ((|| PResult::Ok({
@@ -16602,7 +16315,7 @@ let b = _input.read_byte()?;
 if b == 13 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15510952803379905659u64));
+return Err(ParseError::ExcludedBranch(8094248233631264621u64));
 }
 }))())?;
 let field5 = ((|| PResult::Ok({
@@ -16610,7 +16323,7 @@ let b = _input.read_byte()?;
 if b == 10 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14681668243282477517u64));
+return Err(ParseError::ExcludedBranch(1844274570107701975u64));
 }
 }))())?;
 let field6 = ((|| PResult::Ok({
@@ -16618,7 +16331,7 @@ let b = _input.read_byte()?;
 if b == 26 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6209434968043366837u64));
+return Err(ParseError::ExcludedBranch(4839194687019048322u64));
 }
 }))())?;
 let field7 = ((|| PResult::Ok({
@@ -16626,7 +16339,7 @@ let b = _input.read_byte()?;
 if b == 10 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16474038368490899078u64));
+return Err(ParseError::ExcludedBranch(7230273548678969972u64));
 }
 }))())?;
 PResult::Ok((field0, field1, field2, field3, field4, field5, field6, field7))
@@ -16638,7 +16351,7 @@ let inner = (Decoder20(_input))?;
 if ((|length: u32| PResult::Ok(length <= 2147483647u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12217686503432178884u64));
+return Err(ParseError::FalsifiedWhere(14903563845775542749u64));
 }
 }))())?;
 let tag = ((|| PResult::Ok((Decoder203(_input))?))())?;
@@ -16659,7 +16372,7 @@ let inner = (Decoder20(_input))?;
 if ((|length: u32| PResult::Ok(length <= 2147483647u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8399572043096922156u64));
+return Err(ParseError::FalsifiedWhere(1969670610881234889u64));
 }
 }))())?;
 let tag = ((|| PResult::Ok({
@@ -16670,7 +16383,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7832192330748800109u64));
+return Err(ParseError::ExcludedBranch(9038350950373664822u64));
 }
 }))();
 if _res.is_err() {
@@ -16803,7 +16516,7 @@ let inner = (Decoder20(_input))?;
 if ((|length: u32| PResult::Ok(length <= 2147483647u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9815657591077818003u64));
+return Err(ParseError::FalsifiedWhere(7281717462557989541u64));
 }
 }))())?;
 let tag = ((|| PResult::Ok((Decoder172(_input))?))())?;
@@ -16830,7 +16543,7 @@ b
 if ((|method_info: zlib_main_compression_method_flags| PResult::Ok(method_info.compression_method.clone() == 8u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2197379665604321609u64));
+return Err(ParseError::FalsifiedWhere(15510952803379905659u64));
 }
 }))())?;
 let flags = ((|| PResult::Ok({
@@ -16861,7 +16574,7 @@ let inner = (Decoder20(_input))?;
 if ((|length: u32| PResult::Ok(length <= 2147483647u32))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16624020278885696461u64));
+return Err(ParseError::FalsifiedWhere(14681668243282477517u64));
 }
 }))())?;
 let tag = ((|| PResult::Ok((Decoder162(_input))?))())?;
@@ -16882,7 +16595,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14485842416732585139u64));
+return Err(ParseError::ExcludedBranch(6209434968043366837u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -16890,7 +16603,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8179432974518885725u64));
+return Err(ParseError::ExcludedBranch(16474038368490899078u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -16898,7 +16611,7 @@ let b = _input.read_byte()?;
 if b == 78 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5152282179373241998u64));
+return Err(ParseError::ExcludedBranch(12217686503432178884u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -16906,7 +16619,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13780055874544357936u64));
+return Err(ParseError::ExcludedBranch(8399572043096922156u64));
 }
 }))())?;
 PResult::Ok((field0, field1, field2, field3))
@@ -16931,28 +16644,28 @@ accum.push(elem);
 accum
 }))())?;
 let codes = ((|| PResult::Ok((try_flat_map_vec(blocks.iter().cloned(), |x: deflate_block| PResult::Ok(match x.data.clone() {
-deflate_main_codes::uncompressed(ref y) => {
+deflate_main_codes__dupX1::uncompressed(ref y) => {
 y.codes_values.clone()
 },
 
-deflate_main_codes::fixed_huffman(ref y) => {
+deflate_main_codes__dupX1::fixed_huffman(ref y) => {
 y.codes_values.clone()
 },
 
-deflate_main_codes::dynamic_huffman(ref y) => {
+deflate_main_codes__dupX1::dynamic_huffman(ref y) => {
 y.codes_values.clone()
 }
 })))?))())?;
-let inflate = ((|| PResult::Ok((try_flat_map_append_vec(codes.iter().cloned(), |tuple_var: (&Vec<u8>, deflate_main_codes__dupX1)| PResult::Ok(match tuple_var {
+let inflate = ((|| PResult::Ok((try_flat_map_append_vec(codes.iter().cloned(), |tuple_var: (&Vec<u8>, deflate_main_codes)| PResult::Ok(match tuple_var {
 (buffer, symbol) => {
 match symbol {
-deflate_main_codes__dupX1::literal(b) => {
+deflate_main_codes::literal(b) => {
 [b].to_vec()
 },
 
-deflate_main_codes__dupX1::reference(r) => {
+deflate_main_codes::reference(r) => {
 {
-let ix = (try_sub!((buffer.len()) as u32, (r.distance.clone()) as u32, 11669649807369914251u64)) as usize;
+let ix = (try_sub!((buffer.len()) as u32, (r.distance.clone()) as u32, 9851243859021733611u64)) as usize;
 (slice_ext(&buffer, ix..ix + (((r.length.clone()) as u32) as usize))).to_vec()
 }
 }
@@ -16975,17 +16688,17 @@ let field1 = ((|| PResult::Ok((Decoder166(_input))?))())?;
 let data = ((|| PResult::Ok(match r#type {
 0u8 => {
 let inner = (Decoder_deflate_uncompressed(_input))?;
-deflate_main_codes::uncompressed(inner)
+deflate_main_codes__dupX1::uncompressed(inner)
 },
 
 1u8 => {
 let inner = (Decoder_deflate_fixed_huffman(_input))?;
-deflate_main_codes::fixed_huffman(inner)
+deflate_main_codes__dupX1::fixed_huffman(inner)
 },
 
 2u8 => {
 let inner = (Decoder_deflate_dynamic_huffman(_input))?;
-deflate_main_codes::dynamic_huffman(inner)
+deflate_main_codes__dupX1::dynamic_huffman(inner)
 },
 
 _other => {
@@ -17066,7 +16779,7 @@ let field7 = ((|| PResult::Ok((Decoder166(_input))?))())?;
 }
 accum
 }))())?;
-let codes_values = ((|| PResult::Ok((try_flat_map_vec(bytes.iter().cloned(), |x: u8| PResult::Ok([deflate_main_codes__dupX1::literal(x)].to_vec())))?))())?;
+let codes_values = ((|| PResult::Ok((try_flat_map_vec(bytes.iter().cloned(), |x: u8| PResult::Ok([deflate_main_codes::literal(x)].to_vec())))?))())?;
 PResult::Ok(deflate_uncompressed { align, len, nlen, bytes, codes_values })
 }
 
@@ -17845,11 +17558,11 @@ let codes_values = ((|| PResult::Ok((try_flat_map_vec(codes.iter().cloned(), |x:
 257u16..=285u16 => {
 match x.extra.clone() {
 Some(ref rec) => {
-[deflate_main_codes__dupX1::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
+[deflate_main_codes::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8880661182590738257u64));
+return Err(ParseError::ExcludedBranch(5357406925723651718u64));
 }
 }
 },
@@ -17859,7 +17572,7 @@ return Err(ParseError::ExcludedBranch(8880661182590738257u64));
 },
 
 _ => {
-[deflate_main_codes__dupX1::literal((x.code.clone()) as u8)].to_vec()
+[deflate_main_codes::literal((x.code.clone()) as u8)].to_vec()
 }
 })))?))())?;
 PResult::Ok(deflate_fixed_huffman { codes, codes_values })
@@ -17970,7 +17683,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(691490157317212239u64));
+return Err(ParseError::ExcludedBranch(12318721104400761032u64));
 }
 }))
 },
@@ -18004,7 +17717,7 @@ x.clone()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10719628102612994677u64));
+return Err(ParseError::ExcludedBranch(3320665455366264189u64));
 }
 }))
 },
@@ -18545,11 +18258,11 @@ let codes_values = ((|| PResult::Ok((try_flat_map_vec(codes.iter().cloned(), |x:
 257u16..=285u16 => {
 match x.extra.clone() {
 Some(ref rec) => {
-[deflate_main_codes__dupX1::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
+[deflate_main_codes::reference(deflate_main_codes_reference { length: rec.length.clone(), distance: rec.distance_record.distance.clone() })].to_vec()
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13685962128001446815u64));
+return Err(ParseError::ExcludedBranch(3673300442962989464u64));
 }
 }
 },
@@ -18559,7 +18272,7 @@ return Err(ParseError::ExcludedBranch(13685962128001446815u64));
 },
 
 _ => {
-[deflate_main_codes__dupX1::literal((x.code.clone()) as u8)].to_vec()
+[deflate_main_codes::literal((x.code.clone()) as u8)].to_vec()
 }
 })))?))())?;
 PResult::Ok(deflate_dynamic_huffman { hlit, hdist, hclen, code_length_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths_value, literal_length_alphabet_code_lengths_value, distance_alphabet_code_lengths_value, codes, codes_values })
@@ -18688,7 +18401,7 @@ PResult::Ok(match distance_code as u8 {
 },
 
 30u8..=31u8 => {
-return Err(ParseError::FailToken(16909208071962620789u64));
+return Err(ParseError::FailToken(7832192330748800109u64));
 },
 
 _other => {
@@ -18899,7 +18612,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7933266403838225878u64));
+return Err(ParseError::ExcludedBranch(9815657591077818003u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -18907,7 +18620,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12100308281236296642u64));
+return Err(ParseError::ExcludedBranch(2197379665604321609u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -18915,7 +18628,7 @@ let b = _input.read_byte()?;
 if b == 65 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9041056097467752267u64));
+return Err(ParseError::ExcludedBranch(16624020278885696461u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -18923,7 +18636,7 @@ let b = _input.read_byte()?;
 if b == 84 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5025197102194587315u64));
+return Err(ParseError::ExcludedBranch(14485842416732585139u64));
 }
 }))())?;
 PResult::Ok((field0, field1, field2, field3))
@@ -18956,7 +18669,7 @@ let b = _input.read_byte()?;
 PResult::Ok(if (ByteSet::from_bits([18446744069414594048, 18446744073709551615, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3810055094392728880u64));
+return Err(ParseError::ExcludedBranch(8179432974518885725u64));
 })
 }
 
@@ -19071,7 +18784,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15252450768049745444u64));
+return Err(ParseError::ExcludedBranch(5152282179373241998u64));
 }
 }))())?;
 (field0, field1)
@@ -19087,7 +18800,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x == 0u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5599331855309773603u64));
+return Err(ParseError::FalsifiedWhere(13780055874544357936u64));
 }
 }))())?;
 let compressed_profile = ((|| PResult::Ok((Decoder202(_input))?))())?;
@@ -19156,7 +18869,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x <= 3u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16437491640759399344u64));
+return Err(ParseError::FalsifiedWhere(16909208071962620789u64));
 }
 }))())?;
 PResult::Ok(png_srgb { rendering_intent })
@@ -19171,7 +18884,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2988545765690796708u64));
+return Err(ParseError::ExcludedBranch(7933266403838225878u64));
 }
 }))())?;
 (field0, field1)
@@ -19187,7 +18900,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([3, 0, 0, 0])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6215067399528787845u64));
+return Err(ParseError::ExcludedBranch(12100308281236296642u64));
 }
 }))())?;
 let compression_method = ((|| PResult::Ok({
@@ -19195,7 +18908,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17176374570344757031u64));
+return Err(ParseError::ExcludedBranch(9041056097467752267u64));
 }
 }))())?;
 let language_tag = ((|| PResult::Ok((Decoder_base_asciiz_string(_input))?))())?;
@@ -19207,7 +18920,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3566920116549027235u64));
+return Err(ParseError::ExcludedBranch(5025197102194587315u64));
 }
 }))())?;
 (field0, field1)
@@ -19301,7 +19014,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7979287392867129207u64));
+return Err(ParseError::ExcludedBranch(3810055094392728880u64));
 }
 }))())?;
 (field0, field1)
@@ -19345,7 +19058,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3653195934333285574u64));
+return Err(ParseError::ExcludedBranch(15252450768049745444u64));
 }
 }))())?;
 (field0, field1)
@@ -19361,7 +19074,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16671136947067655757u64));
+return Err(ParseError::ExcludedBranch(5599331855309773603u64));
 }
 }))())?;
 let compressed_text = ((|| PResult::Ok({
@@ -19466,7 +19179,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10721249873135158334u64));
+return Err(ParseError::ExcludedBranch(16437491640759399344u64));
 }
 }))())?;
 (field0, field1)
@@ -19482,7 +19195,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok((x == 8u8) || (x == 16u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8898504689444561451u64));
+return Err(ParseError::FalsifiedWhere(2988545765690796708u64));
 }
 }))())?;
 let pallette = ((|| PResult::Ok(match sample_depth {
@@ -20130,6 +19843,54 @@ tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(17176374570344757031u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3566920116549027235u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7979287392867129207u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3653195934333285574u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16671136947067655757u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(10721249873135158334u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8898504689444561451u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(441240706992005484u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(3950014938140253048u64));
 }
 }
@@ -20552,54 +20313,6 @@ return Err(ParseError::ExcludedBranch(1977196682923428575u64));
 _ => {
 return Err(ParseError::ExcludedBranch(14908034280634314212u64));
 }
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3857251694269754536u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5041932778480497827u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4514882359072253410u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13286112843953025473u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15541745679144160988u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16366772103869684910u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16354405091856567045u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15047091743774256727u64));
-}
 };
 _input.close_peek_context()?;
 ret
@@ -20613,7 +20326,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(441240706992005484u64));
+return Err(ParseError::ExcludedBranch(6215067399528787845u64));
 }
 };
 accum.push(next_elem);
@@ -21185,6 +20898,54 @@ tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(5041932778480497827u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4514882359072253410u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13286112843953025473u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15541745679144160988u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16366772103869684910u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16354405091856567045u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15047091743774256727u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(89425857491903975u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(4693381172248071257u64));
 }
 }
@@ -21607,54 +21368,6 @@ return Err(ParseError::ExcludedBranch(7572218778908935167u64));
 _ => {
 return Err(ParseError::ExcludedBranch(12520942526725743695u64));
 }
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5905249956584638130u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8609603324479018835u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8973115486793444912u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2872401692234135189u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3556125603266802472u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16173438081116718978u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3532284049956758497u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1214015012285792661u64));
-}
 };
 _input.close_peek_context()?;
 ret
@@ -21668,7 +21381,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(89425857491903975u64));
+return Err(ParseError::ExcludedBranch(3857251694269754536u64));
 }
 };
 accum.push(next_elem);
@@ -21689,7 +21402,7 @@ b
 if ((|method_info: zlib_main_compression_method_flags| PResult::Ok(method_info.compression_method.clone() == 8u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18287039256282529512u64));
+return Err(ParseError::FalsifiedWhere(5905249956584638130u64));
 }
 }))())?;
 let flags = ((|| PResult::Ok({
@@ -21767,7 +21480,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6040541316788286267u64));
+return Err(ParseError::ExcludedBranch(8609603324479018835u64));
 }
 };
 _input.close_peek_context()?;
@@ -22347,6 +22060,54 @@ tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(2872401692234135189u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3556125603266802472u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16173438081116718978u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3532284049956758497u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1214015012285792661u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18287039256282529512u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6040541316788286267u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6926344996361682930u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(1335666833550050804u64));
 }
 }
@@ -22769,54 +22530,6 @@ return Err(ParseError::ExcludedBranch(2930236810929305906u64));
 _ => {
 return Err(ParseError::ExcludedBranch(9788088961065186348u64));
 }
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13475201244121026739u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10514680212862927148u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1404288588910574651u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9722140062746187322u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14672290401516300248u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1570732024996461745u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3970524133912495743u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10022572355386706896u64));
-}
 };
 _input.close_peek_context()?;
 ret
@@ -22830,7 +22543,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6926344996361682930u64));
+return Err(ParseError::ExcludedBranch(8973115486793444912u64));
 }
 };
 accum.push(next_elem);
@@ -23402,6 +23115,54 @@ tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(10514680212862927148u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1404288588910574651u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9722140062746187322u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14672290401516300248u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1570732024996461745u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(3970524133912495743u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(10022572355386706896u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7175325427369635964u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(10941190781838111798u64));
 }
 }
@@ -23824,54 +23585,6 @@ return Err(ParseError::ExcludedBranch(13045651918551022996u64));
 _ => {
 return Err(ParseError::ExcludedBranch(12507789284617859731u64));
 }
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4636203914394120912u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12770885481695079655u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5713736954960046494u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5286459060741837465u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10857757036842967573u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8347358143797316202u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9289217078927880343u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7619374930571283120u64));
-}
 };
 _input.close_peek_context()?;
 ret
@@ -23885,7 +23598,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7175325427369635964u64));
+return Err(ParseError::ExcludedBranch(13475201244121026739u64));
 }
 };
 accum.push(next_elem);
@@ -23912,7 +23625,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9422091606538556682u64));
+return Err(ParseError::ExcludedBranch(12770885481695079655u64));
 }
 };
 _input.close_peek_context()?;
@@ -23925,7 +23638,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5502272810018950495u64));
+return Err(ParseError::ExcludedBranch(4636203914394120912u64));
 }
 };
 accum.push(next_elem);
@@ -23940,7 +23653,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1986031727359985319u64));
+return Err(ParseError::ExcludedBranch(5713736954960046494u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -23995,7 +23708,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2609726213773413101u64));
+return Err(ParseError::ExcludedBranch(5286459060741837465u64));
 }
 };
 _input.close_peek_context()?;
@@ -24024,7 +23737,7 @@ b
 if ((|method_info: zlib_main_compression_method_flags| PResult::Ok(method_info.compression_method.clone() == 8u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4688564412461098550u64));
+return Err(ParseError::FalsifiedWhere(10857757036842967573u64));
 }
 }))())?;
 let flags = ((|| PResult::Ok({
@@ -24094,7 +23807,7 @@ tmp if ((ByteSet::from_bits([0, 0, 0, 3940649673949184])).contains(tmp)) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4942686269660057715u64));
+return Err(ParseError::ExcludedBranch(8347358143797316202u64));
 }
 };
 _input.close_peek_context()?;
@@ -24674,6 +24387,54 @@ tmp if ((ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(7619374930571283120u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5502272810018950495u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9422091606538556682u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1986031727359985319u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2609726213773413101u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4688564412461098550u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4942686269660057715u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9251320185524837870u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(16934907723271638747u64));
 }
 }
@@ -25096,54 +24857,6 @@ return Err(ParseError::ExcludedBranch(15321253101048235163u64));
 _ => {
 return Err(ParseError::ExcludedBranch(14285291594842403582u64));
 }
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7161350271661739096u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14445026714989735755u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7573348369521592997u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2912602219218223367u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15885886181646629118u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(13594649006224468849u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14349391981174483355u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10927780046062734427u64));
-}
 };
 _input.close_peek_context()?;
 ret
@@ -25157,7 +24870,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320, 9223372036854775807, 18446744065119617024, 18446744073709551615])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9251320185524837870u64));
+return Err(ParseError::ExcludedBranch(9289217078927880343u64));
 }
 };
 accum.push(next_elem);
@@ -25178,7 +24891,7 @@ b
 if ((|method_info: zlib_main_compression_method_flags| PResult::Ok(method_info.compression_method.clone() == 8u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13819997351842221509u64));
+return Err(ParseError::FalsifiedWhere(7161350271661739096u64));
 }
 }))())?;
 let flags = ((|| PResult::Ok({
@@ -25209,7 +24922,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11959902760514814588u64));
+return Err(ParseError::ExcludedBranch(14445026714989735755u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -25217,7 +24930,7 @@ let b = _input.read_byte()?;
 if b == 72 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14114750189009003637u64));
+return Err(ParseError::ExcludedBranch(7573348369521592997u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -25225,7 +24938,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12268471799124361536u64));
+return Err(ParseError::ExcludedBranch(2912602219218223367u64));
 }
 }))())?;
 let field3 = ((|| PResult::Ok({
@@ -25233,7 +24946,7 @@ let b = _input.read_byte()?;
 if b == 82 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9620443865397033050u64));
+return Err(ParseError::ExcludedBranch(15885886181646629118u64));
 }
 }))())?;
 PResult::Ok((field0, field1, field2, field3))
@@ -25260,11 +24973,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 7538966935051243003u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8970999014112821604u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 4867798537713738914u64)) as u64
+(try_sub!(size_field, 8u32, 17089130856162883194u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -25409,11 +25122,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 11266387855511437693u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 13537165373980795457u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 11452033436843896773u64)) as u64
+(try_sub!(size_field, 8u32, 11669649807369914251u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -25558,11 +25271,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8138544351856664662u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8880661182590738257u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 12696272221194189133u64)) as u64
+(try_sub!(size_field, 8u32, 691490157317212239u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -25619,11 +25332,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 3995820927126919547u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 10719628102612994677u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 9149418055219508197u64)) as u64
+(try_sub!(size_field, 8u32, 13685962128001446815u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -25901,11 +25614,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8000269442706245049u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 7538966935051243003u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 4100106362216887809u64)) as u64
+(try_sub!(size_field, 8u32, 4867798537713738914u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26067,11 +25780,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 3198904588321530108u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 11266387855511437693u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 8674930063339641954u64)) as u64
+(try_sub!(size_field, 8u32, 11452033436843896773u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26230,11 +25943,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 15244023661753025012u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8138544351856664662u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 11029695522295027332u64)) as u64
+(try_sub!(size_field, 8u32, 12696272221194189133u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26308,11 +26021,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 1560031033762626303u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 3995820927126919547u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 2452372056966650770u64)) as u64
+(try_sub!(size_field, 8u32, 9149418055219508197u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26387,11 +26100,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 7866350329714952610u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 8000269442706245049u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 12954594173805448799u64)) as u64
+(try_sub!(size_field, 8u32, 4100106362216887809u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26535,7 +26248,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3933597635930613605u64));
+return Err(ParseError::ExcludedBranch(14349391981174483355u64));
 }
 };
 _input.close_peek_context()?;
@@ -26548,7 +26261,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3999778194527899420u64));
+return Err(ParseError::ExcludedBranch(13594649006224468849u64));
 }
 };
 accum.push(next_elem);
@@ -26563,7 +26276,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5638313771627483501u64));
+return Err(ParseError::ExcludedBranch(10927780046062734427u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -26579,11 +26292,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 9573183374517388194u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 3198904588321530108u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 15327783809571612236u64)) as u64
+(try_sub!(size_field, 8u32, 8674930063339641954u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26719,11 +26432,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 9684775926499943714u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 15244023661753025012u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 5912167672739605892u64)) as u64
+(try_sub!(size_field, 8u32, 11029695522295027332u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26763,11 +26476,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 1998097826508262195u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 1560031033762626303u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 16370266426490485062u64)) as u64
+(try_sub!(size_field, 8u32, 2452372056966650770u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26852,11 +26565,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 14923902544344582218u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 7866350329714952610u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 9033025935232855564u64)) as u64
+(try_sub!(size_field, 8u32, 12954594173805448799u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -26886,11 +26599,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 6569230515699692699u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 9573183374517388194u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 15682767706885925172u64)) as u64
+(try_sub!(size_field, 8u32, 15327783809571612236u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -27215,11 +26928,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 2946338368865429585u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 9684775926499943714u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 466150863659326234u64)) as u64
+(try_sub!(size_field, 8u32, 5912167672739605892u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -27335,11 +27048,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 11988854374464943326u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 1998097826508262195u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 7620281735474506525u64)) as u64
+(try_sub!(size_field, 8u32, 16370266426490485062u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -27412,11 +27125,11 @@ let size = ((|| PResult::Ok(match size_field {
 
 1u32 => {
 let inner = (Decoder99(_input))?;
-((|x: u64| PResult::Ok(try_sub!(x, 16u64, 11599300513837427027u64)))(inner))?
+((|x: u64| PResult::Ok(try_sub!(x, 16u64, 14923902544344582218u64)))(inner))?
 },
 
 _ => {
-(try_sub!(size_field, 8u32, 950046280632689001u64)) as u64
+(try_sub!(size_field, 8u32, 9033025935232855564u64)) as u64
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -27502,7 +27215,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(646997207007428137u64));
+return Err(ParseError::ExcludedBranch(11959902760514814588u64));
 }
 };
 _input.close_peek_context()?;
@@ -27515,7 +27228,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1105171745447487568u64));
+return Err(ParseError::ExcludedBranch(13819997351842221509u64));
 }
 };
 accum.push(next_elem);
@@ -27530,7 +27243,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6351919260209655786u64));
+return Err(ParseError::ExcludedBranch(14114750189009003637u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -27554,7 +27267,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17332407069754301555u64));
+return Err(ParseError::ExcludedBranch(9620443865397033050u64));
 }
 };
 _input.close_peek_context()?;
@@ -27567,7 +27280,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(552953513858366451u64));
+return Err(ParseError::ExcludedBranch(12268471799124361536u64));
 }
 };
 accum.push(next_elem);
@@ -27582,7 +27295,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14279133095670415871u64));
+return Err(ParseError::ExcludedBranch(3999778194527899420u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -27606,7 +27319,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10748847049349746078u64));
+return Err(ParseError::ExcludedBranch(5638313771627483501u64));
 }
 };
 _input.close_peek_context()?;
@@ -27619,7 +27332,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7347749870002275487u64));
+return Err(ParseError::ExcludedBranch(3933597635930613605u64));
 }
 };
 accum.push(next_elem);
@@ -27634,7 +27347,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14220958138979104104u64));
+return Err(ParseError::ExcludedBranch(1105171745447487568u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -27658,7 +27371,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12223407337737822059u64));
+return Err(ParseError::ExcludedBranch(6351919260209655786u64));
 }
 };
 _input.close_peek_context()?;
@@ -27671,7 +27384,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17741760072369420240u64));
+return Err(ParseError::ExcludedBranch(646997207007428137u64));
 }
 };
 accum.push(next_elem);
@@ -27686,7 +27399,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6072942808717419822u64));
+return Err(ParseError::ExcludedBranch(552953513858366451u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -27710,7 +27423,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7977419944699061624u64));
+return Err(ParseError::ExcludedBranch(14279133095670415871u64));
 }
 };
 _input.close_peek_context()?;
@@ -27723,7 +27436,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15560056883377919848u64));
+return Err(ParseError::ExcludedBranch(17332407069754301555u64));
 }
 };
 accum.push(next_elem);
@@ -27738,7 +27451,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8323252642575612937u64));
+return Err(ParseError::ExcludedBranch(7347749870002275487u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -27750,7 +27463,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11678443062630698028u64));
+return Err(ParseError::ExcludedBranch(10748847049349746078u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -27758,7 +27471,7 @@ let b = _input.read_byte()?;
 if b == 216 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14832405617500840744u64));
+return Err(ParseError::ExcludedBranch(14220958138979104104u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -27782,11 +27495,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1398536204687975789u64));
+return Err(ParseError::ExcludedBranch(17741760072369420240u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(7336714497745271452u64));
+return Err(ParseError::ExcludedBranch(12223407337737822059u64));
 };
 _input.close_peek_context()?;
 ret
@@ -27804,7 +27517,7 @@ jpeg_frame_initial_segment::app1(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4152914559762097168u64));
+return Err(ParseError::ExcludedBranch(6072942808717419822u64));
 }
 }
 }))())?;
@@ -27955,11 +27668,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1152534299541961510u64));
+return Err(ParseError::ExcludedBranch(15560056883377919848u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(5095757730543354711u64));
+return Err(ParseError::ExcludedBranch(7977419944699061624u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28081,11 +27794,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4668055697655854201u64));
+return Err(ParseError::ExcludedBranch(8323252642575612937u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(6515957116553005671u64));
+return Err(ParseError::ExcludedBranch(11678443062630698028u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28102,7 +27815,7 @@ jpeg_frame_dnl::none
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2017059186547121525u64));
+return Err(ParseError::ExcludedBranch(14832405617500840744u64));
 }
 }
 }))())?;
@@ -28209,11 +27922,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11789784461021426583u64));
+return Err(ParseError::ExcludedBranch(1398536204687975789u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(16022216421479351095u64));
+return Err(ParseError::ExcludedBranch(7336714497745271452u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28237,7 +27950,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15337804701822118436u64));
+return Err(ParseError::ExcludedBranch(4152914559762097168u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -28245,7 +27958,7 @@ let b = _input.read_byte()?;
 if b == 217 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2750471357152633230u64));
+return Err(ParseError::ExcludedBranch(1152534299541961510u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -28258,7 +27971,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8306706226429158303u64));
+return Err(ParseError::ExcludedBranch(5095757730543354711u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -28266,14 +27979,14 @@ let b = _input.read_byte()?;
 if b == 224 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8033982984919675631u64));
+return Err(ParseError::ExcludedBranch(4668055697655854201u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5625702265340316943u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 6569230515699692699u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_app0_data(_input))?))())?;
 _input.end_slice()?;
@@ -28289,7 +28002,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7258731811542513498u64));
+return Err(ParseError::ExcludedBranch(6515957116553005671u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -28297,14 +28010,14 @@ let b = _input.read_byte()?;
 if b == 225 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1283209893442238385u64));
+return Err(ParseError::ExcludedBranch(2017059186547121525u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 4260205764162136487u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15682767706885925172u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_app1_data(_input))?))())?;
 _input.end_slice()?;
@@ -28406,11 +28119,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1920187793319100008u64));
+return Err(ParseError::ExcludedBranch(11789784461021426583u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(7474037925185307628u64));
+return Err(ParseError::ExcludedBranch(16022216421479351095u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28523,7 +28236,7 @@ jpeg_table_or_misc::com(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4475730102931494177u64));
+return Err(ParseError::ExcludedBranch(15337804701822118436u64));
 }
 })
 }
@@ -28589,11 +28302,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17780439059155340308u64));
+return Err(ParseError::ExcludedBranch(2750471357152633230u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(6739127967943113267u64));
+return Err(ParseError::ExcludedBranch(8306706226429158303u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28666,7 +28379,7 @@ jpeg_frame_header::sof15(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10170756778737993654u64));
+return Err(ParseError::ExcludedBranch(8033982984919675631u64));
 }
 })
 }
@@ -28771,11 +28484,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14306133355400503306u64));
+return Err(ParseError::ExcludedBranch(7258731811542513498u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(8902666087419502325u64));
+return Err(ParseError::ExcludedBranch(1283209893442238385u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28802,7 +28515,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10248009767256971850u64));
+return Err(ParseError::ExcludedBranch(1920187793319100008u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -28810,14 +28523,14 @@ let b = _input.read_byte()?;
 if b == 220 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7807103255128873628u64));
+return Err(ParseError::ExcludedBranch(7474037925185307628u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5712308626808297759u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 2946338368865429585u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dnl_data(_input))?))())?;
 _input.end_slice()?;
@@ -28926,11 +28639,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7840596951976883698u64));
+return Err(ParseError::ExcludedBranch(4475730102931494177u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(8004105446758774533u64));
+return Err(ParseError::ExcludedBranch(17780439059155340308u64));
 };
 _input.close_peek_context()?;
 ret
@@ -28957,7 +28670,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12569316739694558801u64));
+return Err(ParseError::ExcludedBranch(6739127967943113267u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -28965,14 +28678,14 @@ let b = _input.read_byte()?;
 if b == 218 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2967911718584065013u64));
+return Err(ParseError::ExcludedBranch(10170756778737993654u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 8638089167112501923u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 466150863659326234u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sos_data(_input))?))())?;
 _input.end_slice()?;
@@ -29126,13 +28839,13 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16954835414833850385u64));
+return Err(ParseError::ExcludedBranch(7807103255128873628u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1891774877762105457u64));
+return Err(ParseError::ExcludedBranch(7840596951976883698u64));
 }
 };
 _input.close_peek_context()?;
@@ -29190,13 +28903,13 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7227788188777836434u64));
+return Err(ParseError::ExcludedBranch(14306133355400503306u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2859130192484418172u64));
+return Err(ParseError::ExcludedBranch(8902666087419502325u64));
 }
 };
 _input.close_peek_context()?;
@@ -29250,7 +28963,7 @@ jpeg_scan_data_scan_data::rst7(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12550558264664848853u64));
+return Err(ParseError::ExcludedBranch(10248009767256971850u64));
 }
 }
 };
@@ -29316,7 +29029,7 @@ tmp if (tmp != 255) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6882184431082022206u64));
+return Err(ParseError::ExcludedBranch(7227788188777836434u64));
 }
 };
 _input.close_peek_context()?;
@@ -29329,7 +29042,7 @@ let b = _input.read_byte()?;
 if b != 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13705211812356460160u64));
+return Err(ParseError::ExcludedBranch(8004105446758774533u64));
 }
 },
 
@@ -29340,7 +29053,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5515497093089591991u64));
+return Err(ParseError::ExcludedBranch(12569316739694558801u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -29348,7 +29061,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1328880024623199753u64));
+return Err(ParseError::ExcludedBranch(2967911718584065013u64));
 }
 }))())?;
 (field0, field1)
@@ -29357,7 +29070,7 @@ return Err(ParseError::ExcludedBranch(1328880024623199753u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3998072683184925592u64));
+return Err(ParseError::ExcludedBranch(2859130192484418172u64));
 }
 })
 }
@@ -29368,7 +29081,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(29850628954056690u64));
+return Err(ParseError::ExcludedBranch(12550558264664848853u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29376,7 +29089,7 @@ let b = _input.read_byte()?;
 if b == 208 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7279615132236188739u64));
+return Err(ParseError::ExcludedBranch(16954835414833850385u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29388,7 +29101,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17636172564439370608u64));
+return Err(ParseError::ExcludedBranch(1891774877762105457u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29396,7 +29109,7 @@ let b = _input.read_byte()?;
 if b == 209 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13863787293436782080u64));
+return Err(ParseError::ExcludedBranch(13705211812356460160u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29408,7 +29121,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16714498072262546943u64));
+return Err(ParseError::ExcludedBranch(5515497093089591991u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29416,7 +29129,7 @@ let b = _input.read_byte()?;
 if b == 210 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2157707350523277837u64));
+return Err(ParseError::ExcludedBranch(1328880024623199753u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29428,7 +29141,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15134222038433106385u64));
+return Err(ParseError::ExcludedBranch(6882184431082022206u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29436,7 +29149,7 @@ let b = _input.read_byte()?;
 if b == 211 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14950271805613481359u64));
+return Err(ParseError::ExcludedBranch(3998072683184925592u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29448,7 +29161,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5499566165243611472u64));
+return Err(ParseError::ExcludedBranch(29850628954056690u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29456,7 +29169,7 @@ let b = _input.read_byte()?;
 if b == 212 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11265176092564100083u64));
+return Err(ParseError::ExcludedBranch(7279615132236188739u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29468,7 +29181,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14916894554939814670u64));
+return Err(ParseError::ExcludedBranch(17636172564439370608u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29476,7 +29189,7 @@ let b = _input.read_byte()?;
 if b == 213 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10473830801714814973u64));
+return Err(ParseError::ExcludedBranch(13863787293436782080u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29488,7 +29201,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5334325531610156978u64));
+return Err(ParseError::ExcludedBranch(16714498072262546943u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29496,7 +29209,7 @@ let b = _input.read_byte()?;
 if b == 214 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16975008930446149745u64));
+return Err(ParseError::ExcludedBranch(2157707350523277837u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29508,7 +29221,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(760820951392925727u64));
+return Err(ParseError::ExcludedBranch(15134222038433106385u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29516,7 +29229,7 @@ let b = _input.read_byte()?;
 if b == 215 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14363790737598139216u64));
+return Err(ParseError::ExcludedBranch(14950271805613481359u64));
 }
 }))())?;
 PResult::Ok(jpeg_eoi { ff, marker })
@@ -29528,7 +29241,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok((x >= 1u8) && (x <= 4u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4600414761378562541u64));
+return Err(ParseError::FalsifiedWhere(5499566165243611472u64));
 }
 }))())?;
 let image_components = ((|| PResult::Ok({
@@ -29543,7 +29256,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x <= 63u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18313399323903636110u64));
+return Err(ParseError::FalsifiedWhere(11265176092564100083u64));
 }
 }))())?;
 let end_spectral_selection = ((|| PResult::Ok({
@@ -29551,7 +29264,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x <= 63u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15786118691017431738u64));
+return Err(ParseError::FalsifiedWhere(14916894554939814670u64));
 }
 }))())?;
 let approximation_bit_position = ((|| PResult::Ok({
@@ -29577,7 +29290,7 @@ b
 if ((|entropy_coding_table_ids: jpeg_sos_image_component_entropy_coding_table_ids| PResult::Ok((entropy_coding_table_ids.dc_entropy_coding_table_id.clone() <= 3u8) && (entropy_coding_table_ids.ac_entropy_coding_table_id.clone() <= 3u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16165934354425559621u64));
+return Err(ParseError::FalsifiedWhere(10473830801714814973u64));
 }
 }))())?;
 PResult::Ok(jpeg_sos_image_component { component_selector, entropy_coding_table_ids })
@@ -29589,7 +29302,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16399036514137665776u64));
+return Err(ParseError::FalsifiedWhere(5334325531610156978u64));
 }
 }))())?;
 PResult::Ok(jpeg_dnl_data { num_lines })
@@ -29744,13 +29457,13 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8584109755265226714u64));
+return Err(ParseError::ExcludedBranch(4600414761378562541u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8076978189295213982u64));
+return Err(ParseError::ExcludedBranch(18313399323903636110u64));
 }
 };
 _input.close_peek_context()?;
@@ -29808,13 +29521,13 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7931358881575056193u64));
+return Err(ParseError::ExcludedBranch(16975008930446149745u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17863486658382945784u64));
+return Err(ParseError::ExcludedBranch(760820951392925727u64));
 }
 };
 _input.close_peek_context()?;
@@ -29868,7 +29581,7 @@ jpeg_scan_data_scan_data::rst7(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11515797873012483658u64));
+return Err(ParseError::ExcludedBranch(14363790737598139216u64));
 }
 }
 };
@@ -29926,7 +29639,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11570281271401624317u64));
+return Err(ParseError::ExcludedBranch(15786118691017431738u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29934,14 +29647,14 @@ let b = _input.read_byte()?;
 if b == 192 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14687724984806605719u64));
+return Err(ParseError::ExcludedBranch(16165934354425559621u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1453530207670075215u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 11988854374464943326u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29957,7 +29670,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1378805635639824117u64));
+return Err(ParseError::ExcludedBranch(16399036514137665776u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29965,14 +29678,14 @@ let b = _input.read_byte()?;
 if b == 193 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8385173961957899741u64));
+return Err(ParseError::ExcludedBranch(7931358881575056193u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15915510438164744429u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7620281735474506525u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -29988,7 +29701,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8407356061009412694u64));
+return Err(ParseError::ExcludedBranch(17863486658382945784u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -29996,14 +29709,14 @@ let b = _input.read_byte()?;
 if b == 194 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6881565717664829242u64));
+return Err(ParseError::ExcludedBranch(11515797873012483658u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1542992798780655146u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 11599300513837427027u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30019,7 +29732,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13752480002470540422u64));
+return Err(ParseError::ExcludedBranch(8584109755265226714u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30027,14 +29740,14 @@ let b = _input.read_byte()?;
 if b == 195 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17107648091243309207u64));
+return Err(ParseError::ExcludedBranch(8076978189295213982u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 7028560493922100069u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 950046280632689001u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30050,7 +29763,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5534609128357633386u64));
+return Err(ParseError::ExcludedBranch(11570281271401624317u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30058,14 +29771,14 @@ let b = _input.read_byte()?;
 if b == 197 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14539762430836305896u64));
+return Err(ParseError::ExcludedBranch(14687724984806605719u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 2649783168072194737u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5625702265340316943u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30081,7 +29794,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16625761205375889740u64));
+return Err(ParseError::ExcludedBranch(1378805635639824117u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30089,14 +29802,14 @@ let b = _input.read_byte()?;
 if b == 198 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2662265345698212949u64));
+return Err(ParseError::ExcludedBranch(8385173961957899741u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 8253205784254894771u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 4260205764162136487u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30112,7 +29825,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3344648651879382526u64));
+return Err(ParseError::ExcludedBranch(8407356061009412694u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30120,14 +29833,14 @@ let b = _input.read_byte()?;
 if b == 199 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8599210436172030522u64));
+return Err(ParseError::ExcludedBranch(6881565717664829242u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1225514472166157741u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5712308626808297759u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30143,7 +29856,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3484767027554133518u64));
+return Err(ParseError::ExcludedBranch(13752480002470540422u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30151,14 +29864,14 @@ let b = _input.read_byte()?;
 if b == 201 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15403934492100194569u64));
+return Err(ParseError::ExcludedBranch(17107648091243309207u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 1224415506115142500u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 8638089167112501923u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30174,7 +29887,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12041148194529633639u64));
+return Err(ParseError::ExcludedBranch(5534609128357633386u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30182,14 +29895,14 @@ let b = _input.read_byte()?;
 if b == 202 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2288772415159374970u64));
+return Err(ParseError::ExcludedBranch(14539762430836305896u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 16859485491091215361u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1453530207670075215u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30205,7 +29918,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17888323854924040413u64));
+return Err(ParseError::ExcludedBranch(16625761205375889740u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30213,14 +29926,14 @@ let b = _input.read_byte()?;
 if b == 203 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6279087434444973374u64));
+return Err(ParseError::ExcludedBranch(2662265345698212949u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 14898840355839773829u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15915510438164744429u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30236,7 +29949,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11074951631636946051u64));
+return Err(ParseError::ExcludedBranch(3344648651879382526u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30244,14 +29957,14 @@ let b = _input.read_byte()?;
 if b == 205 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15601622509425384091u64));
+return Err(ParseError::ExcludedBranch(8599210436172030522u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 9453951600195794313u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1542992798780655146u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30267,7 +29980,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13675295148592556047u64));
+return Err(ParseError::ExcludedBranch(3484767027554133518u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30275,14 +29988,14 @@ let b = _input.read_byte()?;
 if b == 206 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4569970360394099475u64));
+return Err(ParseError::ExcludedBranch(15403934492100194569u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10036157788440812915u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7028560493922100069u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30298,7 +30011,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9110520999974091875u64));
+return Err(ParseError::ExcludedBranch(12041148194529633639u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30306,14 +30019,14 @@ let b = _input.read_byte()?;
 if b == 207 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15293691521783146694u64));
+return Err(ParseError::ExcludedBranch(2288772415159374970u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 6349531732377484771u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 2649783168072194737u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_sof_data(_input))?))())?;
 _input.end_slice()?;
@@ -30328,7 +30041,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok((x >= 2u8) && (x <= 16u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15433822888775103886u64));
+return Err(ParseError::FalsifiedWhere(17888323854924040413u64));
 }
 }))())?;
 let num_lines = ((|| PResult::Ok((Decoder23(_input))?))())?;
@@ -30337,7 +30050,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8403192837054512577u64));
+return Err(ParseError::FalsifiedWhere(6279087434444973374u64));
 }
 }))())?;
 let num_image_components = ((|| PResult::Ok({
@@ -30345,7 +30058,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x != 0u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17073037115051226650u64));
+return Err(ParseError::FalsifiedWhere(11074951631636946051u64));
 }
 }))())?;
 let image_components = ((|| PResult::Ok({
@@ -30372,7 +30085,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x <= 3u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3975307768385535064u64));
+return Err(ParseError::FalsifiedWhere(15601622509425384091u64));
 }
 }))())?;
 PResult::Ok(jpeg_sof_image_component { id, sampling_factor, quantization_table_id })
@@ -30385,7 +30098,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10599514554463239458u64));
+return Err(ParseError::ExcludedBranch(13675295148592556047u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30393,14 +30106,14 @@ let b = _input.read_byte()?;
 if b == 219 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16112061863928357291u64));
+return Err(ParseError::ExcludedBranch(4569970360394099475u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 13785646910930464515u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 8253205784254894771u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30440,7 +30153,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12017601628070515145u64));
+return Err(ParseError::ExcludedBranch(9110520999974091875u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30448,14 +30161,14 @@ let b = _input.read_byte()?;
 if b == 196 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1872233699568519226u64));
+return Err(ParseError::ExcludedBranch(15293691521783146694u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5323644471994966730u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1225514472166157741u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dht_data(_input))?))())?;
 _input.end_slice()?;
@@ -30471,7 +30184,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10708294527730390829u64));
+return Err(ParseError::ExcludedBranch(15433822888775103886u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30479,14 +30192,14 @@ let b = _input.read_byte()?;
 if b == 204 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7432469293302627017u64));
+return Err(ParseError::ExcludedBranch(8403192837054512577u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 13278122992382147879u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 1224415506115142500u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dac_data(_input))?))())?;
 _input.end_slice()?;
@@ -30502,7 +30215,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13181260675040079306u64));
+return Err(ParseError::ExcludedBranch(17073037115051226650u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30510,14 +30223,14 @@ let b = _input.read_byte()?;
 if b == 221 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9159119361499271180u64));
+return Err(ParseError::ExcludedBranch(3975307768385535064u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 18159646757349796721u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 16859485491091215361u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok((Decoder_jpeg_dri_data(_input))?))())?;
 _input.end_slice()?;
@@ -30533,7 +30246,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7795160901559545235u64));
+return Err(ParseError::ExcludedBranch(10599514554463239458u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30541,14 +30254,14 @@ let b = _input.read_byte()?;
 if b == 226 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3490919313637905107u64));
+return Err(ParseError::ExcludedBranch(16112061863928357291u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 7124606020426797957u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 14898840355839773829u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30584,7 +30297,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9331389203258424019u64));
+return Err(ParseError::ExcludedBranch(12017601628070515145u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30592,14 +30305,14 @@ let b = _input.read_byte()?;
 if b == 227 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16679512278832019969u64));
+return Err(ParseError::ExcludedBranch(1872233699568519226u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15116592996336247086u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 9453951600195794313u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30635,7 +30348,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15311158871930328757u64));
+return Err(ParseError::ExcludedBranch(10708294527730390829u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30643,14 +30356,14 @@ let b = _input.read_byte()?;
 if b == 228 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9892894478446917378u64));
+return Err(ParseError::ExcludedBranch(7432469293302627017u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10346499338674982396u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10036157788440812915u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30686,7 +30399,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3585635225240718191u64));
+return Err(ParseError::ExcludedBranch(13181260675040079306u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30694,14 +30407,14 @@ let b = _input.read_byte()?;
 if b == 229 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5208404121666294786u64));
+return Err(ParseError::ExcludedBranch(9159119361499271180u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10951432197815892834u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 6349531732377484771u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30737,7 +30450,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(237665900562449517u64));
+return Err(ParseError::ExcludedBranch(7795160901559545235u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30745,14 +30458,14 @@ let b = _input.read_byte()?;
 if b == 230 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13751590285972774894u64));
+return Err(ParseError::ExcludedBranch(3490919313637905107u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 14864597187136898256u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 13785646910930464515u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30788,7 +30501,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12552648416444111338u64));
+return Err(ParseError::ExcludedBranch(9331389203258424019u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30796,14 +30509,14 @@ let b = _input.read_byte()?;
 if b == 231 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9201081899504003615u64));
+return Err(ParseError::ExcludedBranch(16679512278832019969u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 15238960955167157760u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 5323644471994966730u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30839,7 +30552,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10776065777346510440u64));
+return Err(ParseError::ExcludedBranch(15311158871930328757u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30847,14 +30560,14 @@ let b = _input.read_byte()?;
 if b == 232 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1821331332215525359u64));
+return Err(ParseError::ExcludedBranch(9892894478446917378u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 17527274083228188873u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 13278122992382147879u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30890,7 +30603,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1550574349011231204u64));
+return Err(ParseError::ExcludedBranch(3585635225240718191u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30898,14 +30611,14 @@ let b = _input.read_byte()?;
 if b == 233 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6867774794241173436u64));
+return Err(ParseError::ExcludedBranch(5208404121666294786u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 17855530393917176367u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 18159646757349796721u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30941,7 +30654,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3475686103639625566u64));
+return Err(ParseError::ExcludedBranch(237665900562449517u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -30949,14 +30662,14 @@ let b = _input.read_byte()?;
 if b == 234 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4130856500275801127u64));
+return Err(ParseError::ExcludedBranch(13751590285972774894u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 11054356281452530428u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 7124606020426797957u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -30992,7 +30705,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11582380281701370059u64));
+return Err(ParseError::ExcludedBranch(12552648416444111338u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31000,14 +30713,14 @@ let b = _input.read_byte()?;
 if b == 235 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7228157205966134869u64));
+return Err(ParseError::ExcludedBranch(9201081899504003615u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 17406968167054271466u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15116592996336247086u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31043,7 +30756,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2184161105566707760u64));
+return Err(ParseError::ExcludedBranch(10776065777346510440u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31051,14 +30764,14 @@ let b = _input.read_byte()?;
 if b == 236 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9924059786910440358u64));
+return Err(ParseError::ExcludedBranch(1821331332215525359u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 11100042044514704042u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10346499338674982396u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31094,7 +30807,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7274029685341305701u64));
+return Err(ParseError::ExcludedBranch(1550574349011231204u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31102,14 +30815,14 @@ let b = _input.read_byte()?;
 if b == 237 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16051783775494465147u64));
+return Err(ParseError::ExcludedBranch(6867774794241173436u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 5409189036752851054u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 10951432197815892834u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31145,7 +30858,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13744164271564421708u64));
+return Err(ParseError::ExcludedBranch(3475686103639625566u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31153,14 +30866,14 @@ let b = _input.read_byte()?;
 if b == 238 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5892114170581446733u64));
+return Err(ParseError::ExcludedBranch(4130856500275801127u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 4726315105662630465u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 14864597187136898256u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31196,7 +30909,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11821813774070801620u64));
+return Err(ParseError::ExcludedBranch(11582380281701370059u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31204,14 +30917,14 @@ let b = _input.read_byte()?;
 if b == 239 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14520503729026832983u64));
+return Err(ParseError::ExcludedBranch(7228157205966134869u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 10036638040555853769u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 15238960955167157760u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31247,7 +30960,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5309491469191307378u64));
+return Err(ParseError::ExcludedBranch(2184161105566707760u64));
 }
 }))())?;
 let marker = ((|| PResult::Ok({
@@ -31255,14 +30968,14 @@ let b = _input.read_byte()?;
 if b == 254 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17983075411320920965u64));
+return Err(ParseError::ExcludedBranch(9924059786910440358u64));
 }
 }))())?;
 jpeg_eoi { ff, marker }
 }))())?;
 let length = ((|| PResult::Ok((Decoder23(_input))?))())?;
 let data = ((|| PResult::Ok({
-let sz = (try_sub!(length, 2u16, 13230337088401352826u64)) as usize<>;
+let sz = (try_sub!(length, 2u16, 17527274083228188873u64)) as usize<>;
 _input.start_slice(sz)?;
 let ret = ((|| PResult::Ok({
 let mut accum = Vec::new();
@@ -31308,7 +31021,7 @@ b
 if ((|class_table_id: jpeg_dac_data_class_table_id| PResult::Ok((class_table_id.class.clone() < 2u8) && (class_table_id.table_id.clone() < 4u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7023661717588102849u64));
+return Err(ParseError::FalsifiedWhere(7274029685341305701u64));
 }
 }))())?;
 let value = ((|| PResult::Ok((Decoder24(_input))?))())?;
@@ -31327,7 +31040,7 @@ b
 if ((|class_table_id: jpeg_dac_data_class_table_id| PResult::Ok((class_table_id.class.clone() < 2u8) && (class_table_id.table_id.clone() < 4u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3448575031819686448u64));
+return Err(ParseError::FalsifiedWhere(16051783775494465147u64));
 }
 }))())?;
 let num_codes = ((|| PResult::Ok({
@@ -31365,7 +31078,7 @@ b
 if ((|precision_table_id: jpeg_dqt_data_precision_table_id| PResult::Ok((precision_table_id.precision.clone() <= 1u8) && (precision_table_id.table_id.clone() <= 3u8)))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9960855096836829935u64));
+return Err(ParseError::FalsifiedWhere(13744164271564421708u64));
 }
 }))())?;
 let elements = ((|| PResult::Ok(match precision_table_id.precision.clone() {
@@ -31457,7 +31170,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(18357658168615546095u64));
+return Err(ParseError::ExcludedBranch(11821813774070801620u64));
 }
 };
 _input.close_peek_context()?;
@@ -31470,7 +31183,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(218475477370319322u64));
+return Err(ParseError::ExcludedBranch(5892114170581446733u64));
 }
 };
 accum.push(next_elem);
@@ -31485,7 +31198,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10650412753233146525u64));
+return Err(ParseError::ExcludedBranch(14520503729026832983u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -31497,7 +31210,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15859964085544252343u64));
+return Err(ParseError::ExcludedBranch(5309491469191307378u64));
 }
 }))())?;
 let exif = ((|| PResult::Ok((Decoder_tiff_main(_input))?))())?;
@@ -31583,7 +31296,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3349032559334020401u64));
+return Err(ParseError::ExcludedBranch(7023661717588102849u64));
 }
 };
 _input.close_peek_context()?;
@@ -31596,7 +31309,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(653325817133119558u64));
+return Err(ParseError::ExcludedBranch(17983075411320920965u64));
 }
 };
 accum.push(next_elem);
@@ -31611,7 +31324,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14115009527471272688u64));
+return Err(ParseError::ExcludedBranch(3448575031819686448u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -31625,7 +31338,7 @@ let inner = (Decoder24(_input))?;
 if ((|x: u8| PResult::Ok(x <= 2u8))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8350850950759220429u64));
+return Err(ParseError::FalsifiedWhere(9960855096836829935u64));
 }
 }))())?;
 let density_x = ((|| PResult::Ok({
@@ -31633,7 +31346,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15412400192383838763u64));
+return Err(ParseError::FalsifiedWhere(218475477370319322u64));
 }
 }))())?;
 let density_y = ((|| PResult::Ok({
@@ -31641,7 +31354,7 @@ let inner = (Decoder23(_input))?;
 if ((|x: u16| PResult::Ok(x != 0u16))(inner.clone()))? {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16334217566159141080u64));
+return Err(ParseError::FalsifiedWhere(18357658168615546095u64));
 }
 }))())?;
 let thumbnail_width = ((|| PResult::Ok((Decoder24(_input))?))())?;
@@ -31676,7 +31389,7 @@ let b = _input.read_byte()?;
 if b == 31 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15032955882314050195u64));
+return Err(ParseError::ExcludedBranch(10650412753233146525u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -31684,7 +31397,7 @@ let b = _input.read_byte()?;
 if b == 139 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12522857579864693834u64));
+return Err(ParseError::ExcludedBranch(15859964085544252343u64));
 }
 }))())?;
 (field0, field1)
@@ -31773,7 +31486,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17055268834995250246u64));
+return Err(ParseError::ExcludedBranch(3349032559334020401u64));
 }
 };
 _input.close_peek_context()?;
@@ -31786,7 +31499,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15286713778088114821u64));
+return Err(ParseError::ExcludedBranch(653325817133119558u64));
 }
 };
 accum.push(next_elem);
@@ -31801,7 +31514,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15014773733126201031u64));
+return Err(ParseError::ExcludedBranch(14115009527471272688u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -31825,7 +31538,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3344835778759068560u64));
+return Err(ParseError::ExcludedBranch(15412400192383838763u64));
 }
 };
 _input.close_peek_context()?;
@@ -31838,7 +31551,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9895655502210650925u64));
+return Err(ParseError::ExcludedBranch(8350850950759220429u64));
 }
 };
 accum.push(next_elem);
@@ -31853,7 +31566,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2014773054382805425u64));
+return Err(ParseError::ExcludedBranch(16334217566159141080u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -31960,7 +31673,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5117297982688264891u64));
+return Err(ParseError::ExcludedBranch(12522857579864693834u64));
 }
 };
 _input.close_peek_context()?;
@@ -31973,7 +31686,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3011460078285478248u64));
+return Err(ParseError::ExcludedBranch(15032955882314050195u64));
 }
 };
 accum.push(next_elem);
@@ -31988,7 +31701,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4614223265245060097u64));
+return Err(ParseError::ExcludedBranch(15286713778088114821u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -32012,7 +31725,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13162270726566423196u64));
+return Err(ParseError::ExcludedBranch(15014773733126201031u64));
 }
 };
 _input.close_peek_context()?;
@@ -32025,7 +31738,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2858990937242709991u64));
+return Err(ParseError::ExcludedBranch(17055268834995250246u64));
 }
 };
 accum.push(next_elem);
@@ -32040,7 +31753,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6766897041260485978u64));
+return Err(ParseError::ExcludedBranch(9895655502210650925u64));
 }
 }))())?;
 PResult::Ok(base_asciiz_string { string, null })
@@ -32053,7 +31766,7 @@ let b = _input.read_byte()?;
 if b == 71 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7359082011512182682u64));
+return Err(ParseError::ExcludedBranch(3344835778759068560u64));
 }
 }))())?;
 let field1 = ((|| PResult::Ok({
@@ -32061,7 +31774,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4005260763079064488u64));
+return Err(ParseError::ExcludedBranch(2014773054382805425u64));
 }
 }))())?;
 let field2 = ((|| PResult::Ok({
@@ -32069,7 +31782,7 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9895427541506148364u64));
+return Err(ParseError::ExcludedBranch(3011460078285478248u64));
 }
 }))())?;
 (field0, field1, field2)
@@ -32124,7 +31837,7 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15241527188218394569u64));
+return Err(ParseError::ExcludedBranch(5117297982688264891u64));
 }
 }
 },
@@ -32134,7 +31847,7 @@ return Err(ParseError::ExcludedBranch(15241527188218394569u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5019692195244899787u64));
+return Err(ParseError::ExcludedBranch(4614223265245060097u64));
 }
 };
 _input.close_peek_context()?;
@@ -32153,7 +31866,7 @@ gif_block::special_purpose_block(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(663652071640520941u64));
+return Err(ParseError::ExcludedBranch(2858990937242709991u64));
 }
 })
 }
@@ -32164,7 +31877,7 @@ let b = _input.read_byte()?;
 if b == 59 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16835260701216065402u64));
+return Err(ParseError::ExcludedBranch(13162270726566423196u64));
 }
 }))())?;
 PResult::Ok(gif_trailer { separator })
@@ -32189,7 +31902,7 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4248622096514297129u64));
+return Err(ParseError::ExcludedBranch(6766897041260485978u64));
 }
 }
 },
@@ -32199,7 +31912,7 @@ return Err(ParseError::ExcludedBranch(4248622096514297129u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(18304605036866855350u64));
+return Err(ParseError::ExcludedBranch(7359082011512182682u64));
 }
 };
 _input.close_peek_context()?;
@@ -32217,7 +31930,7 @@ gif_graphic_block_graphic_control_extension::none
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(49400955721755355u64));
+return Err(ParseError::ExcludedBranch(4005260763079064488u64));
 }
 }
 }))())?;
@@ -32242,11 +31955,11 @@ match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8882217996184815919u64));
+return Err(ParseError::ExcludedBranch(9895427541506148364u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(11885930557202460461u64));
+return Err(ParseError::ExcludedBranch(15241527188218394569u64));
 };
 _input.close_peek_context()?;
 ret
@@ -32264,7 +31977,7 @@ gif_special_purpose_block::comment_extension(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9841369023026740320u64));
+return Err(ParseError::ExcludedBranch(5019692195244899787u64));
 }
 })
 }
@@ -32275,7 +31988,7 @@ let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15065685669539080124u64));
+return Err(ParseError::ExcludedBranch(663652071640520941u64));
 }
 }))())?;
 let label = ((|| PResult::Ok({
@@ -32283,7 +31996,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4896351207164742422u64));
+return Err(ParseError::ExcludedBranch(16835260701216065402u64));
 }
 }))())?;
 let block_size = ((|| PResult::Ok({
@@ -32291,7 +32004,7 @@ let b = _input.read_byte()?;
 if b == 11 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12845528861092334564u64));
+return Err(ParseError::ExcludedBranch(4248622096514297129u64));
 }
 }))())?;
 let identifier = ((|| PResult::Ok({
@@ -32325,7 +32038,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8497774971318424699u64));
+return Err(ParseError::ExcludedBranch(18304605036866855350u64));
 }
 };
 _input.close_peek_context()?;
@@ -32351,7 +32064,7 @@ let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13677998342346693652u64));
+return Err(ParseError::ExcludedBranch(49400955721755355u64));
 }
 }))())?;
 let label = ((|| PResult::Ok({
@@ -32359,7 +32072,7 @@ let b = _input.read_byte()?;
 if b == 254 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18442161777584514946u64));
+return Err(ParseError::ExcludedBranch(8882217996184815919u64));
 }
 }))())?;
 let comment_data = ((|| PResult::Ok({
@@ -32379,7 +32092,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2668737607901180946u64));
+return Err(ParseError::ExcludedBranch(11885930557202460461u64));
 }
 };
 _input.close_peek_context()?;
@@ -32405,7 +32118,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12828788577937869717u64));
+return Err(ParseError::ExcludedBranch(9841369023026740320u64));
 }
 }))())?;
 let data = ((|| PResult::Ok({
@@ -32423,7 +32136,7 @@ let b = _input.read_byte()?;
 PResult::Ok(if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4528919599938425798u64));
+return Err(ParseError::ExcludedBranch(15065685669539080124u64));
 })
 }
 
@@ -32433,7 +32146,7 @@ let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12955185663715491460u64));
+return Err(ParseError::ExcludedBranch(4896351207164742422u64));
 }
 }))())?;
 let label = ((|| PResult::Ok({
@@ -32441,7 +32154,7 @@ let b = _input.read_byte()?;
 if b == 249 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6221053009072016381u64));
+return Err(ParseError::ExcludedBranch(12845528861092334564u64));
 }
 }))())?;
 let block_size = ((|| PResult::Ok({
@@ -32449,7 +32162,7 @@ let b = _input.read_byte()?;
 if b == 4 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4825757476091239776u64));
+return Err(ParseError::ExcludedBranch(8497774971318424699u64));
 }
 }))())?;
 let flags = ((|| PResult::Ok({
@@ -32480,7 +32193,7 @@ let ret = match b {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13877876706306354357u64));
+return Err(ParseError::ExcludedBranch(13677998342346693652u64));
 }
 };
 _input.close_peek_context()?;
@@ -32499,7 +32212,7 @@ gif_graphic_rendering_block::plain_text_extension(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12525311251009778949u64));
+return Err(ParseError::ExcludedBranch(18442161777584514946u64));
 }
 })
 }
@@ -32525,7 +32238,7 @@ let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14962551735998681614u64));
+return Err(ParseError::ExcludedBranch(2668737607901180946u64));
 }
 }))())?;
 let label = ((|| PResult::Ok({
@@ -32533,7 +32246,7 @@ let b = _input.read_byte()?;
 if b == 1 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2007599397777734421u64));
+return Err(ParseError::ExcludedBranch(12828788577937869717u64));
 }
 }))())?;
 let block_size = ((|| PResult::Ok({
@@ -32541,7 +32254,7 @@ let b = _input.read_byte()?;
 if b == 12 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18069850277258932991u64));
+return Err(ParseError::ExcludedBranch(4528919599938425798u64));
 }
 }))())?;
 let text_grid_left_position = ((|| PResult::Ok((Decoder139(_input))?))())?;
@@ -32569,7 +32282,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(180881308211696508u64));
+return Err(ParseError::ExcludedBranch(12955185663715491460u64));
 }
 };
 _input.close_peek_context()?;
@@ -32595,7 +32308,7 @@ let b = _input.read_byte()?;
 if b == 44 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17753230141940491005u64));
+return Err(ParseError::ExcludedBranch(6221053009072016381u64));
 }
 }))())?;
 let image_left_position = ((|| PResult::Ok((Decoder139(_input))?))())?;
@@ -32638,7 +32351,7 @@ tmp if (tmp != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6110942357212830202u64));
+return Err(ParseError::ExcludedBranch(4825757476091239776u64));
 }
 };
 _input.close_peek_context()?;
@@ -32748,55 +32461,55 @@ match b {
 },
 
 _ => {
+return Err(ParseError::ExcludedBranch(12525311251009778949u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14962551735998681614u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2007599397777734421u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18069850277258932991u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(180881308211696508u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17753230141940491005u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6110942357212830202u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6596410053543851077u64));
+}
+}
+},
+
+_ => {
 return Err(ParseError::ExcludedBranch(16339654162669176472u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1886358831178290550u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17004441093219507547u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3168197157646945762u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(360138127928998237u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9092411637461100444u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15117497265985508077u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11247369915737850258u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7546547171508918509u64));
 }
 };
 _input.close_peek_context()?;
@@ -32811,7 +32524,7 @@ let b = _input.read_byte()?;
 if b == 83 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6596410053543851077u64));
+return Err(ParseError::ExcludedBranch(13877876706306354357u64));
 }
 };
 accum.push(next_elem);
@@ -32824,7 +32537,7 @@ let b = _input.read_byte()?;
 if b == 90 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14304129837244038526u64));
+return Err(ParseError::ExcludedBranch(1886358831178290550u64));
 }
 }))())?;
 (field0, field1)

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -5602,7 +5602,7 @@ PResult::Ok(opentype_table_record { table_id, checksum, offset, length })
 }
 
 fn Decoder_opentype_table_directory_table_links<'input>(_input: &mut Parser<'input>, start: u32, tables: &Vec<opentype_table_record>) -> Result<opentype_table_directory_table_links, ParseError> {
-let cmap = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668112752u32, tables)).cloned() {
+let cmap = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668112752u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5621,7 +5621,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let head = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751474532u32, tables)).cloned() {
+let head = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751474532u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5640,7 +5640,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let hhea = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751672161u32, tables)).cloned() {
+let hhea = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1751672161u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5659,7 +5659,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let maxp = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1835104368u32, tables)).cloned() {
+let maxp = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1835104368u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5678,7 +5678,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let hmtx = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1752003704u32, tables)).cloned() {
+let hmtx = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1752003704u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5697,7 +5697,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let name = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1851878757u32, tables)).cloned() {
+let name = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1851878757u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5716,7 +5716,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let os2 = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1330851634u32, tables)).cloned() {
+let os2 = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1330851634u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5736,7 +5736,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let post = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886352244u32, tables)).cloned() {
+let post = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886352244u32, tables)).cloned() {
 Some(ref matching_table) => {
 let tgt_offset = start + matching_table.offset.clone();
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
@@ -5755,7 +5755,7 @@ _other => {
 unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?}"#);
 }
 }))())?;
-let cvt = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668707360u32, tables)).cloned() {
+let cvt = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1668707360u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5797,7 +5797,7 @@ None => {
 None
 }
 }))())?;
-let fpgm = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1718642541u32, tables)).cloned() {
+let fpgm = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1718642541u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5839,7 +5839,7 @@ None => {
 None
 }
 }))())?;
-let loca = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1819239265u32, tables)).cloned() {
+let loca = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1819239265u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5861,7 +5861,7 @@ None => {
 None
 }
 }))())?;
-let glyf = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735162214u32, tables)).cloned() {
+let glyf = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735162214u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5891,7 +5891,7 @@ None => {
 None
 }
 }))())?;
-let prep = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886545264u32, tables)).cloned() {
+let prep = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1886545264u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5933,7 +5933,7 @@ None => {
 None
 }
 }))())?;
-let gasp = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1734439792u32, tables)).cloned() {
+let gasp = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1734439792u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5955,7 +5955,7 @@ None => {
 None
 }
 }))())?;
-let base = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1111577413u32, tables)).cloned() {
+let base = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1111577413u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5977,7 +5977,7 @@ None => {
 None
 }
 }))())?;
-let gdef = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1195656518u32, tables)).cloned() {
+let gdef = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1195656518u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -5999,7 +5999,7 @@ None => {
 None
 }
 }))())?;
-let gpos = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196445523u32, tables)).cloned() {
+let gpos = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196445523u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6021,7 +6021,7 @@ None => {
 None
 }
 }))())?;
-let gsub = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196643650u32, tables)).cloned() {
+let gsub = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1196643650u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6043,7 +6043,7 @@ None => {
 None
 }
 }))())?;
-let fvar = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1719034226u32, tables)).cloned() {
+let fvar = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1719034226u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6065,7 +6065,7 @@ None => {
 None
 }
 }))())?;
-let gvar = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735811442u32, tables)).cloned() {
+let gvar = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1735811442u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6087,7 +6087,7 @@ None => {
 None
 }
 }))())?;
-let kern = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1801810542u32, tables)).cloned() {
+let kern = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1801810542u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6109,7 +6109,7 @@ None => {
 None
 }
 }))())?;
-let stat = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1398030676u32, tables)).cloned() {
+let stat = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1398030676u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6131,7 +6131,7 @@ None => {
 None
 }
 }))())?;
-let vhea = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986553185u32, tables)).cloned() {
+let vhea = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986553185u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();
@@ -6153,7 +6153,7 @@ None => {
 None
 }
 }))())?;
-let vmtx = ((|| PResult::Ok(match (find_by_key_sorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986884728u32, tables)).cloned() {
+let vmtx = ((|| PResult::Ok(match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id.clone(), 1986884728u32, tables)).cloned() {
 Some(ref table) => {
 let inner = {
 let tgt_offset = start + table.offset.clone();

--- a/src/codegen/rust_ast.rs
+++ b/src/codegen/rust_ast.rs
@@ -1298,7 +1298,9 @@ impl RustClosure {
         )
     }
 
-    /// Constructs a new closure with 'predicate' (ref) semantics.
+    /// Constructs a new closure with 'predicate' (ref-bound argument) semantics.
+    ///
+    /// Also applies to extract-key semantics `(&T) -> K where K: Copy`
     pub fn new_predicate(
         head: impl IntoLabel,
         deref_t: Option<RustType>,

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -682,8 +682,13 @@ impl<TypeRep> TypedExpr<TypeRep> {
 }
 
 impl TypedExpr<GenType> {
+    /// Returns the `GenType` associated with `self`.
+    ///
+    /// Returns `None` if and only if `self` is `TypedExpr::Lambda`.
     pub(crate) fn get_type(&self) -> Option<Cow<'_, GenType>> {
         match self {
+            TypedExpr::Lambda(..) => None,
+
             TypedExpr::Bool(_) => Some(Cow::Owned(GenType::from(PrimType::Bool))),
             TypedExpr::AsU8(_) | TypedExpr::U8(_) => Some(Cow::Owned(GenType::from(PrimType::U8))),
             TypedExpr::U16Le(_) | TypedExpr::U16Be(_) | TypedExpr::AsU16(_) | TypedExpr::U16(_) => {
@@ -698,7 +703,6 @@ impl TypedExpr<GenType> {
                 Some(Cow::Owned(GenType::from(PrimType::U64)))
             }
             TypedExpr::AsChar(_) => Some(Cow::Owned(GenType::from(PrimType::Char))),
-            TypedExpr::Lambda(..) => None,
             TypedExpr::Var(gt, ..)
             | TypedExpr::Tuple(gt, ..)
             | TypedExpr::TupleProj(gt, ..)

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -543,6 +543,13 @@ pub enum TypedExpr<TypeRep> {
         TypeHint,
         Box<TypedExpr<TypeRep>>,
     ),
+    FindByKey(
+        TypeRep,
+        bool,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedExpr<TypeRep>>,
+        Box<TypedExpr<TypeRep>>,
+    ),
     FlatMapList(
         TypeRep,
         Box<TypedExpr<TypeRep>>,
@@ -637,6 +644,12 @@ impl<TypeRep> std::hash::Hash for TypedExpr<TypeRep> {
                 acc.hash(state);
                 seq.hash(state);
             }
+            TypedExpr::FindByKey(_, is_sorted, f, key, seq) => {
+                is_sorted.hash(state);
+                f.hash(state);
+                key.hash(state);
+                seq.hash(state);
+            }
             TypedExpr::FlatMapList(_, f, _vt, seq) => {
                 f.hash(state);
                 seq.hash(state);
@@ -703,6 +716,7 @@ impl TypedExpr<GenType> {
             | TypedExpr::FlatMap(gt, ..)
             | TypedExpr::FlatMapAccum(gt, ..)
             | TypedExpr::LeftFold(gt, ..)
+            | TypedExpr::FindByKey(gt, ..)
             | TypedExpr::FlatMapList(gt, ..)
             | TypedExpr::LiftOption(gt, ..)
             | TypedExpr::Dup(gt, ..)
@@ -877,6 +891,9 @@ mod __impls {
                 }
                 TypedExpr::LeftFold(_, lambda, acc, vt, seq) => {
                     Expr::LeftFold(rebox(lambda), rebox(acc), vt, rebox(seq))
+                }
+                TypedExpr::FindByKey(_, is_sorted, lambda, key, seq) => {
+                    Expr::FindByKey(is_sorted, rebox(lambda), rebox(key), rebox(seq))
                 }
                 TypedExpr::FlatMapList(_, lambda, vt, seq) => {
                     Expr::FlatMapList(rebox(lambda), vt, rebox(seq))

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -160,8 +160,6 @@ impl Value {
             _ => false,
         }
     }
-
-
 }
 
 impl Value {
@@ -692,23 +690,25 @@ impl Expr {
             Expr::FindByKey(is_sorted, f_get_key, query_key, seq) => match seq.eval_value(scope) {
                 Value::Seq(values) => {
                     let query = query_key.eval_value(scope);
-                    let eval = |lambda: &Expr, arg: &Value| {
-                        lambda.eval_lambda(scope, arg)
-                    };
+                    let eval = |lambda: &Expr, arg: &Value| lambda.eval_lambda(scope, arg);
                     if *is_sorted {
                         match search::find_index_by_key_sorted(f_get_key, &query, &values, eval) {
-                            Some(ix) => Cow::Owned(Value::Option(Some(Box::new(values[ix].clone())))),
+                            Some(ix) => {
+                                Cow::Owned(Value::Option(Some(Box::new(values[ix].clone()))))
+                            }
                             None => Cow::Owned(Value::Option(None)),
                         }
                     } else {
                         match search::find_index_by_key_unsorted(f_get_key, &query, &values, eval) {
-                            Some(ix) => Cow::Owned(Value::Option(Some(Box::new(values[ix].clone())))),
+                            Some(ix) => {
+                                Cow::Owned(Value::Option(Some(Box::new(values[ix].clone()))))
+                            }
                             None => Cow::Owned(Value::Option(None)),
                         }
                     }
                 }
                 _ => panic!("FindByKey: expected Seq"),
-            }
+            },
             Expr::FlatMapList(expr, _ret_type, seq) => match seq.eval_value(scope) {
                 Value::Seq(values) => {
                     let mut vs = Vec::new();

--- a/src/decoder/search.rs
+++ b/src/decoder/search.rs
@@ -1,4 +1,4 @@
-use crate::decoder::{Value, seq_kind::SeqKind};
+use crate::decoder::{seq_kind::SeqKind, Value};
 use crate::Expr;
 
 /// Helper trait to apply find_index_by_key_sorted to ParsedValue and Value generically
@@ -51,7 +51,12 @@ impl<T> KeyCache<T> {
     }
 }
 
-pub(crate) fn find_index_by_key_sorted<'a, V, V0, Eval>(f_get_key: &Expr, query: &V, values: &SeqKind<V0>, evaluate: Eval) -> Option<usize>
+pub(crate) fn find_index_by_key_sorted<'a, V, V0, Eval>(
+    f_get_key: &Expr,
+    query: &V,
+    values: &SeqKind<V0>,
+    evaluate: Eval,
+) -> Option<usize>
 where
     Eval: 'a + Fn(&Expr, &V0) -> V,
     V: AsKey,
@@ -68,9 +73,7 @@ where
     // cache to store keys we have seen after computing them once
     let cache = KeyCache::<V>::new(len);
     // helper closure to keep code below lightweight and more implementation-agnostic
-    let get_key_at_index = |ix: usize| {
-        cache.get_or_init(ix, || evaluate(f_get_key, &values[ix]))
-    };
+    let get_key_at_index = |ix: usize| cache.get_or_init(ix, || evaluate(f_get_key, &values[ix]));
 
     // check boundaries, once only, at very start
     let lower_bound = get_key_at_index(0);
@@ -96,7 +99,7 @@ where
         Ordering::Equal => return Some(last_ix),
         Ordering::Less => {
             // skip entire loop when there are no middle values
-            if len <= 2  {
+            if len <= 2 {
                 return None;
             }
         }
@@ -123,7 +126,12 @@ where
     None
 }
 
-pub(crate) fn find_index_by_key_unsorted<'a, V, V0, Eval>(f_get_key: &'a Expr, query: &V, values: &SeqKind<V0>, evaluate: Eval) -> Option<usize>
+pub(crate) fn find_index_by_key_unsorted<'a, V, V0, Eval>(
+    f_get_key: &'a Expr,
+    query: &V,
+    values: &SeqKind<V0>,
+    evaluate: Eval,
+) -> Option<usize>
 where
     Eval: 'a + Fn(&Expr, &V0) -> V,
     V: AsKey,

--- a/src/decoder/search.rs
+++ b/src/decoder/search.rs
@@ -1,0 +1,139 @@
+use crate::decoder::{Value, seq_kind::SeqKind};
+use crate::Expr;
+
+/// Helper trait to apply find_index_by_key_sorted to ParsedValue and Value generically
+pub(crate) trait AsKey {
+    /// Compares two values as keys, using natural order on the types being represented.
+    ///
+    /// Currently, only applies to strictly-numeric Value kinds (U8, etc.)
+    fn compare_as_key(&self, other: &Self) -> std::cmp::Ordering;
+
+    /// Tests equality over two values as keys, using natural equality on the types being represented.
+    ///
+    /// Currently, only applies to strictly-numeric Value kinds (U8, etc.), to mirror `compare_as_key`
+    /// (even though more complex equalities can be established on value-kinds without natural ordering).
+    fn eq_key(&self, other: &Self) -> bool;
+}
+
+impl AsKey for Value {
+    fn compare_as_key(&self, other: &Self) -> std::cmp::Ordering {
+        match (self, other) {
+            (Value::U8(a), Value::U8(b)) => a.cmp(b),
+            (Value::U16(a), Value::U16(b)) => a.cmp(b),
+            (Value::U32(a), Value::U32(b)) => a.cmp(b),
+            (Value::U64(a), Value::U64(b)) => a.cmp(b),
+            _ => panic!("Value::compare_as_key: Can't compare {self:?} and {other:?} as keys"),
+        }
+    }
+
+    fn eq_key(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Value::U8(a), Value::U8(b)) => a == b,
+            (Value::U16(a), Value::U16(b)) => a == b,
+            (Value::U32(a), Value::U32(b)) => a == b,
+            (Value::U64(a), Value::U64(b)) => a == b,
+            _ => panic!("Value::eq_key: can't compare {self:?} and {other:?} as keys"),
+        }
+    }
+}
+
+/// Helper struct to avoid evaluating key-values at the same index more than once
+pub(crate) struct KeyCache<T>(Vec<std::cell::OnceCell<T>>);
+
+impl<T> KeyCache<T> {
+    pub(crate) fn new(len: usize) -> Self {
+        let store = (0..len).map(|_| std::cell::OnceCell::new()).collect();
+        Self(store)
+    }
+
+    pub(crate) fn get_or_init(&self, index: usize, f: impl FnOnce() -> T) -> &T {
+        self.0[index].get_or_init(f)
+    }
+}
+
+pub(crate) fn find_index_by_key_sorted<'a, V, V0, Eval>(f_get_key: &Expr, query: &V, values: &SeqKind<V0>, evaluate: Eval) -> Option<usize>
+where
+    Eval: 'a + Fn(&Expr, &V0) -> V,
+    V: AsKey,
+    V0: Clone,
+{
+    use std::cmp::Ordering;
+    // If values is empty, search is trivial
+    if values.is_empty() {
+        return None;
+    }
+
+    let len = values.len();
+
+    // cache to store keys we have seen after computing them once
+    let cache = KeyCache::<V>::new(len);
+    // helper closure to keep code below lightweight and more implementation-agnostic
+    let get_key_at_index = |ix: usize| {
+        cache.get_or_init(ix, || evaluate(f_get_key, &values[ix]))
+    };
+
+    // check boundaries, once only, at very start
+    let lower_bound = get_key_at_index(0);
+
+    // don't bother evaluating upper_bound if query <= lower-bound
+    match query.compare_as_key(lower_bound) {
+        Ordering::Less => return None,
+        Ordering::Equal => return Some(0),
+        Ordering::Greater => {
+            // skip computing 'upper bound' on singleton list
+            if len <= 1 {
+                return None;
+            }
+        }
+    }
+
+    // safe because values cannot be empty
+    let last_ix = len - 1;
+    let upper_bound = get_key_at_index(last_ix);
+
+    match query.compare_as_key(&upper_bound) {
+        Ordering::Greater => return None,
+        Ordering::Equal => return Some(last_ix),
+        Ordering::Less => {
+            // skip entire loop when there are no middle values
+            if len <= 2  {
+                return None;
+            }
+        }
+    }
+
+    // binary search, after already checking edge-cases bounds
+
+    let mut lower_bound_ix = 0;
+    let mut upper_bound_ix = last_ix;
+
+    while lower_bound_ix <= upper_bound_ix {
+        // if lower_bound_ix == upper_bound_ix, this will converge to that
+        // value, and any branch below besides return, will break the loop
+        // condition
+        let mid = (lower_bound_ix + upper_bound_ix) / 2;
+
+        let mid_key = get_key_at_index(mid);
+        match query.compare_as_key(&mid_key) {
+            Ordering::Less => upper_bound_ix = mid - 1,
+            Ordering::Equal => return Some(mid),
+            Ordering::Greater => lower_bound_ix = mid + 1,
+        }
+    }
+    None
+}
+
+pub(crate) fn find_index_by_key_unsorted<'a, V, V0, Eval>(f_get_key: &'a Expr, query: &V, values: &SeqKind<V0>, evaluate: Eval) -> Option<usize>
+where
+    Eval: 'a + Fn(&Expr, &V0) -> V,
+    V: AsKey,
+    V0: Clone,
+{
+    for (ix, v) in values.iter().enumerate() {
+        let key = evaluate(f_get_key, v);
+        if query.eq_key(&key) {
+            return Some(ix);
+        }
+    }
+    None
+}

--- a/src/decoder/seq_kind.rs
+++ b/src/decoder/seq_kind.rs
@@ -141,8 +141,7 @@ impl<T: Clone> SeqKind<T> {
     }
 }
 
-impl<T: Clone> Index<usize> for SeqKind<T>
-{
+impl<T: Clone> Index<usize> for SeqKind<T> {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/decoder/seq_kind.rs
+++ b/src/decoder/seq_kind.rs
@@ -141,15 +141,13 @@ impl<T: Clone> SeqKind<T> {
     }
 }
 
-impl<T> Index<usize> for SeqKind<T>
-where
-    T: Clone + Debug,
+impl<T: Clone> Index<usize> for SeqKind<T>
 {
     type Output = T;
 
     fn index(&self, index: usize) -> &Self::Output {
         self.get(index)
-            .expect(format!("out of bounds indexing {index:?} on {self:?}").as_str())
+            .expect(format!("out of bounds indexing {index:?} (len: {})", self.len()).as_str())
     }
 }
 

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1284,3 +1284,18 @@ pub fn fmt_let(clone_varname: &'static str, orig: Expr, dep_format: Format) -> F
 pub fn enum_from_to(start: Expr, end: Expr) -> Expr {
     Expr::EnumFromTo(Box::new(start), Box::new(end))
 }
+
+/// Helper for [`Expr::FindByKey`].
+pub fn find_by_key(
+    is_sorted: bool,
+    key_fn: impl FnOnce(Expr) -> Expr,
+    query: Expr,
+    array: Expr,
+) -> Expr {
+    Expr::FindByKey(
+        is_sorted,
+        Box::new(lambda("elem", key_fn(var("elem")))),
+        Box::new(query),
+        Box::new(array),
+    )
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -477,13 +477,15 @@ impl Expr {
                         child_scope.push(name.clone(), t.as_ref().clone());
                         match expr.infer_type(&child_scope)?.unify(&key_type)? {
                             ValueType::Base(b) if b.is_numeric() => Ok(ValueType::Option(t)),
-                            other => Err(anyhow!("FindByKey: expected numeric key type, found {other:?}"))
+                            other => Err(anyhow!(
+                                "FindByKey: expected numeric key type, found {other:?}"
+                            )),
                         }
                     }
                     other => Err(anyhow!("FindByKey: expected Seq, found {other:?}")),
-                }
+                },
                 other => Err(anyhow!("FindByKey: Expected Lambda, found {other:?}")),
-            }
+            },
             Expr::FlatMapList(expr, ret_type, seq) => match expr.as_ref() {
                 Expr::Lambda(name, expr) => match seq.infer_type(scope)? {
                     ValueType::Seq(t) => {

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -1,11 +1,13 @@
 use crate::byte_set::ByteSet;
+use crate::decoder::{
+    cow_map, cow_remap, extract_pair,
+    search::{find_index_by_key_sorted, find_index_by_key_unsorted},
+    seq_kind::sub_range,
+    Compiler, Decoder, Program, ScopeEntry, SeqKind, Value, ValueSeq,
+};
 use crate::error::{DecodeError, LocDecodeError};
 use crate::read::ReadCtxt;
-use crate::decoder::{cow_map, cow_remap, extract_pair, search::{find_index_by_key_sorted, find_index_by_key_unsorted}, seq_kind::sub_range, Compiler, Decoder, Program, ScopeEntry, SeqKind, Value, ValueSeq};
-use crate::{
-    Pattern,
-    Arith, UnaryOp, IntRel, Label, DynFormat, Expr, Format,
-};
+use crate::{Arith, DynFormat, Expr, Format, IntRel, Label, Pattern, UnaryOp};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
@@ -301,13 +303,11 @@ impl ParsedValue {
             ParsedValue::Tuple(ts) => {
                 Value::Tuple(Vec::from_iter(ts.inner.iter().cloned().map(Value::from)))
             }
-            ParsedValue::Seq(seq) => {
-                match &seq.inner {
-                    SeqKind::Strict(elts) => Value::Seq(SeqKind::Strict(Vec::from_iter(
-                        elts.iter().cloned().map(Value::from),
-                    ))),
-                    SeqKind::Dup(n, v) => Value::Seq(SeqKind::Dup(*n, Box::new(v.clone_into_value()))),
-                }
+            ParsedValue::Seq(seq) => match &seq.inner {
+                SeqKind::Strict(elts) => Value::Seq(SeqKind::Strict(Vec::from_iter(
+                    elts.iter().cloned().map(Value::from),
+                ))),
+                SeqKind::Dup(n, v) => Value::Seq(SeqKind::Dup(*n, Box::new(v.clone_into_value()))),
             },
             ParsedValue::Record(fs) => Value::Record(Vec::from_iter(
                 fs.inner.iter().cloned().map(|(lab, f)| (lab, f.into())),
@@ -983,14 +983,21 @@ impl Expr {
                     _ => panic!("FlatMap: expected Seq"),
                 }
             }
-            Expr::FlatMapAccum(expr, accum, _accum_type, seq) => match seq.eval_with_loc(scope).coerce_mapped_value().get_sequence() {
+            Expr::FlatMapAccum(expr, accum, _accum_type, seq) => match seq
+                .eval_with_loc(scope)
+                .coerce_mapped_value()
+                .get_sequence()
+            {
                 Some(values) => {
                     let mut accum = accum.eval_value_with_loc(scope);
                     let mut vs = Vec::new();
                     for v in values {
                         let ret = expr.eval_lambda_with_loc(
                             scope,
-                            &ParsedValue::from_evaluated(Value::Tuple(vec![accum, v.clone_into_value()])),
+                            &ParsedValue::from_evaluated(Value::Tuple(vec![
+                                accum,
+                                v.clone_into_value(),
+                            ])),
                         );
                         accum = match extract_pair(ret.unwrap_tuple()) {
                             (accum, Value::Seq(vn)) => {
@@ -1003,41 +1010,61 @@ impl Expr {
                     Cow::Owned(ParsedValue::from_evaluated(Value::Seq(vs.into())))
                 }
                 None => panic!("FlatMapAccum: expected Seq"),
-            }
-            Expr::LeftFold(expr, accum, _accum_type, seq) => match seq.eval_with_loc(scope).coerce_mapped_value().get_sequence() {
+            },
+            Expr::LeftFold(expr, accum, _accum_type, seq) => match seq
+                .eval_with_loc(scope)
+                .coerce_mapped_value()
+                .get_sequence()
+            {
                 Some(values) => {
                     let mut accum = accum.eval_value_with_loc(scope);
                     for v in values {
                         let new_accum = expr.eval_lambda_with_loc(
                             scope,
-                            &ParsedValue::from_evaluated(Value::Tuple(vec![accum, v.clone_into_value()])),
+                            &ParsedValue::from_evaluated(Value::Tuple(vec![
+                                accum,
+                                v.clone_into_value(),
+                            ])),
                         );
                         accum = new_accum;
                     }
                     Cow::Owned(ParsedValue::from_evaluated(accum))
                 }
                 None => panic!("LeftFold: expected Seq"),
-            }
+            },
             Expr::FindByKey(is_sorted, f_get_key, query_key, seq) => {
-                match seq.eval_with_loc(scope).coerce_mapped_value().get_sequence() {
+                match seq
+                    .eval_with_loc(scope)
+                    .coerce_mapped_value()
+                    .get_sequence()
+                {
                     Some(ValueSeq::ValueSeq(values)) => {
-                        let eval = |lambda: &Expr, v: &ParsedValue| {
-                            lambda.eval_lambda_with_loc(scope, v)
-                        };
+                        let eval =
+                            |lambda: &Expr, v: &ParsedValue| lambda.eval_lambda_with_loc(scope, v);
                         let query = query_key.eval_value_with_loc(scope);
                         if *is_sorted {
                             match find_index_by_key_sorted(f_get_key, &query, &values, eval) {
-                                Some(ix) => Cow::Owned(ParsedValue::Option(Some(Box::new(values[ix].clone())))),
-                                None => Cow::Owned(ParsedValue::from_evaluated(Value::Option(None))),
+                                Some(ix) => Cow::Owned(ParsedValue::Option(Some(Box::new(
+                                    values[ix].clone(),
+                                )))),
+                                None => {
+                                    Cow::Owned(ParsedValue::from_evaluated(Value::Option(None)))
+                                }
                             }
                         } else {
                             match find_index_by_key_unsorted(f_get_key, &query, &values, eval) {
-                                Some(ix) => Cow::Owned(ParsedValue::Option(Some(Box::new(values[ix].clone())))),
-                                None => Cow::Owned(ParsedValue::from_evaluated(Value::Option(None))),
+                                Some(ix) => Cow::Owned(ParsedValue::Option(Some(Box::new(
+                                    values[ix].clone(),
+                                )))),
+                                None => {
+                                    Cow::Owned(ParsedValue::from_evaluated(Value::Option(None)))
+                                }
                             }
                         }
                     }
-                    Some(ValueSeq::IntRange(_)) => unimplemented!("FindByKey: unimplemented on IntRange"),
+                    Some(ValueSeq::IntRange(_)) => {
+                        unimplemented!("FindByKey: unimplemented on IntRange")
+                    }
                     None => panic!("FindByKey: expected Seq"),
                 }
             }

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1711,7 +1711,15 @@ impl<'module> TreePrinter<'module> {
                 Precedence::FUN_APPLICATION,
             ),
             Expr::FindByKey(is_sorted, keying_fn, query, seq) => cond_paren(
-                self.prefix_op(if *is_sorted { "binary-search" } else { "linear-search" }, Some(&[keying_fn, query]), seq),
+                self.prefix_op(
+                    if *is_sorted {
+                        "binary-search"
+                    } else {
+                        "linear-search"
+                    },
+                    Some(&[keying_fn, query]),
+                    seq,
+                ),
                 prec,
                 Precedence::FUN_APPLICATION,
             ),

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1710,6 +1710,11 @@ impl<'module> TreePrinter<'module> {
                 prec,
                 Precedence::FUN_APPLICATION,
             ),
+            Expr::FindByKey(is_sorted, keying_fn, query, seq) => cond_paren(
+                self.prefix_op(if *is_sorted { "binary-search" } else { "linear-search" }, Some(&[keying_fn, query]), seq),
+                prec,
+                Precedence::FUN_APPLICATION,
+            ),
             Expr::FlatMapList(expr, _ret_type, seq) => cond_paren(
                 self.prefix_op("flat-map-list", Some(&[expr]), seq),
                 prec,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -123,6 +123,32 @@ where
     Ok(res)
 }
 
+/// Performs a binary search through a slice, returning the element at the index found by the
+/// slice method [`std::slice::binary_search_by_key`]. If this search fails, returns `None`
+/// instead.
+pub fn find_by_key_sorted<T, K>(f: impl FnMut(&T) -> K, query: K, slice: &[T]) -> Option<&T>
+where
+    K: Ord + Copy
+{
+    match slice.binary_search_by_key(&query, f) {
+        Ok(ix) => Some(&slice[ix]),
+        Err(_) => None,
+    }
+}
+
+/// Performs a linear search through a slice, returning the first element such that
+/// `f(elem) == query`.
+///
+/// Short-circuiting, and does not bother to check any further elements after a match is
+/// found. This means that even if there are multiple candidate matches, only the first
+/// is encountered and returned.
+pub fn find_by_key_unsorted<T, K>(mut f: impl FnMut(&T) -> K, query: K, slice: &[T]) -> Option<&T>
+where
+    K: Eq + Copy
+{
+    slice.iter().find(|x| f(x) == query)
+}
+
 pub fn u16le(input: (u8, u8)) -> u16 {
     u16::from_le_bytes([input.0, input.1])
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -128,7 +128,7 @@ where
 /// instead.
 pub fn find_by_key_sorted<T, K>(f: impl FnMut(&T) -> K, query: K, slice: &[T]) -> Option<&T>
 where
-    K: Ord + Copy
+    K: Ord + Copy,
 {
     match slice.binary_search_by_key(&query, f) {
         Ok(ix) => Some(&slice[ix]),
@@ -144,7 +144,7 @@ where
 /// is encountered and returned.
 pub fn find_by_key_unsorted<T, K>(mut f: impl FnMut(&T) -> K, query: K, slice: &[T]) -> Option<&T>
 where
-    K: Eq + Copy
+    K: Eq + Copy,
 {
     slice.iter().find(|x| f(x) == query)
 }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2207,10 +2207,7 @@ impl TypeChecker {
                 self.unify_var_proj_elem(xs_var, x_var)?;
                 self.unify_var_pair(ret_var, key_var)?;
                 self.unify_var_pair(elem_var, x_var)?;
-                self.unify_var_utype(
-                    newvar,
-                    Rc::new(UType::Option(x_var.into()))
-                )?;
+                self.unify_var_utype(newvar, Rc::new(UType::Option(x_var.into())))?;
 
                 newvar
             }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -2194,6 +2194,26 @@ impl TypeChecker {
 
                 newvar
             }
+            Expr::FindByKey(_is_sorted, f_get_key, query_key, seq_expr) => {
+                // NOTE - (is-sorted) ~> (x -> key) -> key -> [x] -> Option(T)
+                let newvar = self.get_new_uvar();
+
+                let (elem_var, ret_var) = self.infer_vars_expr_lambda(f_get_key, scope)?;
+                let key_var = self.infer_var_expr(query_key, scope)?;
+                let xs_var = self.infer_var_expr(seq_expr, scope)?;
+
+                let x_var = self.get_new_uvar();
+
+                self.unify_var_proj_elem(xs_var, x_var)?;
+                self.unify_var_pair(ret_var, key_var)?;
+                self.unify_var_pair(elem_var, x_var)?;
+                self.unify_var_utype(
+                    newvar,
+                    Rc::new(UType::Option(x_var.into()))
+                )?;
+
+                newvar
+            }
             Expr::FlatMapList(f_expr, ret_type, seq_expr) => {
                 // NOTE - (([y], x) -> [y]) -> Vt(y) -> [x] -> [y]
                 let ys_var = self.get_new_uvar();

--- a/tests/expected/decode/test.gif.stdout
+++ b/tests/expected/decode/test.gif.stdout
@@ -7,14 +7,14 @@
 │       │   ├── descriptor <- gif.logical-screen-descriptor :=
 │       │   │   ├── screen-width <- base.u16le := 50
 │       │   │   ├── screen-height <- base.u16le := 50
-│       │   │   ├── flags <- map (packedbits -> { ... }) U8 :=
+│       │   │   ├── flags <- map (packed_bits -> { ... }) U8 :=
 │       │   │   │   ├── table-flag := 1
 │       │   │   │   ├── color-resolution := 7
 │       │   │   │   ├── sort-flag := 0
 │       │   │   │   └── table-size := 4
 │       │   │   ├── bg-color-index <- base.u8 := 0
 │       │   │   └── pixel-aspect-ratio <- base.u8 := 0
-│       │   └── global-color-table <- maybe (descriptor.flags.table-flag != 0) (repeat-count (2 << as-u16 (descriptor.flags.table-size)) gif.color-table-entry) :=
+│       │   └── global-color-table <- maybe (descriptor.flags.table-flag > 0) (repeat-count (2 << as-u16 (descriptor.flags.table-size)) gif.color-table-entry) :=
 │       │       └── some <- repeat-count (2 << as-u16 (descriptor.flags.table-size)) gif.color-table-entry :=
 │       │           └──    r   g   b
 │       │                  0   0   0
@@ -57,7 +57,7 @@
 │       │           │       ├── separator <- [= 33]
 │       │           │       ├── label <- [= 249]
 │       │           │       ├── block-size <- [= 4]
-│       │           │       ├── flags <- map (packedbits -> { ... }) U8 :=
+│       │           │       ├── flags <- map (packed_bits -> { ... }) U8 :=
 │       │           │       │   ├── reserved := 0
 │       │           │       │   ├── disposal-method := 0
 │       │           │       │   ├── user-input-flag := 0
@@ -73,13 +73,13 @@
 │       │                   │   ├── image-top-position <- base.u16le := 0
 │       │                   │   ├── image-width <- base.u16le := 50
 │       │                   │   ├── image-height <- base.u16le := 50
-│       │                   │   └── flags <- map (packedbits -> { ... }) U8 :=
+│       │                   │   └── flags <- map (packed_bits -> { ... }) U8 :=
 │       │                   │       ├── table-flag := 0
 │       │                   │       ├── interlace-flag := 0
 │       │                   │       ├── sort-flag := 0
 │       │                   │       ├── reserved := 0
 │       │                   │       └── table-size := 0
-│       │                   ├── local-color-table <- maybe (descriptor.flags.table-flag != 0) (repeat-count (2 << as-u16 (descriptor.flags.table-size)) gif.color-table-entry) := none
+│       │                   ├── local-color-table <- maybe (descriptor.flags.table-flag > 0) (repeat-count (2 << as-u16 (descriptor.flags.table-size)) gif.color-table-entry) := none
 │       │                   └── data <- gif.table-based-image-data :=
 │       │                       ├── lzw-min-code-size <- base.u8 := 5
 │       │                       ├── image-data <- repeat gif.subblock :=

--- a/tests/expected/decode/test.jpg.stdout
+++ b/tests/expected/decode/test.jpg.stdout
@@ -25,7 +25,7 @@
 │       │   │   │       ├── length <- base.u16be := 67
 │       │   │   │       └── data <- slice (length - 2) (repeat1 jpeg.dqt-data) :=
 │       │   │   │           └── 0 <- jpeg.dqt-data :=
-│       │   │   │               ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │               ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │               │   ├── precision := 0
 │       │   │   │               │   └── table-id := 0
 │       │   │   │               └── elements <- match precision-table-id.precision { ... } :=
@@ -48,7 +48,7 @@
 │       │   │           ├── length <- base.u16be := 67
 │       │   │           └── data <- slice (length - 2) (repeat1 jpeg.dqt-data) :=
 │       │   │               └── 0 <- jpeg.dqt-data :=
-│       │   │                   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │                   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │                   │   ├── precision := 0
 │       │   │                   │   └── table-id := 1
 │       │   │                   └── elements <- match precision-table-id.precision { ... } :=
@@ -77,19 +77,19 @@
 │       │   │           └── image-components <- repeat-count num-image-components jpeg.sof-image-component :=
 │       │   │               ├── 0 <- jpeg.sof-image-component :=
 │       │   │               │   ├── id <- base.u8 := 1
-│       │   │               │   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │               │   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │               │   │   ├── horizontal := 2
 │       │   │               │   │   └── vertical := 2
 │       │   │               │   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 0
 │       │   │               ├── 1 <- jpeg.sof-image-component :=
 │       │   │               │   ├── id <- base.u8 := 2
-│       │   │               │   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │               │   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │               │   │   ├── horizontal := 1
 │       │   │               │   │   └── vertical := 1
 │       │   │               │   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 1
 │       │   │               └── 2 <- jpeg.sof-image-component :=
 │       │   │                   ├── id <- base.u8 := 3
-│       │   │                   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │                   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │                   │   ├── horizontal := 1
 │       │   │                   │   └── vertical := 1
 │       │   │                   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 1
@@ -100,7 +100,7 @@
 │       │   │   │   │       ├── marker <- { ... }
 │       │   │   │   │       ├── length <- base.u16be := 27
 │       │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
-│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │   │           │   ├── class := 0
 │       │   │   │   │           │   └── table-id := 0
 │       │   │   │   │           ├── num-codes <- repeat-count 16 base.u8 :=
@@ -142,7 +142,7 @@
 │       │   │   │   │       ├── marker <- { ... }
 │       │   │   │   │       ├── length <- base.u16be := 58
 │       │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
-│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │   │           │   ├── class := 1
 │       │   │   │   │           │   └── table-id := 0
 │       │   │   │   │           ├── num-codes <- repeat-count 16 base.u8 :=
@@ -201,7 +201,7 @@
 │       │   │   │   │       ├── marker <- { ... }
 │       │   │   │   │       ├── length <- base.u16be := 26
 │       │   │   │   │       └── data <- slice (length - 2) jpeg.dht-data :=
-│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │   │           ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │   │           │   ├── class := 0
 │       │   │   │   │           │   └── table-id := 1
 │       │   │   │   │           ├── num-codes <- repeat-count 16 base.u8 :=
@@ -242,7 +242,7 @@
 │       │   │   │           ├── marker <- { ... }
 │       │   │   │           ├── length <- base.u16be := 38
 │       │   │   │           └── data <- slice (length - 2) jpeg.dht-data :=
-│       │   │   │               ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │               ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │               │   ├── class := 1
 │       │   │   │               │   └── table-id := 1
 │       │   │   │               ├── num-codes <- repeat-count 16 base.u8 :=
@@ -298,22 +298,22 @@
 │       │   │   │       ├── image-components <- repeat-count num-image-components jpeg.sos-image-component :=
 │       │   │   │       │   ├── 0 <- jpeg.sos-image-component :=
 │       │   │   │       │   │   ├── component-selector <- base.u8 := 1
-│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │   │       ├── dc-entropy-coding-table-id := 0
 │       │   │   │       │   │       └── ac-entropy-coding-table-id := 0
 │       │   │   │       │   ├── 1 <- jpeg.sos-image-component :=
 │       │   │   │       │   │   ├── component-selector <- base.u8 := 2
-│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │   │       ├── dc-entropy-coding-table-id := 1
 │       │   │   │       │   │       └── ac-entropy-coding-table-id := 1
 │       │   │   │       │   └── 2 <- jpeg.sos-image-component :=
 │       │   │   │       │       ├── component-selector <- base.u8 := 3
-│       │   │   │       │       └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │       └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │           ├── dc-entropy-coding-table-id := 1
 │       │   │   │       │           └── ac-entropy-coding-table-id := 1
 │       │   │   │       ├── start-spectral-selection <- assert (x -> x <= 63) base.u8 := 0
 │       │   │   │       ├── end-spectral-selection <- assert (x -> x <= 63) base.u8 := 63
-│       │   │   │       └── approximation-bit-position <- map (packedbits -> { ... }) U8 :=
+│       │   │   │       └── approximation-bit-position <- map (packed_bits -> { ... }) U8 :=
 │       │   │   │           ├── high := 0
 │       │   │   │           └── low := 0
 │       │   │   └── data <- jpeg.scan-data :=

--- a/tests/expected/decode/test.png.stdout
+++ b/tests/expected/decode/test.png.stdout
@@ -89,14 +89,14 @@
 │       │       │       └── second <- base.u8 := 34
 │       │       └── crc <- base.u32be := 491070829
 │       ├── idat <- let-format idat (map (xs -> flat-map (x -> x.data) xs) (repeat1 png.idat)) (decode-bytes idat zlib.main) :=
-│       │   ├── compression-method-flags <- assert (method-info -> method-info.compression-method == 8) (map (packedbits -> { ... }) U8) :=
+│       │   ├── compression-method-flags <- assert (method-info -> method-info.compression-method == 8) (map (packed_bits -> { ... }) U8) :=
 │       │   │   ├── compression-info := 4
 │       │   │   └── compression-method := 8
-│       │   ├── flags <- map (packedbits -> { ... }) U8 :=
+│       │   ├── flags <- map (packed_bits -> { ... }) U8 :=
 │       │   │   ├── flevel := 3
-│       │   │   ├── fdict := 0
+│       │   │   ├── fdict := false
 │       │   │   └── fcheck := 7
-│       │   ├── dict-id <- maybe (flags.fdict != 0) base.u32be := none
+│       │   ├── dict-id <- maybe (flags.fdict) base.u32be := none
 │       │   ├── data <- bits deflate.main :=
 │       │   │   ├── blocks <- repeat-until-last (x -> x.final == 1) deflate.block :=
 │       │   │   │   └── 0 <- deflate.block :=

--- a/tests/expected/decode/test.waldo.stdout
+++ b/tests/expected/decode/test.waldo.stdout
@@ -4,7 +4,7 @@
 │       ├── noise <- repeat [= 255]
 │       ├── sep <- [= 0]
 │       ├── here <- pos := 12
-│       └── waldo <- with-relative-offset (where - here) (...) :=
+│       └── waldo <- with-relative-offset here (where - here) (...) :=
 │           ├── 0 <- [= 87]
 │           ├── 1 <- [= 97]
 │           ├── 2 <- [= 108]

--- a/tests/expected/decode/test1.gz.stdout
+++ b/tests/expected/decode/test1.gz.stdout
@@ -4,7 +4,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1683505215
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3

--- a/tests/expected/decode/test2.gz.stdout
+++ b/tests/expected/decode/test2.gz.stdout
@@ -4,7 +4,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1683505384
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3

--- a/tests/expected/decode/test2.jpg.stdout
+++ b/tests/expected/decode/test2.jpg.stdout
@@ -12,10 +12,11 @@
 │       │   │               └── exif <- jpeg.app1-exif :=
 │       │   │                   ├── padding <- [= 0]
 │       │   │                   └── exif <- tiff.main :=
+│       │   │                       ├── start_of_header <- map (x -> as-u32 x) pos := 12
 │       │   │                       ├── byte-order <- _ |...| _ := be
 │       │   │                       ├── magic <- match byte-order { ... } := 42
 │       │   │                       ├── offset <- match byte-order { ... } := 8
-│       │   │                       └── ifd <- with-relative-offset (offset - 8) (match byte-order { ... }) :=
+│       │   │                       └── ifd <- with-relative-offset start_of_header offset (match byte-order { ... }) :=
 │       │   │                           ├── num-fields <- base.u16be := 7
 │       │   │                           ├── fields <- repeat-count num-fields { ... } :=
 │       │   │                           │   ├── 0 :=
@@ -146,7 +147,7 @@
 │       │   │           ├── length <- base.u16be := 132
 │       │   │           └── data <- slice (length - 2) (repeat1 jpeg.dqt-data) :=
 │       │   │               ├── 0 <- jpeg.dqt-data :=
-│       │   │               │   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │               │   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │               │   │   ├── precision := 0
 │       │   │               │   │   └── table-id := 0
 │       │   │               │   └── elements <- match precision-table-id.precision { ... } :=
@@ -164,7 +165,7 @@
 │       │   │               │           ~
 │       │   │               │           └── 63 := 12
 │       │   │               └── 1 <- jpeg.dqt-data :=
-│       │   │                   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │                   ├── precision-table-id <- assert (precision-table-id -> (precision-table-id.precision <= 1) && (precision-table-id.table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │                   │   ├── precision := 0
 │       │   │                   │   └── table-id := 1
 │       │   │                   └── elements <- match precision-table-id.precision { ... } :=
@@ -193,19 +194,19 @@
 │       │   │           └── image-components <- repeat-count num-image-components jpeg.sof-image-component :=
 │       │   │               ├── 0 <- jpeg.sof-image-component :=
 │       │   │               │   ├── id <- base.u8 := 1
-│       │   │               │   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │               │   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │               │   │   ├── horizontal := 1
 │       │   │               │   │   └── vertical := 1
 │       │   │               │   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 0
 │       │   │               ├── 1 <- jpeg.sof-image-component :=
 │       │   │               │   ├── id <- base.u8 := 2
-│       │   │               │   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │               │   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │               │   │   ├── horizontal := 1
 │       │   │               │   │   └── vertical := 1
 │       │   │               │   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 1
 │       │   │               └── 2 <- jpeg.sof-image-component :=
 │       │   │                   ├── id <- base.u8 := 3
-│       │   │                   ├── sampling-factor <- map (packedbits -> { ... }) U8 :=
+│       │   │                   ├── sampling-factor <- map (packed_bits -> { ... }) U8 :=
 │       │   │                   │   ├── horizontal := 1
 │       │   │                   │   └── vertical := 1
 │       │   │                   └── quantization-table-id <- assert (x -> x <= 3) base.u8 := 1
@@ -222,7 +223,7 @@
 │       │   │   │           ├── marker <- { ... }
 │       │   │   │           ├── length <- base.u16be := 418
 │       │   │   │           └── data <- slice (length - 2) jpeg.dht-data :=
-│       │   │   │               ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │               ├── class-table-id <- assert (class-table-id -> (class-table-id.class < 2) && (class-table-id.table-id < 4)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │               │   ├── class := 0
 │       │   │   │               │   └── table-id := 0
 │       │   │   │               ├── num-codes <- repeat-count 16 base.u8 :=
@@ -271,22 +272,22 @@
 │       │   │   │       ├── image-components <- repeat-count num-image-components jpeg.sos-image-component :=
 │       │   │   │       │   ├── 0 <- jpeg.sos-image-component :=
 │       │   │   │       │   │   ├── component-selector <- base.u8 := 1
-│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │   │       ├── dc-entropy-coding-table-id := 0
 │       │   │   │       │   │       └── ac-entropy-coding-table-id := 0
 │       │   │   │       │   ├── 1 <- jpeg.sos-image-component :=
 │       │   │   │       │   │   ├── component-selector <- base.u8 := 2
-│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │   │   └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │   │       ├── dc-entropy-coding-table-id := 1
 │       │   │   │       │   │       └── ac-entropy-coding-table-id := 1
 │       │   │   │       │   └── 2 <- jpeg.sos-image-component :=
 │       │   │   │       │       ├── component-selector <- base.u8 := 3
-│       │   │   │       │       └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packedbits -> { ... }) U8) :=
+│       │   │   │       │       └── entropy-coding-table-ids <- assert (entropy-coding-table-ids -> (entropy-coding-table-ids.dc-entropy-coding-table-id <= 3) && (entropy-coding-table-ids.ac-entropy-coding-table-id <= 3)) (map (packed_bits -> { ... }) U8) :=
 │       │   │   │       │           ├── dc-entropy-coding-table-id := 1
 │       │   │   │       │           └── ac-entropy-coding-table-id := 1
 │       │   │   │       ├── start-spectral-selection <- assert (x -> x <= 63) base.u8 := 0
 │       │   │   │       ├── end-spectral-selection <- assert (x -> x <= 63) base.u8 := 63
-│       │   │   │       └── approximation-bit-position <- map (packedbits -> { ... }) U8 :=
+│       │   │   │       └── approximation-bit-position <- map (packed_bits -> { ... }) U8 :=
 │       │   │   │           ├── high := 0
 │       │   │   │           └── low := 0
 │       │   │   └── data <- jpeg.scan-data :=

--- a/tests/expected/decode/test3.gz.stdout
+++ b/tests/expected/decode/test3.gz.stdout
@@ -4,7 +4,7 @@
 │       │   ├── header <- gzip.header :=
 │       │   │   ├── magic <- (...)
 │       │   │   ├── method <- base.u8 := 8
-│       │   │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│       │   │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │       │   │   ├── timestamp <- base.u32le := 1683505215
 │       │   │   ├── compression-flags <- base.u8 := 0
 │       │   │   └── os-id <- base.u8 := 3
@@ -100,7 +100,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1683505384
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3

--- a/tests/expected/decode/test4.gz.stdout
+++ b/tests/expected/decode/test4.gz.stdout
@@ -4,7 +4,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1684478387
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3

--- a/tests/expected/decode/test5.gz.stdout
+++ b/tests/expected/decode/test5.gz.stdout
@@ -4,7 +4,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1687676820
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3

--- a/tests/expected/decode/test6.gz.stdout
+++ b/tests/expected/decode/test6.gz.stdout
@@ -4,7 +4,7 @@
 │           ├── header <- gzip.header :=
 │           │   ├── magic <- (...)
 │           │   ├── method <- base.u8 := 8
-│           │   ├── file-flags <- map (flagbits -> { ... }) U8 := bool-flags[fname]
+│           │   ├── file-flags <- map (packed_bits -> { ... }) U8 := bool-flags[fname]
 │           │   ├── timestamp <- base.u32le := 1688888025
 │           │   ├── compression-flags <- base.u8 := 0
 │           │   └── os-id <- base.u8 := 3


### PR DESCRIPTION
Expr::FindByKey for short-circuiting linear-or-binary searches for a value in an array-kinded `Expr` with a specific key-value.