### PR TITLE
Add Format::Sequence, Expr::Append for Sequence QoL

### DIFF
--- a/doodle-formats/src/format/png.rs
+++ b/doodle-formats/src/format/png.rs
@@ -466,7 +466,7 @@ pub fn main(
     module.define_format(
         "png.main",
         record_auto([
-            ("__signature", is_bytes(PNG_SIGNATURE)),
+            ("signature", byte_seq(PNG_SIGNATURE)),
             ("ihdr", ihdr.call()),
             ("chunks", repeat(png_chunk.call_args(vec![var("ihdr")]))),
             (

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -4242,9 +4242,10 @@ tag: (u8, u8, u8, u8),
 crc: u32
 }
 
-/// expected size: 184
+/// expected size: 208
 #[derive(Debug, Clone)]
 pub struct png_main {
+signature: Vec<u8>,
 ihdr: png_ihdr,
 chunks: Vec<png_chunk>,
 idat: zlib_main,
@@ -4951,72 +4952,72 @@ PResult::Ok(mpeg4_main { atoms })
 }
 
 fn Decoder_png_main<>(_input: &mut Parser<'_>) -> Result<png_main, ParseError> {
-{
-let field0 = ((|| {
+let signature = {
+let _seq0 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 137 {
+if b == 137 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(8253205784254894771u64));
-})
-})())?;
-let field1 = ((|| {
+}
+};
+let _seq1 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 80 {
+if b == 80 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(1225514472166157741u64));
-})
-})())?;
-let field2 = ((|| {
+}
+};
+let _seq2 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 78 {
+if b == 78 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(1224415506115142500u64));
-})
-})())?;
-let field3 = ((|| {
+}
+};
+let _seq3 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 71 {
+if b == 71 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(16859485491091215361u64));
-})
-})())?;
-let field4 = ((|| {
+}
+};
+let _seq4 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 13 {
+if b == 13 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(14898840355839773829u64));
-})
-})())?;
-let field5 = ((|| {
+}
+};
+let _seq5 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 10 {
+if b == 10 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(9453951600195794313u64));
-})
-})())?;
-let field6 = ((|| {
+}
+};
+let _seq6 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 26 {
+if b == 26 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(10036157788440812915u64));
-})
-})())?;
-let field7 = ((|| {
+}
+};
+let _seq7 = {
 let b = _input.read_byte()?;
-PResult::Ok(if b == 10 {
+if b == 10 {
 b
 } else {
 return Err(ParseError::ExcludedBranch(6349531732377484771u64));
-})
-})())?;
-(field0, field1, field2, field3, field4, field5, field6, field7)
+}
+};
+vec![_seq0, _seq1, _seq2, _seq3, _seq4, _seq5, _seq6, _seq7]
 };
 let ihdr = (Decoder_png_ihdr(_input))?;
 let chunks = {
@@ -5162,7 +5163,7 @@ break
 accum
 };
 let iend = (Decoder_png_iend(_input))?;
-PResult::Ok(png_main { ihdr, chunks, idat, more_chunks, iend })
+PResult::Ok(png_main { signature, ihdr, chunks, idat, more_chunks, iend })
 }
 
 fn Decoder_riff_main<>(_input: &mut Parser<'_>) -> Result<riff_main, ParseError> {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -313,6 +313,14 @@ impl CodeGen {
                             "TypedDecoder::Tuple expected to have type RustType::AnonTuple(..) (or UNIT if empty), found {other:?}"
                         ),
                 }
+            TypedDecoder::Sequence(gt, elts) => match gt {
+                GenType::Inline(RustType::Atom(AtomType::Comp(CompType::Vec(_t)))) => {
+                    let as_array = _t.prefer_array(elts.len());
+                    let elements = elts.iter().map(|elt| self.translate(elt.get_dec())).collect();
+                    CaseLogic::Sequential(SequentialLogic::AccumSeq { as_array, elements })
+                },
+                other => unreachable!("TypedDecoder::Sequence expected to have type CompType::Vec(..), found {other:?}"),
+            },
             TypedDecoder::Repeat0While(_gt, tree_continue, single) =>
                 CaseLogic::Repeat(
                     RepeatLogic::Repeat0ContinueOnMatch(
@@ -839,7 +847,11 @@ fn embed_expr(expr: &GTExpr, info: ExprInfo) -> RustExpr {
                 )
             )
         }
-
+        TypedExpr::Append(_, seq0, seq1) => {
+            let lhs = embed_expr(seq0, info);
+            let rhs = embed_expr(seq1, info);
+            RustExpr::FunctionCall(Box::new(RustExpr::local("seq_append")), vec![lhs, rhs])
+        }
         TypedExpr::SubSeq(_, seq, ix, len) => {
             let start_expr = embed_expr_dft(ix);
             let bind_ix = RustStmt::assign(
@@ -2751,7 +2763,12 @@ enum RepeatLogic<ExprT> {
     /// Fused logic for a left-fold that is updated on each repeat, and contributes to the condition for termination
     ///
     /// Lambda order: termination-predicate, then update-function
-    AccumUntil(GenLambda, GenLambda, Typed<RustExpr>, Typed<Box<CaseLogic<ExprT>>>),
+    AccumUntil(
+        GenLambda,
+        GenLambda,
+        Typed<RustExpr>,
+        Typed<Box<CaseLogic<ExprT>>>,
+    ),
 }
 
 pub(crate) type Typed<T> = (T, GenType);
@@ -3134,7 +3151,10 @@ where
                     loop_body.push(RustStmt::assign("elem", elt_expr));
                     loop_body.push(RustStmt::Expr(RustExpr::local("seq").call_method_with(
                         "push",
-                        [RustExpr::owned(RustExpr::local("elem"), elt_type.to_rust_type())],
+                        [RustExpr::owned(
+                            RustExpr::local("elem"),
+                            elt_type.to_rust_type(),
+                        )],
                     )));
                     let new_acc = update.apply_pair(
                         RustExpr::local("acc"),
@@ -3161,6 +3181,10 @@ enum SequentialLogic<ExprT> {
         constructor: Option<Constructor>,
         elements: Vec<CaseLogic<ExprT>>,
     },
+    AccumSeq {
+        as_array: bool,
+        elements: Vec<CaseLogic<ExprT>>,
+    },
 }
 
 impl<ExprT> ToAst for SequentialLogic<ExprT>
@@ -3171,6 +3195,27 @@ where
 
     fn to_ast(&self, ctxt: ProdCtxt<'_>) -> GenBlock {
         match self {
+            // REVIEW - in certain cases, we may be able to use fixed-sized arrays instead of vec, but that might complicate matters...
+            SequentialLogic::AccumSeq { as_array, elements } => {
+                if elements.is_empty() {
+                    return GenBlock::simple_expr(RustExpr::VEC_NIL);
+                }
+                let mut stmts = Vec::new();
+                let mut terms = Vec::new();
+
+                for (ix, cl) in elements.iter().enumerate() {
+                    const LAB_PREFIX: &str = "_seq";
+                    let lab = Label::Owned(format!("{LAB_PREFIX}{ix}"));
+                    stmts.push(GenStmt::BindOnce(lab.clone(), cl.to_ast(ctxt)));
+                    terms.push(RustExpr::local(lab));
+                }
+                let ret = Some(GenExpr::Embed(if *as_array {
+                    RustExpr::ArrayLit(terms)
+                } else {
+                    RustExpr::Macro(RustMacro::Vec(VecExpr::List(terms)))
+                }));
+                GenBlock { stmts, ret }
+            }
             SequentialLogic::AccumTuple {
                 constructor,
                 elements,
@@ -4141,6 +4186,24 @@ impl<'a> Elaborator<'a> {
                 let gt = self.get_gt_from_index(index);
                 TypedFormat::Tuple(gt, t_elts)
             }
+            Format::Sequence(formats) => {
+                let index = self.get_and_increment_index();
+                self.increment_index();
+                let t_formats = match &formats[..] {
+                    [] => unreachable!("empty list has no unambiguous type"),
+                    [v] => vec![self.elaborate_format(v, dyn_scope)],
+                    formats => {
+                        let mut t_formats = Vec::with_capacity(formats.len());
+                        for t in formats {
+                            let t_format = self.elaborate_format(t, dyn_scope);
+                            t_formats.push(t_format);
+                        }
+                        t_formats
+                    }
+                };
+                let gt = self.get_gt_from_index(index);
+                TypedFormat::Sequence(gt, t_formats)
+            }
             Format::Repeat(inner) => {
                 let index = self.get_and_increment_index();
                 let t_inner = self.elaborate_format(inner, dyn_scope);
@@ -4484,7 +4547,14 @@ impl<'a> Elaborator<'a> {
                 let gt = self.get_gt_from_index(index);
                 TypedExpr::Seq(gt, t_elts)
             }
+            Expr::Append(lhs, rhs) => {
+                let t_lhs = self.elaborate_expr(lhs);
+                let t_rhs = self.elaborate_expr(rhs);
+                self.increment_index();
 
+                let gt = self.get_gt_from_index(index);
+                TypedExpr::Append(gt, Box::new(t_lhs), Box::new(t_rhs))
+            }
             Expr::RecordProj(e, fld) => {
                 self.codegen.name_gen.ctxt.push_atom(NameAtom::DeadEnd);
                 let t_e = self.elaborate_expr(e);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -5114,7 +5114,7 @@ mod tests {
                 "{}",
                 lambda
                     .apply_pair(
-                        RustExpr::CloneOf(Box::new(RustExpr::local("acc"))),
+                        RustExpr::Owned(OwnedRustExpr { expr: Box::new(RustExpr::local("acc")), kind: OwnedKind::Cloned }),
                         RustExpr::local("seq"),
                         ExprInfo::default()
                     )

--- a/src/codegen/rust_ast/mod.rs
+++ b/src/codegen/rust_ast/mod.rs
@@ -685,6 +685,15 @@ impl RustType {
         }
     }
 
+    /// Returns `true` if seq-formats ([`Format::Sequence`]) of type `Seq(<self>)` should prefer to use
+    /// fixed-size arrays (`[T; N]`) over vectors (`Vec<T>`) during construction. An additional parameter,
+    /// the length of the sequence (`len`), is passed in to guide the decision, as simple types can be
+    /// preferable as vectors depending more on the length of the sequence than anything else.
+    pub(crate) fn prefer_array(&self, _n: usize) -> bool {
+        // REVIEW - currently, we would need to orchestrate the correct decision at multiple layers, which would take a lot of work
+        false
+    }
+
     /// Returns `true` if `self` is a known-`Copy` `RustType`.
     ///
     /// # Note
@@ -1399,6 +1408,17 @@ pub(crate) enum RustExpr {
 #[derive(Debug, Clone)]
 pub(crate) enum RustMacro {
     Matches(Box<RustExpr>, Vec<RustPattern>),
+    Vec(VecExpr),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum VecExpr {
+    Nil,
+    #[expect(dead_code)]
+    Single(Box<RustExpr>),
+    #[expect(dead_code)]
+    Repeat(Box<RustExpr>, Box<RustExpr>),
+    List(Vec<RustExpr>),
 }
 
 impl RustExpr {
@@ -1409,6 +1429,8 @@ impl RustExpr {
     pub const TRUE: Self = Self::PrimitiveLit(RustPrimLit::Boolean(true));
 
     pub const FALSE: Self = Self::PrimitiveLit(RustPrimLit::Boolean(false));
+
+    pub const VEC_NIL: Self = RustExpr::Macro(RustMacro::Vec(VecExpr::Nil));
 
     /// Returns `Some(varname)` if `self` is a simple entity-reference to identifier `varname`, and
     /// `None` otherwise.
@@ -1490,12 +1512,15 @@ impl RustExpr {
             Self::Owned(OwnedRustExpr { expr, .. }) => match &*expr {
                 Self::FieldAccess(..) => Self::Borrow(expr),
                 _ => *expr,
-            }
+            },
             other => Self::Borrow(Box::new(other)),
         }
     }
 
-    pub fn field<Name>(self, name: Name) -> Self where Name: Into<Label> + AsRef<str> {
+    pub fn field<Name>(self, name: Name) -> Self
+    where
+        Name: Into<Label> + AsRef<str>,
+    {
         match self {
             Self::Owned(OwnedRustExpr { expr, kind }) => {
                 let (expr, kind) = match kind {
@@ -1504,7 +1529,7 @@ impl RustExpr {
                         let lens = lens.field(lab.clone());
                         (Box::new(expr.field(lab)), OwnedKind::Unresolved(lens))
                     }
-                    _ => (Box::new(expr.field(name)), kind)
+                    _ => (Box::new(expr.field(name)), kind),
                 };
                 Self::Owned(OwnedRustExpr { expr, kind })
             }
@@ -1531,17 +1556,26 @@ impl RustExpr {
     pub fn index(self, ix: RustExpr) -> RustExpr {
         match self {
             Self::Owned(owned) => match owned {
-                OwnedRustExpr { kind: OwnedKind::Copied | OwnedKind::Deref, expr: this } => this.index(ix),
-                OwnedRustExpr { kind: OwnedKind::Unresolved(lens), expr }  => {
-                    Self::Owned(OwnedRustExpr {
-                        expr: Box::new(expr.index(ix)),
-                        kind: OwnedKind::Unresolved(lens.elem()),
-                    })
-                },
-                OwnedRustExpr { kind: OwnedKind::Cloned, .. }  => {
-                    unreachable!("index smart-constructor should only be used on undecided expressions");
+                OwnedRustExpr {
+                    kind: OwnedKind::Copied | OwnedKind::Deref,
+                    expr: this,
+                } => this.index(ix),
+                OwnedRustExpr {
+                    kind: OwnedKind::Unresolved(lens),
+                    expr,
+                } => Self::Owned(OwnedRustExpr {
+                    expr: Box::new(expr.index(ix)),
+                    kind: OwnedKind::Unresolved(lens.elem()),
+                }),
+                OwnedRustExpr {
+                    kind: OwnedKind::Cloned,
+                    ..
+                } => {
+                    unreachable!(
+                        "index smart-constructor should only be used on undecided expressions"
+                    );
                 }
-            }
+            },
             other => Self::Index(Box::new(other), Box::new(ix)),
         }
     }
@@ -1563,7 +1597,7 @@ impl RustExpr {
     /// clone-then-borrow constructs in the generated code.
     pub fn vec_as_slice(self) -> Self {
         let this = match self {
-            Self::Owned(OwnedRustExpr {expr, .. }) => *expr,
+            Self::Owned(OwnedRustExpr { expr, .. }) => *expr,
             other => other,
         };
         this.call_method("as_slice")
@@ -1640,6 +1674,7 @@ impl RustExpr {
                 RustPrimLit::String(..) => None,
             },
             RustExpr::Macro(RustMacro::Matches(..)) => Some(PrimType::Bool),
+            RustExpr::Macro(RustMacro::Vec(..)) => None,
             RustExpr::ArrayLit(..) => None,
             RustExpr::MethodCall(_recv, _method, _args) => {
                 match _method {
@@ -1788,6 +1823,12 @@ impl RustExpr {
         match self {
             RustExpr::Entity(..) => true,
             RustExpr::Macro(RustMacro::Matches(expr, ..)) => expr.is_pure(),
+            RustExpr::Macro(RustMacro::Vec(vec_expr)) => match vec_expr {
+                VecExpr::Nil => true,
+                VecExpr::Single(x) => x.is_pure(),
+                VecExpr::Repeat(x, n) => x.is_pure() && n.is_pure(),
+                VecExpr::List(xs) => xs.iter().all(Self::is_pure),
+            },
             RustExpr::PrimitiveLit(..) => true,
             RustExpr::ArrayLit(arr) => arr.iter().all(Self::is_pure),
             // REVIEW - over types we have no control over, clone itself can be impure, but it should never be so for the code we ourselves are generating
@@ -1810,9 +1851,7 @@ impl RustExpr {
                 StructExpr::TupleExpr(values) => values.iter().all(|val| val.is_pure()),
                 StructExpr::EmptyExpr => true,
             },
-            RustExpr::Borrow(expr) | RustExpr::BorrowMut(expr) => {
-                expr.is_pure()
-            }
+            RustExpr::Borrow(expr) | RustExpr::BorrowMut(expr) => expr.is_pure(),
             // NOTE - while we can construct pure Try-expressions manually, the intent of `?` is to have potential side-effects and so we judge them de-facto impure
             RustExpr::Try(..) => false,
             RustExpr::Operation(op) => match op {
@@ -1872,6 +1911,8 @@ impl RustExpr {
 
             // Special case - `matches!` macro is an idiomatic conditional expression
             RustExpr::Macro(RustMacro::Matches(..)) => false,
+            // Special case - `vec!` will typically be constructed only over simple sub-expressions
+            RustExpr::Macro(RustMacro::Vec(..)) => false,
 
             // REVIEW - is there a better heuristic?
             RustExpr::Closure(..) => true,
@@ -1983,11 +2024,36 @@ impl RustExpr {
 
     pub(crate) fn owned(loc: RustExpr, expr_type: RustType) -> RustExpr {
         let owned = if expr_type.can_be_copy() {
-            OwnedRustExpr { expr: Box::new(loc), kind: OwnedKind::Copied }
+            OwnedRustExpr {
+                expr: Box::new(loc),
+                kind: OwnedKind::Copied,
+            }
         } else {
-            OwnedRustExpr { expr: Box::new(loc), kind: OwnedKind::Unresolved(Lens::Ground(expr_type)) }
+            OwnedRustExpr {
+                expr: Box::new(loc),
+                kind: OwnedKind::Unresolved(Lens::Ground(expr_type)),
+            }
         };
         RustExpr::Owned(owned)
+    }
+}
+
+impl ToFragment for VecExpr {
+    fn to_fragment(&self) -> Fragment {
+        let contents = match self {
+            VecExpr::Nil => Fragment::Empty,
+            VecExpr::Single(x) => x.to_fragment_precedence(Precedence::Top),
+            VecExpr::Repeat(x, n) => x.to_fragment_precedence(Precedence::Top).intervene(
+                Fragment::string("; "),
+                n.to_fragment_precedence(Precedence::Top),
+            ),
+            VecExpr::List(elts) => Fragment::seq(
+                elts.iter()
+                    .map(|x| x.to_fragment_precedence(Precedence::Top)),
+                Some(Fragment::string(", ")),
+            ),
+        };
+        contents.delimit(Fragment::Char('['), Fragment::Char(']'))
     }
 }
 
@@ -2035,19 +2101,27 @@ impl ToFragmentExt for RustExpr {
                 prec,
                 Precedence::INVOKE,
             ),
-            RustExpr::Owned(OwnedRustExpr { expr: x, kind: OwnedKind::Cloned }) => cond_paren(
+            RustExpr::Owned(OwnedRustExpr {
+                expr: x,
+                kind: OwnedKind::Cloned,
+            }) => cond_paren(
                 x.to_fragment_precedence(Precedence::Projection)
                     .intervene(Fragment::Char('.'), Fragment::string("clone()")),
                 prec,
                 Precedence::Projection,
             ),
-            RustExpr::Owned(OwnedRustExpr { kind: OwnedKind::Deref, expr}) => {
-                Fragment::Char('*').cat(expr.to_fragment_precedence(Precedence::Prefix))
-            }
-            RustExpr::Owned(OwnedRustExpr { kind: OwnedKind::Copied, expr }) => {
-                expr.to_fragment_precedence(prec)
-            }
-            RustExpr::Owned(OwnedRustExpr { kind: OwnedKind::Unresolved(lens), expr}) => {
+            RustExpr::Owned(OwnedRustExpr {
+                kind: OwnedKind::Deref,
+                expr,
+            }) => Fragment::Char('*').cat(expr.to_fragment_precedence(Precedence::Prefix)),
+            RustExpr::Owned(OwnedRustExpr {
+                kind: OwnedKind::Copied,
+                expr,
+            }) => expr.to_fragment_precedence(prec),
+            RustExpr::Owned(OwnedRustExpr {
+                kind: OwnedKind::Unresolved(lens),
+                expr,
+            }) => {
                 unreachable!("unresolved ownership: ({expr:?}: {lens:?})")
             }
             RustExpr::FieldAccess(x, name) => x
@@ -2070,6 +2144,9 @@ impl ToFragmentExt for RustExpr {
                         .delimit(Fragment::Char('('), Fragment::Char(')')),
                 )
                 .group(),
+            RustExpr::Macro(RustMacro::Vec(vec_expr)) => {
+                Fragment::string("vec!").cat(vec_expr.to_fragment())
+            }
             RustExpr::Tuple(elts) => match elts.as_slice() {
                 [elt] => elt
                     .to_fragment_precedence(Precedence::Top)
@@ -3096,7 +3173,8 @@ mod test {
 
 pub mod short_circuit {
     use super::{
-        OwnedRustExpr, ReturnKind, RustCatchAll, RustControl, RustExpr, RustMacro, RustMatchBody, RustMatchCase, RustOp, RustStmt, StructExpr
+        OwnedRustExpr, ReturnKind, RustCatchAll, RustControl, RustExpr, RustMacro, RustMatchBody,
+        RustMatchCase, RustOp, RustStmt, StructExpr, VecExpr,
     };
 
     #[derive(Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
@@ -3104,9 +3182,9 @@ pub mod short_circuit {
         /// Can never constitute a short-circuit
         Pure = 0,
         /// Short-circuit if and only if it is the only non-pure term in a terminal value-producing node
-        SemiPure = 1,
-        /// Constitutes a potential short-circuit regardless of context
-        Impure = 2,
+        Try = 1,
+        /// Explicit `return` keyword -- constitutes a potential short-circuit regardless of context
+        Return = 2,
     }
 
     impl std::ops::BitOr for EvalPurity {
@@ -3115,21 +3193,22 @@ pub mod short_circuit {
         fn bitor(self, rhs: Self) -> Self::Output {
             match self {
                 EvalPurity::Pure => rhs,
-                EvalPurity::SemiPure => match rhs {
-                    EvalPurity::Pure => self,
-                    _ => EvalPurity::Impure,
+                EvalPurity::Try => match rhs {
+                    EvalPurity::Return => EvalPurity::Return,
+                    _ => self,
                 },
-                EvalPurity::Impure => EvalPurity::Impure,
+                EvalPurity::Return => EvalPurity::Return,
             }
         }
     }
 
     impl std::ops::BitOrAssign for EvalPurity {
         fn bitor_assign(&mut self, rhs: Self) {
-            match (&self, rhs) {
-                (EvalPurity::Pure, _) | (_, EvalPurity::Impure) => *self = rhs,
-                (EvalPurity::Impure, _) | (_, EvalPurity::Pure) => (),
-                (EvalPurity::SemiPure, EvalPurity::SemiPure) => *self = EvalPurity::Impure,
+            if matches!(
+                (&self, rhs),
+                (EvalPurity::Pure, _) | (_, EvalPurity::Return)
+            ) {
+                *self = rhs;
             }
         }
     }
@@ -3150,8 +3229,8 @@ pub mod short_circuit {
         fn has_short_circuit(&self, is_last: bool) -> bool {
             match self.check_eval_purity() {
                 EvalPurity::Pure => false,
-                EvalPurity::SemiPure => !is_last,
-                EvalPurity::Impure => true,
+                EvalPurity::Try => !is_last,
+                EvalPurity::Return => true,
             }
         }
     }
@@ -3234,7 +3313,7 @@ pub mod short_circuit {
                 | RustStmt::Let(.., expr)
                 | RustStmt::LetPattern(.., expr)
                 | RustStmt::Return(ReturnKind::Implicit, expr) => expr.check_eval_purity(),
-                RustStmt::Return(ReturnKind::Keyword, ..) => EvalPurity::SemiPure,
+                RustStmt::Return(ReturnKind::Keyword, ..) => EvalPurity::Try,
                 RustStmt::Control(ctrl) => ctrl.check_eval_purity(),
             }
         }
@@ -3329,7 +3408,7 @@ pub mod short_circuit {
             match self {
                 RustMatchBody::Irrefutable(branches) => branches.check_eval_purity(),
                 RustMatchBody::Refutable(branches, rust_catch_all) => match rust_catch_all {
-                    RustCatchAll::ReturnErrorValue { .. } => EvalPurity::SemiPure,
+                    RustCatchAll::ReturnErrorValue { .. } => EvalPurity::Try,
                     RustCatchAll::PanicUnreachable { .. } => branches.check_eval_purity(),
                 },
             }
@@ -3372,6 +3451,7 @@ pub mod short_circuit {
                     stmts.is_short_circuiting() || expr.is_short_circuiting()
                 }
                 RustExpr::Macro(RustMacro::Matches(expr, ..)) => expr.is_short_circuiting(),
+                RustExpr::Macro(RustMacro::Vec(vec_expr)) => vec_expr.is_short_circuiting(),
                 RustExpr::Control(ctrl) => ctrl.is_short_circuiting(),
                 RustExpr::Closure(..) => false,
                 RustExpr::Index(head, index) => {
@@ -3396,7 +3476,7 @@ pub mod short_circuit {
                     fn check_eval_purity(&self) -> EvalPurity {
                         let mut acc = EvalPurity::Pure;
                         for expr in self.iter() {
-                            if acc == EvalPurity::Impure { break; }
+                            if acc == EvalPurity::Return { break; }
                             acc |= expr.check_eval_purity();
                         }
                         acc
@@ -3410,8 +3490,8 @@ pub mod short_circuit {
         fn check_eval_purity(&self) -> EvalPurity {
             let mut acc = EvalPurity::Pure;
             for expr in self.iter() {
-                if matches!(acc, EvalPurity::SemiPure | EvalPurity::Impure) {
-                    return EvalPurity::Impure;
+                if matches!(acc, EvalPurity::Try | EvalPurity::Return) {
+                    return EvalPurity::Return;
                 }
                 acc |= expr.check_eval_purity();
             }
@@ -3441,13 +3521,14 @@ pub mod short_circuit {
                 | RustExpr::BorrowMut(inner) => inner.check_eval_purity(),
                 RustExpr::Try(inner) => match inner.as_ref() {
                     RustExpr::ResultOk(.., expr) => expr.check_eval_purity(),
-                    _ => EvalPurity::SemiPure,
+                    _ => EvalPurity::Try,
                 },
                 RustExpr::Operation(op) => op.check_eval_purity(),
                 RustExpr::BlockScope(stmts, expr) => {
                     stmts.check_eval_purity() | expr.check_eval_purity()
                 }
                 RustExpr::Macro(RustMacro::Matches(expr, ..)) => expr.check_eval_purity(),
+                RustExpr::Macro(RustMacro::Vec(vec_expr)) => vec_expr.check_eval_purity(),
                 RustExpr::Control(ctrl) => ctrl.check_eval_purity(),
                 RustExpr::Index(head, index) => {
                     head.check_eval_purity() | index.check_eval_purity()
@@ -3458,6 +3539,28 @@ pub mod short_circuit {
                 RustExpr::RangeExclusive(start, stop) => {
                     start.check_eval_purity() | stop.check_eval_purity()
                 }
+            }
+        }
+    }
+
+    impl ShortCircuit for VecExpr {
+        fn is_short_circuiting(&self) -> bool {
+            match self {
+                VecExpr::Nil => false,
+                VecExpr::Single(x) => x.is_short_circuiting(),
+                VecExpr::Repeat(x, n) => x.is_short_circuiting() || n.is_short_circuiting(),
+                VecExpr::List(xs) => xs.is_short_circuiting(),
+            }
+        }
+    }
+
+    impl ShortCircuitExt for VecExpr {
+        fn check_eval_purity(&self) -> EvalPurity {
+            match self {
+                VecExpr::Nil => EvalPurity::Pure,
+                VecExpr::Single(x) => x.check_eval_purity(),
+                VecExpr::Repeat(x, n) => x.check_eval_purity() | n.check_eval_purity(),
+                VecExpr::List(xs) => xs.check_eval_purity(),
             }
         }
     }
@@ -3523,7 +3626,9 @@ pub use short_circuit::{ShortCircuit, ShortCircuitExt, ValueCheckpoint};
 
 pub mod var_container {
     use super::{
-        ClosureBody, MatchCaseLHS, OwnedRustExpr, RustCatchAll, RustClosure, RustClosureHead, RustControl, RustEntity, RustExpr, RustMacro, RustMatchBody, RustMatchCase, RustOp, RustPattern, RustStmt, StructExpr
+        ClosureBody, MatchCaseLHS, OwnedRustExpr, RustCatchAll, RustClosure, RustClosureHead,
+        RustControl, RustEntity, RustExpr, RustMacro, RustMatchBody, RustMatchCase, RustOp,
+        RustPattern, RustStmt, StructExpr, VecExpr,
     };
 
     pub trait VarBinder {
@@ -3721,6 +3826,7 @@ pub mod var_container {
                         || (!stmts.binds_var(var) && expr.contains_var_ref(var))
                 }
                 RustExpr::Macro(RustMacro::Matches(expr, ..)) => expr.contains_var_ref(var),
+                RustExpr::Macro(RustMacro::Vec(vec_expr)) => vec_expr.contains_var_ref(var),
                 RustExpr::Control(ctrl) => ctrl.contains_var_ref(var),
                 RustExpr::PrimitiveLit(..) => false,
                 RustExpr::ArrayLit(rust_exprs) => {
@@ -3737,6 +3843,20 @@ pub mod var_container {
                 RustExpr::RangeExclusive(lo, hi) => {
                     lo.contains_var_ref(var) || hi.contains_var_ref(var)
                 }
+            }
+        }
+    }
+
+    impl VarContainer for VecExpr {
+        fn contains_var_ref<Name>(&self, var: &Name) -> bool
+        where
+            Name: AsRef<str> + ?Sized,
+        {
+            match self {
+                VecExpr::Nil => false,
+                VecExpr::Single(x) => x.contains_var_ref(var),
+                VecExpr::Repeat(x, n) => x.contains_var_ref(var) || n.contains_var_ref(var),
+                VecExpr::List(xs) => xs.contains_var_ref(var),
             }
         }
     }

--- a/src/codegen/rust_ast/mod.rs
+++ b/src/codegen/rust_ast/mod.rs
@@ -1345,8 +1345,8 @@ impl ToFragment for StructExpr {
 
 #[derive(Debug, Clone)]
 pub(crate) struct OwnedRustExpr {
-    expr: Box<RustExpr>,
-    kind: OwnedKind,
+    pub expr: Box<RustExpr>,
+    pub kind: OwnedKind,
 }
 
 #[derive(Debug, Clone)]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -277,6 +277,11 @@ pub fn tuple(formats: impl IntoIterator<Item = Format>) -> Format {
     Format::Tuple(formats.into_iter().collect())
 }
 
+/// Helper-function for [`Format::Sequence`] that can take any iterable container of [`Format`]s.
+pub fn seq(formats: impl IntoIterator<Item = Format>) -> Format {
+    Format::Sequence(formats.into_iter().collect())
+}
+
 /// Helper-function for [`Format::Union`] over branches that are all [`Format::Variant`].
 ///
 /// Accepts any iterable container of tuples `(Name, Format)` for any `Name` that implements [`IntoLabel`].
@@ -566,9 +571,14 @@ pub fn not_byte(b: u8) -> Format {
     Format::Byte(!ByteSet::from([b]))
 }
 
-/// Returns a format that matches a given byte-sequence.
+/// Returns a format that matches a given byte-sequence and returns a tuple.
 pub fn is_bytes(bytes: &[u8]) -> Format {
     tuple(bytes.iter().copied().map(is_byte))
+}
+
+/// Returns a format that matches a given byte-sequence and returns an array/vector.
+pub fn byte_seq(bytes: &[u8]) -> Format {
+    seq(bytes.iter().copied().map(is_byte))
 }
 
 /// Helper const for a format that matches every byte.

--- a/src/output/flat.rs
+++ b/src/output/flat.rs
@@ -143,7 +143,7 @@ fn check_covered(
                 check_covered(module, path, format)?;
             }
         }
-        Format::Tuple(formats) => {
+        Format::Tuple(formats) | Format::Sequence(formats) => {
             for format in formats {
                 check_covered(module, path, format)?;
             }
@@ -258,6 +258,16 @@ impl<'module, W: io::Write> Context<'module, W> {
                     Ok(())
                 }
                 _ => panic!("expected tuple, found {value:?}"),
+            },
+            Format::Sequence(formats) => match value {
+                Value::Seq(seq_kind) => {
+                    for (index, value) in seq_kind.iter().enumerate() {
+                        let format = &formats[index];
+                        self.write_flat(value, format)?;
+                    }
+                    Ok(())
+                }
+                _ => panic!("expected sequence, found {value:?}"),
             },
             Format::Repeat(format)
             | Format::Repeat1(format)

--- a/src/precedence.rs
+++ b/src/precedence.rs
@@ -221,6 +221,9 @@ impl Precedence {
 
     pub(crate) const FORMAT_COMPOUND: Self = Self::Top;
 
+    // REVIEW - does list-append need its own precedence or is this good enough?
+    pub(crate) const APPEND: Self = Precedence::ArithInfix(ArithLevel::AddSub);
+
     pub(crate) fn bump_format(&self) -> Self {
         match self {
             Precedence::Top => Precedence::Atomic,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -81,6 +81,17 @@ where
     Ok(res)
 }
 
+/// Joins two slices into a single vector via iterator chaining, returning the result
+pub fn seq_append<T, S>(lhs: impl AsRef<S>, rhs: impl AsRef<S>) -> Vec<T>
+where
+    T: Clone,
+    for<'a> &'a S: IntoIterator<Item = &'a T>,
+{
+    let lhs_iter = lhs.as_ref().into_iter().cloned();
+    let rhs_iter = rhs.as_ref().into_iter().cloned();
+    Iterator::chain(lhs_iter, rhs_iter).collect()
+}
+
 /// Performs a fold/reduce-style operation on a given list, starting from an initial accumulator value
 /// and replacing it with the evaluation of `f(accum, elem)` for each element in the iterator, in order.
 ///

--- a/tests/expected/decode/test.png.stdout
+++ b/tests/expected/decode/test.png.stdout
@@ -1,5 +1,14 @@
 └── data <- _ |...| _ :=
     └── png <- png.main :=
+        ├── signature <- [ ... ] :=
+        │   ├── 0
+        │   ├── 1
+        │   ├── 2
+        │   ├── 3
+        │   ├── 4
+        │   ├── 5
+        │   ├── 6
+        │   └── 7
         ├── ihdr <- png.ihdr :=
         │   ├── length <- assert (length -> length <= 2147483647) base.u32be := 13
         │   ├── tag <- png.ihdr-tag


### PR DESCRIPTION
Adds `Format::Sequence`, which is effectively a restricted form of `Format::Tuple` for parses of the same type, which returns them in a `Seq` container rather than an N-tuple.