### PR TITLE
Improve indentation control in `otf_metrics::display` model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,8 @@ dependencies = [
  "doodle",
  "encoding",
  "fixed",
+ "log",
+ "stderrlog",
 ]
 
 [[package]]

--- a/generated/Cargo.toml
+++ b/generated/Cargo.toml
@@ -46,3 +46,5 @@ clap = { version = "4.2", features = ["derive"] }
 derive_builder = "0.20.2"
 fixed = "1.28.0"
 cfg-if = "1.0.0"
+log = "0.4.29"
+stderrlog = "0.6.0"

--- a/generated/api_helper/otf_metrics.rs
+++ b/generated/api_helper/otf_metrics.rs
@@ -3009,11 +3009,13 @@ struct GdefTableDataMetrics {
 }
 
 /**
+```ignore
    0 <=> No Glyph Class assigned (implicit default)
    1 <=> Base glyph (single character, spacing glyph)
    2 <=> Ligature glyph (multiple character, spacing glyph)
    3 <=> Mark glyph (non-spacing combining glyph)
    4 <=> Component glyph (part of a single character, spacing glyph)
+```
 */
 type GlyphClass = u16; // REVIEW - consider replacing with semantically distinguished const-enum
 
@@ -7233,7 +7235,10 @@ fn is_extra(table_id: &u32) -> bool {
     match TableKind::try_from(*table_id) {
         Ok(table_kind) => !table_kind.is_implemented(),
         Err(e) => {
-            log::warn!("is_extra: unknown table id {}: {e}", output::display_u32_ascii(*table_id).into_string());
+            log::warn!(
+                "is_extra: unknown table id {}: {e}",
+                output::display_u32_ascii(*table_id).into_string()
+            );
             false
         }
     }

--- a/generated/api_helper/otf_metrics.rs
+++ b/generated/api_helper/otf_metrics.rs
@@ -10,9 +10,6 @@ use encoding::{
 };
 use fixed::types::{I2F14, I16F16};
 
-/// Half-Tab for partial indentation
-const HT: &str = "    ";
-
 // SECTION - CLI-related utilities
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
 #[repr(u8)]
@@ -7229,11 +7226,16 @@ pub mod table {
 }
 
 /// Returns `true` if `table_id` is not a first-class OpenType table in our current implementation
+///
+/// Returns `false` if `table_id` is recognized and supported, or if it is not recognized to begin with.
 fn is_extra(table_id: &u32) -> bool {
     use table::TableKind;
     match TableKind::try_from(*table_id) {
         Ok(table_kind) => !table_kind.is_implemented(),
-        Err(e) => unreachable!("is_extra: {e}"),
+        Err(e) => {
+            log::warn!("is_extra: unknown table id {}: {e}", output::display_u32_ascii(*table_id).into_string());
+            false
+        }
     }
 }
 

--- a/generated/api_helper/otf_metrics/arrayfmt.rs
+++ b/generated/api_helper/otf_metrics/arrayfmt.rs
@@ -4,18 +4,21 @@ use super::display::{
 };
 use crate::api_helper::util::{EnumLen, Wec, trisect_unchecked};
 
-/// Generic helper for displaying an array of possibly-None elements, skipping over
-/// all None-values and only showing up to the first, and last `N` elements, where
-/// `N` is determined by `bookend` (shows all elements if the lenght is less than or equal to `2 * bookend`).
+/// Multiline display helper for arrays of possibly-None values.
 ///
-/// The `show_fn` function is used to display individual elements, and takes both the index and the value of the element in question.
+/// All elements are considered for the purposes of indexing, but no None-values are
+/// displayed; the resulting output will show up to the first, and last `N` elements, where
+/// `N` is determined by `bookend` (shows all elements if the number of non-None elements is less than or equal to `2 * bookend`).
 ///
-/// The `ellipsis` function is used to signal information about the skipped middle-elements (if any), and takes two arguments:
-/// the number of elements that were skipped over (after filtering out None-values), and a tuple `(start, stop)` where `start` is the first
-/// element-index skipped and `stop` is the element-index where display resumes.
+/// The `display_fn` closure is used to display individual elements, and takes both the index and the value of the element in question.
+/// In particular, the index is the original index in the input array, and not a re-indexing after filtering out None-values.
+///
+/// The `ellipsis` closure is used to signal information about the skipped middle-elements (if any), and takes two arguments:
+/// the number of elements that were skipped over (after filtering out None-values), and a tuple `(start, stop)` where `start` is the
+/// true index of the first element skipped and `stop` is the true index of the element where display resumes.
 pub(crate) fn display_nullable<T>(
     opt_items: &[Option<T>],
-    mut show_fn: impl FnMut(usize, &T) -> TokenStream<'static>,
+    mut display_fn: impl FnMut(usize, &T) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl Fn(usize, (usize, usize)) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -34,7 +37,7 @@ pub(crate) fn display_nullable<T>(
             unsafe { trisect_unchecked(&items, bookend, bookend) };
 
         for (ix, it) in left_bookend {
-            buffer.push(show_fn(*ix, it));
+            buffer.push(display_fn(*ix, it));
         }
 
         let n_skipped = count - bookend * 2;
@@ -42,28 +45,25 @@ pub(crate) fn display_nullable<T>(
         buffer.push(ellipsis(n_skipped, (middle[0].0, middle[n_skipped - 1].0)));
 
         for (ix, it) in right_bookend {
-            buffer.push(show_fn(*ix, it));
+            buffer.push(display_fn(*ix, it));
         }
     } else {
         for (ix, it) in items.into_iter() {
-            buffer.push(show_fn(ix, it));
+            buffer.push(display_fn(ix, it));
         }
     }
     TokenStream::join_with(buffer, LineBreak)
 }
 
-/// Generic helper for displaying an array of possibly-None elements, skipping over
-/// all None-values and only showing up to the first, and last `N` elements, where
-/// `N` is determined by `bookend` (shows all elements if the lenght is less than or equal to `2 * bookend`).
+/// Inline display helper for arrays of possibly-None values.
 ///
-/// The `show_fn` function is used to display individual elements, and takes both the index and the value of the element in question.
+/// Uses the same semantics and signature as [`display_nullable`], but formats the resulting output as an inline list of items
+/// separated by commas and bounded with brackets, rather than a vertical list of items separated by line-breaks.
 ///
-/// The `ellipsis` function is used to signal information about the skipped middle-elements (if any), and takes two arguments:
-/// the number of elements that were skipped over (after filtering out None-values), and a tuple `(start, stop)` where `start` is the first
-/// element-index skipped and `stop` is the element-index where display resumes.
+/// As all elements will be formatted on the same line, the `display_fn` closure should not include any line-breaks or indentation.
 pub(crate) fn display_inline_nullable<T>(
     opt_items: &[Option<T>],
-    mut show_fn: impl FnMut(usize, &T) -> TokenStream<'static>,
+    mut display_fn: impl FnMut(usize, &T) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl Fn(usize, (usize, usize)) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -82,7 +82,7 @@ pub(crate) fn display_inline_nullable<T>(
             unsafe { trisect_unchecked(&items, bookend, bookend) };
 
         for (ix, it) in left_bookend {
-            buffer.push(show_fn(*ix, it));
+            buffer.push(display_fn(*ix, it));
         }
 
         let n_skipped = count - bookend * 2;
@@ -90,26 +90,28 @@ pub(crate) fn display_inline_nullable<T>(
         buffer.push(ellipsis(n_skipped, (middle[0].0, middle[n_skipped - 1].0)));
 
         for (ix, it) in right_bookend {
-            buffer.push(show_fn(*ix, it));
+            buffer.push(display_fn(*ix, it));
         }
     } else {
         for (ix, it) in items.into_iter() {
-            buffer.push(show_fn(ix, it));
+            buffer.push(display_fn(ix, it));
         }
     }
     TokenStream::join_with(buffer, tok(", ")).bracket()
 }
 
-/// Generic helper for displaying an array of elements, showing at most `bookend` elements at the start and end of the array and a single ellipsis if the array is longer than `2 * bookend`.
+/// Inline display helper for arrays.
 ///
-/// Each element that is to be displayed is formatted using the provided closure `fmt_fn`.
+/// Formats the elements of the input array as an inline list of items (each produced by `display_fn`) separated by the token `", "` and bounded with brackets,
+/// with an elision-string based on the number of medial elements skipped when the array is long enough (i.e. when the number of elements exceeds `2 * bookend`).
 ///
-/// All elements will be written on the same line, and so the `fmt_fn` closure should not include any line-breaks.
+/// The `ellipsis` closure is used to produce such an elision-string, which takes as its sole parameter the number of skipped middle-elements.
+/// When no elements are skipped, `ellipsis` will not be called and no elision-string will be included in the output.
 ///
-/// The `ellipsis` function is used to signal information about the skipped middle-elements (if any), and takes the number of elements that were skipped over.
+/// All elements will be written on the same line, and so the `display_fn` closure should not include any line-breaks or indentation.
 pub(crate) fn display_items_inline<T>(
     items: &[T],
-    mut fmt_fn: impl FnMut(&T) -> TokenStream<'static>,
+    mut display_fn: impl FnMut(&T) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl Fn(usize) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -120,27 +122,33 @@ pub(crate) fn display_items_inline<T>(
     let count = items.len();
     if count > bookend * 2 {
         for item in &items[..bookend] {
-            buffer.push(fmt_fn(item));
+            buffer.push(display_fn(item));
         }
 
         buffer.push(ellipsis(count - bookend * 2));
 
         for item in &items[count - bookend..] {
-            buffer.push(fmt_fn(item));
+            buffer.push(display_fn(item));
         }
     } else {
-        buffer.extend(items.iter().map(fmt_fn));
+        buffer.extend(items.iter().map(display_fn));
     }
     TokenStream::join_with(buffer, tok(", ")).bracket()
 }
 
-/// Enumerates the contents of a slice, showing only the first and last `bookend` items if the slice is long enough.
+/// Multiline display helper for arrays.
 ///
-/// Each item is shown with `show_fn`, and `fn_message` is used to signal the range of indices skipped.
-/// If the slice length is less than or equal to `2 * bookend`, all elements are displayed and `ellipsis` is not called.
+/// Formats each element of the input array as a separate line (using `display_fn`), showing only the first and last `bookend` items if the array is long enough (i.e. when the number of elements exceeds `2 * bookend`).
+///
+/// The `display_fn` closure takes both the index and the value of each element, and should produce a `TokenStream` representing the intended multiline display of that element (including any line-breaks or indentation).
+///
+/// When the array is long enough to warrant elision, the `ellipsis` closure is used to produce a `TokenStream` representing the desired format of the elision-string, taking as parameters the indices of the first and last items to be elided.
+/// Namely, the first parameter is the index immediately following the last item shown in the initial bookend, and the second parameter is the index preceding the first item shown in the terminal bookend.
+///
+/// If the length of `items` is less than or equal to `2 * bookend`, no elision is performed and the `ellipsis` closure will not be called.
 pub(crate) fn display_items_elided<T>(
     items: &[T],
-    show_fn: impl Fn(usize, &T) -> TokenStream<'static>,
+    display_fn: impl Fn(usize, &T) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl Fn(usize, usize) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -150,40 +158,55 @@ pub(crate) fn display_items_elided<T>(
     let count = items.len();
     if count > bookend * 2 {
         for (ix, item) in items.iter().enumerate().take(bookend) {
-            buffer.push(show_fn(ix, item));
+            buffer.push(display_fn(ix, item));
         }
 
         buffer.push(ellipsis(bookend, count - bookend));
 
         for (ix, item) in items.iter().enumerate().skip(count - bookend) {
-            buffer.push(show_fn(ix, item));
+            buffer.push(display_fn(ix, item));
         }
     } else {
-        buffer.extend(items.iter().enumerate().map(|(ix, item)| show_fn(ix, item)));
+        buffer.extend(
+            items
+                .iter()
+                .enumerate()
+                .map(|(ix, item)| display_fn(ix, item)),
+        );
     }
     TokenStream::join_with(buffer, LineBreak)
 }
 
-// Enumerates the contents of a Wec<T>, showing only the first and last `bookend` rows if the Wec is tall enough.
+/// Multiline display helper for [`Wec`]-based 2D matrices.
 ///
-/// Each row is shown with `show_fn`, and the `elision_message` is printed (along with the range of indices skipped)
-/// if the slice length exceeds than 2 * `bookend`, in between the initial and terminal span of `bookend` items.
+/// For each row of the matrix, `display_fn` is used to produce a `TokenStream` corresponding to the intended display of that row, and the resulting output is the vertical concatenation of these per-row displays, with an optional elision-string in the middle when the number of rows exceeds `2 * bookend`.
+///
+/// As each row of the `Wec` is already a slice of items, the `display_fn` closure takes as parameters the row-index and a slice consisting of the elements of that row.
+///
+/// The closure `ellipsis` is called if the number of rows exceeds `2 * bookend`, and produces the elision-string that is displayed on its own line between the first and last `N` rows that are directly displayed, where `N` is the value passed to `bookend`.
+/// This closure takes, as its parameters, the indices of the first and last rows to be elided. Namely, the first parameter is the index immediately following the last row shown in the initial bookend, and the second parameter is row-index immediately prior to
+/// the first row shown in the terminal bookend.
+///
+/// # Notes
+///
+/// The closure passed in as `display_fn` will most often make use of one of the other display helpers in this module to format the individual rows. In such cases, care should be taken to either ensure that
+/// the output is entirely inline, or to increment indentation of indexed items if multiline, to avoid ambiguity between the indexing of rows and the indexing of items within each row.
 pub(crate) fn display_wec_rows_elided<T>(
     matrix: &Wec<T>,
-    show_fn: impl Fn(usize, &[T]) -> TokenStream<'static>,
+    display_fn: impl Fn(usize, &[T]) -> TokenStream<'static>,
     bookend: usize,
-    fn_message: impl Fn(usize, usize) -> TokenStream<'static>,
+    ellipsis: impl Fn(usize, usize) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
     let count = matrix.rows();
     let mut lines = Vec::with_capacity(Ord::min(count, bookend * 2 + 1));
 
     if count > bookend * 2 {
         for ix in 0..bookend {
-            lines.push(show_fn(ix, &matrix[ix]));
+            lines.push(display_fn(ix, &matrix[ix]));
         }
-        lines.push(fn_message(bookend, count - bookend));
+        lines.push(ellipsis(bookend, count - bookend));
         for ix in (count - bookend)..count {
-            lines.push(show_fn(ix, &matrix[ix]));
+            lines.push(display_fn(ix, &matrix[ix]));
         }
     } else {
         let mut lines = Vec::with_capacity(count);
@@ -191,20 +214,25 @@ pub(crate) fn display_wec_rows_elided<T>(
             matrix
                 .iter_rows()
                 .enumerate()
-                .map(|(ix, row)| show_fn(ix, row)),
+                .map(|(ix, row)| display_fn(ix, row)),
         );
     }
     TokenStream::join_with(lines, LineBreak)
 }
 
-/// Like `display_items_inline`, but for arrays of items that are cross-indexed against glyph-ids in a coverage table.
+/// Inline display helper for arrays of items that are cross-indexed against glyph-ids in a coverage table.
 ///
-/// Takes an additional parameter `coverage`, an iterator with the same cardinality as `items`; `fmt_fn` takes a `u16`
-/// parameter equal to the GlyphId at the corresponding index for each displayed element in `items`.
+/// The `display_fn` closure takes both the GlyphId and the item value as parameters, and should produce a `TokenStream` representing the intended inline display of that item given the
+/// glyphId it is associated with.
+///
+/// In terms of the formatting of the output, this function is functionally equivalent to `display_items_inline`.
+///
+/// Takes an additional parameter `coverage`, an iterator containing as many glyph-ids as there are items in the input array,
+/// and the elements it yields are understood to be in the same order as the items in the input array.
 pub(crate) fn display_coverage_linked_array<T>(
     items: &[T],
     coverage: impl Iterator<Item = u16>,
-    mut fmt_fn: impl FnMut(u16, &T) -> TokenStream<'static>,
+    mut display_fn: impl FnMut(u16, &T) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl FnOnce(usize) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -215,19 +243,20 @@ pub(crate) fn display_coverage_linked_array<T>(
 
     if count > bookend * 2 {
         for (ix, glyph_id) in ix_iter.iter_with().take(bookend) {
-            buffer.push(fmt_fn(glyph_id, &items[ix]));
+            buffer.push(display_fn(glyph_id, &items[ix]));
         }
 
         let n_skipped = count - bookend * 2;
 
+        // REVIEW - do we care to mention the first and last glyphIds elided, or is the number of skipped elements good enough?
         buffer.push(ellipsis(n_skipped));
 
         for (ix, glyph_id) in ix_iter.iter_with().skip(n_skipped).take(bookend) {
-            buffer.push(fmt_fn(glyph_id, &items[ix]));
+            buffer.push(display_fn(glyph_id, &items[ix]));
         }
     } else {
         for (ix, glyph_id) in ix_iter.iter_with() {
-            buffer.push(fmt_fn(glyph_id, &items[ix]));
+            buffer.push(display_fn(glyph_id, &items[ix]));
         }
     }
 
@@ -241,20 +270,21 @@ pub(crate) fn display_coverage_linked_array<T>(
     TokenStream::join_with(buffer, tok(", ")).bracket()
 }
 
-/// Formats a table column as an inline TokenStream for horizontally-oriented table-display.
+/// Inline  helper for horizontally-oriented display of an individual column of a table.
 ///
 /// The resulting `TokenStream` will begin with `heading` (which should be justified across lines of the same table),
-/// and will contain up to `bookend` leading and trailing entries of the `items` array, each tokenized using `show_fn`,
+/// and will contain up to `bookend` leading and trailing entries of the `items` array, each tokenized using `display_fn`,
 /// and separated with a single whitespace character (`' '`).
 ///
-/// Includes a conditional elision-string returned by `ellipsis` (parametrized by the number of entries elided).
+/// Conditionally includes an elision-string returned by `ellipsis`, called with the number of skipped middle-items.
 ///
 /// # Notes
 ///
-/// In order to ensure that each inline-column of a table has horizontally aligned entries, the tokenization of
-/// each item, as well as the `ellipsis` string, should be fixed-width, e.g. by space-padding or 0-padding numeric values.
-///
-/// Furthermore, the `header` strings should all be of consistent width.
+/// When used for per-column display of a table with more than one column, care should be taken to ensure
+/// that the `heading` parameter is of consistent width and justification across all columns of the same table,
+/// and that the closures used for `display_fn` and `ellipsis` produce fixed-width output
+/// (e.g. by space-padding or 0-padding numeric values), so that entries in the same row of the overall
+/// table are properly aligned.
 ///
 /// # Example
 ///
@@ -277,7 +307,7 @@ pub(crate) fn display_coverage_linked_array<T>(
 pub fn display_table_column_horiz<A>(
     heading: &'static str,
     items: &[A],
-    mut show_fn: impl FnMut(&A) -> TokenStream<'static>,
+    mut display_fn: impl FnMut(&A) -> TokenStream<'static>,
     bookend: usize,
     ellipsis: impl FnOnce(usize) -> TokenStream<'static>,
 ) -> TokenStream<'static> {
@@ -288,17 +318,17 @@ pub fn display_table_column_horiz<A>(
             unsafe { trisect_unchecked(items, bookend, bookend) };
 
         for it in left_bookend {
-            buf.push(show_fn(it));
+            buf.push(display_fn(it));
         }
 
         let n_skipped = count - bookend * 2;
         buf.push(ellipsis(n_skipped));
 
         for it in right_bookend {
-            buf.push(show_fn(it));
+            buf.push(display_fn(it));
         }
     } else {
-        buf.extend(items.iter().map(show_fn));
+        buf.extend(items.iter().map(display_fn));
     }
 
     tok(heading).then(TokenStream::join_with(buf, tok(" ")))

--- a/generated/api_helper/otf_metrics/display.rs
+++ b/generated/api_helper/otf_metrics/display.rs
@@ -182,14 +182,37 @@ impl<'a> TokenStream<'a> {
     /// Returns a new `TokenStream` where each line in `self` is indented by `stops` half-tabs (i.e. 4 spaces).
     ///
     /// Will prefer using `'\t'` for indentation, and will include a final half-tab iff `stops` is odd.
-    pub fn indent_by(self, stops: u8) -> Self {
-        let increase = std::iter::repeat(Token::IncreaseIndent).take(stops as usize);
-        let decrease = std::iter::repeat(Token::DecreaseIndent).take(stops as usize);
+    ///
+    /// Can take a negative value, but the formatting will be incorrect when underflowing the current absolute indentation level.
+    pub fn indent_by(self, stops: i8) -> Self {
+        // REVIEW - we can change the implementation of IndentIter to support negative stops as equivalent-to-zero and thereby avoid the underflow misalignment-on-reset
+        match stops.signum() {
+            0 => return self,
+            1 => (),
+            -1 => return self.decrease_indent_by(-stops as u8),
+            _ => unreachable!(),
+        }
+
+        let shift = std::iter::repeat(Token::IncreaseIndent).take(stops as usize);
+        let reset = std::iter::repeat(Token::DecreaseIndent).take(stops as usize);
         TokenStream {
             inner: Box::new(
-                increase
-                    .chain(self.inner)
-                    .chain(decrease), // We rely on the fact that `IndentIter` will ignore all indent tokens at the end of the stream, so we can safely append the necessary `DecreaseIndent` tokens here without worrying about trailing newlines in `self`
+                shift.chain(self.inner).chain(reset), // We rely on the fact that `IndentIter` will ignore all indent tokens at the end of the stream, so we can safely append the necessary `DecreaseIndent` tokens here without worrying about trailing newlines in `self`
+            ),
+        }
+    }
+
+    /// Internal helper for `indent_by` to decrease indentation by a positive number of stops.
+    ///
+    /// # Notes
+    ///
+    /// If the current indentation level is less than `stops`, the subsequent re-indentation will be incorrect, as the underflow is silently ignored.
+    fn decrease_indent_by(self, stops: u8) -> Self {
+        let shift = std::iter::repeat(Token::DecreaseIndent).take(stops as usize);
+        let reset = std::iter::repeat(Token::IncreaseIndent).take(stops as usize);
+        TokenStream {
+            inner: Box::new(
+                shift.chain(self.inner).chain(reset), // We rely on the fact that `IndentIter` will ignore all indent tokens at the end of the stream, so we can safely append the necessary `DecreaseIndent` tokens here without worrying about trailing newlines in `self`
             ),
         }
     }

--- a/generated/api_helper/otf_metrics/display.rs
+++ b/generated/api_helper/otf_metrics/display.rs
@@ -15,6 +15,8 @@ pub fn toks(str: impl Into<doodle::Label>) -> TokenStream<'static> {
 pub enum Token {
     InlineText(doodle::Label),
     LineBreak,
+    IncreaseIndent,
+    DecreaseIndent,
 }
 
 impl std::fmt::Display for Token {
@@ -22,6 +24,7 @@ impl std::fmt::Display for Token {
         match self {
             Token::InlineText(s) => write!(f, "{s}"),
             Token::LineBreak => write!(f, "\n"),
+            Token::IncreaseIndent | Token::DecreaseIndent => Ok(()), // No visual representation for indent tokens, since they are handled implicitly by `IndentIter`
         }
     }
 }
@@ -72,7 +75,8 @@ impl<'a> TokenStream<'a> {
     /// If successful, returns `Ok(true)` if at least one token was written and `Ok(false)` if `self` was empty.
     pub fn write_to<W: std::io::Write>(self, mut w: W) -> std::io::Result<bool> {
         let mut has_written = false;
-        for token in self.inner {
+        let writer = IndentIter::new(Indent::default(), self.inner);
+        for token in writer {
             write!(w, "{token}")?;
             has_written = true;
         }
@@ -120,6 +124,8 @@ impl<'a> TokenStream<'a> {
         for token in self.inner {
             match token {
                 Token::InlineText(s) => line.push_str(&s),
+                Token::DecreaseIndent => lines.push(Token::DecreaseIndent),
+                Token::IncreaseIndent => lines.push(Token::IncreaseIndent),
                 Token::LineBreak => {
                     lines.push(Token::InlineText(std::borrow::Cow::Owned(line.clone())));
                     line.clear();
@@ -173,21 +179,19 @@ impl<'a> TokenStream<'a> {
         }
     }
 
-    /// Prepends indentation to the first line of the stream, measured in 4-space half-tabs.
+    /// Returns a new `TokenStream` where each line in `self` is indented by `stops` half-tabs (i.e. 4 spaces).
     ///
     /// Will prefer using `'\t'` for indentation, and will include a final half-tab iff `stops` is odd.
-    pub fn pre_indent(self, stops: u8) -> Self {
-        let tabs = stops / 2;
-        let hts = stops % 2;
-
-        let mut indent = String::new();
-        for _ in 0..tabs {
-            indent.push('\t');
+    pub fn indent_by(self, stops: u8) -> Self {
+        let increase = std::iter::repeat(Token::IncreaseIndent).take(stops as usize);
+        let decrease = std::iter::repeat(Token::DecreaseIndent).take(stops as usize);
+        TokenStream {
+            inner: Box::new(
+                increase
+                    .chain(self.inner)
+                    .chain(decrease), // We rely on the fact that `IndentIter` will ignore all indent tokens at the end of the stream, so we can safely append the necessary `DecreaseIndent` tokens here without worrying about trailing newlines in `self`
+            ),
         }
-        for _ in 0..hts {
-            indent.push_str(super::HT);
-        }
-        tok(indent).then(self)
     }
 
     /// Joins a stream of streams with a given separator.
@@ -199,6 +203,75 @@ impl<'a> TokenStream<'a> {
             )),
         }
     }
+}
+
+pub struct IndentIter<'a> {
+    level: Indent,
+    stream: Box<dyn Iterator<Item = Token> + 'a>,
+    at_line_start: bool,
+    // Temporary cache for the next token to be emitted by `stream`, to avoid indenting after the final linebreak in `stream`
+    next_token: Option<Token>,
+}
+
+impl<'a> IndentIter<'a> {
+    fn new(level: Indent, stream: Box<dyn Iterator<Item = Token> + 'a>) -> Self {
+        Self {
+            level,
+            stream,
+            at_line_start: true,
+            next_token: None,
+        }
+    }
+}
+
+impl<'a> Iterator for IndentIter<'a> {
+    type Item = Token;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(tok) = self.next_token.take() {
+            return Some(tok);
+        } else {
+            let next = self.stream.next();
+            match next {
+                Some(Token::LineBreak) => {
+                    self.at_line_start = true;
+                    return next;
+                }
+                Some(Token::IncreaseIndent) => {
+                    self.level.0 += 1;
+                    return self.next();
+                }
+                Some(Token::DecreaseIndent) => {
+                    self.level.0 = self.level.0.saturating_sub(1);
+                    return self.next();
+                }
+                Some(tok) => {
+                    if self.at_line_start {
+                        self.next_token = Some(tok);
+                        self.at_line_start = false;
+                        let full_tabs = self.level.0 / 2;
+                        let partial_tabs = self.level.0 % 2;
+
+                        let indent_str = "\t".repeat(full_tabs as usize)
+                            + if partial_tabs > 0 { Indent::HT } else { "" };
+                        return Some(Token::InlineText(indent_str.into()));
+                    } else {
+                        return Some(tok);
+                    }
+                }
+                None => return None,
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+/// Newtype representing indentation level, measured in 4-space half-tabs.
+pub struct Indent(u8);
+
+impl Indent {
+    /// Half-Tab for partial indentation
+    pub const HT: &str = "    ";
 }
 
 pub struct IntersperseIter<'a, T: Clone> {

--- a/generated/api_helper/otf_metrics/output.rs
+++ b/generated/api_helper/otf_metrics/output.rs
@@ -36,7 +36,7 @@ fn display_sfnt_version(magic: u32) -> TokenStream<'static> {
 }
 
 /// Tokenizer used for displaying 32-bit binary values as four ASCII characters interpreted in big-endian order. (inline)
-fn display_u32_ascii(val: u32) -> TokenStream<'static> {
+pub(crate) fn display_u32_ascii(val: u32) -> TokenStream<'static> {
     let bytes = val.to_be_bytes();
     let mut buf: [u8; 6] = *b"'    '";
     let mut space = false;
@@ -130,10 +130,8 @@ fn show_optional_metrics(optional: &OptionalTableMetrics, conf: &Config) {
     )
     .println();
 
-    // WIP - display_fvar_metrics(..).println();
-    show_fvar_metrics(optional.fvar.as_deref(), conf);
-    // WIP - display_gvar_metrics(..).println();
-    show_gvar_metrics(optional.gvar.as_deref(), conf);
+    display_fvar_metrics(optional.fvar.as_deref(), conf).println();
+    display_gvar_metrics(optional.gvar.as_deref(), conf).println();
 
     // WIP - display_kern_metrics(..).println();
     show_kern_metrics(&optional.kern, conf);
@@ -145,37 +143,52 @@ fn show_optional_metrics(optional: &OptionalTableMetrics, conf: &Config) {
     show_vmtx_metrics(&optional.vmtx, conf);
 }
 
-use gvar::show_gvar_metrics;
+use gvar::display_gvar_metrics;
 mod gvar {
     use super::*;
 
     // FIXME - rewrite into pure TokenStream
-    pub(super) fn show_gvar_metrics(gvar: Option<&GvarMetrics>, conf: &Config) {
-        let Some(gvar) = gvar else { return };
+    pub(super) fn display_gvar_metrics(
+        gvar: Option<&GvarMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(gvar) = gvar else {
+            return TokenStream::empty();
+        };
         if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-            // WIP
-            println!(
+            toks(format!(
                 "gvar: version {}",
                 format_version_major_minor(gvar.major_version, gvar.minor_version)
-            );
-            println!("\tShared Tuples ({} total):", gvar.shared_tuples.len());
-            display_shared_tuples(&gvar.shared_tuples).println();
-            println!(
-                "\tGlyph Variation Data ({} glyphs):",
-                gvar.glyph_variation_data_array.len()
-            );
-            display_glyph_variation_data_array(&gvar.glyph_variation_data_array).println();
-            // WIP
+            ))
+            .glue(
+                LineBreak,
+                TokenStream::join_with(
+                    vec![
+                        toks(format!(
+                            "Shared Tuples ({} total):",
+                            gvar.shared_tuples.len()
+                        )),
+                        display_shared_tuples(&gvar.shared_tuples),
+                        toks(format!(
+                            "Glyph Variation Data ({} glyphs):",
+                            gvar.glyph_variation_data_array.len()
+                        )),
+                        display_glyph_variation_data_array(&gvar.glyph_variation_data_array),
+                    ],
+                    LineBreak,
+                )
+                .indent_by(2),
+            )
         } else {
-            print!(
+            tok(format!(
                 "gvar: version {}",
                 format_version_major_minor(gvar.major_version, gvar.minor_version)
-            );
-            println!(
+            ))
+            .then(toks(format!(
                 "; {} shared tuples, {} glyph variation data tables",
                 gvar.shared_tuples.len(),
                 gvar.glyph_variation_data_array.len(),
-            );
+            )))
         }
     }
 
@@ -199,15 +212,15 @@ mod gvar {
                     headers,
                     |ix, header| {
                         toks(format!("[{ix}]: "))
-                            .pre_indent(6)
                             .chain(display_tuple_variation_header(header))
+                            .indent_by(2)
                     },
                     4,
                     |start, stop| {
                         toks(format!(
                             "(skipping tuple variation headers {start}..{stop})"
                         ))
-                        .pre_indent(5)
+                        .indent_by(1)
                     },
                 );
                 // WIP - we may want to show more than just the headers in future
@@ -216,21 +229,23 @@ mod gvar {
         }
     }
 
-    fn display_glyph_variation_data_array(array: &[Option<GlyphVariationData>]) -> TokenStream<'_> {
+    fn display_glyph_variation_data_array(
+        array: &[Option<GlyphVariationData>],
+    ) -> TokenStream<'static> {
         const TABLE_BOOKEND: usize = 4;
         arrayfmt::display_nullable(
             array,
             |ix, table| {
                 toks(format!("[{ix}]: "))
-                    .pre_indent(4)
                     .chain(display_glyph_variation_data(table))
+                    .indent_by(2)
             },
             TABLE_BOOKEND,
             |n, (start, stop)| {
                 toks(format!(
                     "(skipping {n} glyph variation data tables between indices {start}..{stop})"
                 ))
-                .pre_indent(3)
+                .indent_by(1)
             },
         )
     }
@@ -252,57 +267,74 @@ mod gvar {
             |shared_tuple_ix, record| {
                 toks(format!("[{shared_tuple_ix}]: "))
                     .chain(display_shared_tuple_record(record))
-                    .pre_indent(4)
+                    .indent_by(2)
             },
             RECORDS_BOOKEND,
-            |start, stop| toks(format!("(skipping shared tuples {start}..{stop})")).pre_indent(3),
+            |start, stop| toks(format!("(skipping shared tuples {start}..{stop})")).indent_by(1),
         )
     }
 }
 
-use fvar::show_fvar_metrics;
+use fvar::display_fvar_metrics;
 mod fvar {
     use super::*;
 
-    // FIXME - rewrite into pure TokenStream
-    pub(super) fn show_fvar_metrics(fvar: Option<&FvarMetrics>, conf: &Config) {
-        let Some(fvar) = fvar else { return };
+    pub(super) fn display_fvar_metrics(
+        fvar: Option<&FvarMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(fvar) = fvar else {
+            return TokenStream::empty();
+        };
         if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-            println!(
+            toks(format!(
                 "fvar: version {}",
                 format_version_major_minor(fvar.major_version, fvar.minor_version)
-            );
-            println!("\tAxes:");
-
-            // FIXME: rewerite into pure TokenStream
-            arrayfmt::display_items_elided(
-                &fvar.axes,
-                |ix, axis| tok(format!("\t\t[{ix}]: ")).then(display_variation_axis_record(axis)),
-                conf.bookend_size,
-                |start, stop| tok(format!("\t(skipping axis records {start}..{stop})")).into(),
+            ))
+            .glue(
+                LineBreak,
+                toks("Axes:")
+                    .glue(
+                        LineBreak,
+                        arrayfmt::display_items_elided(
+                            &fvar.axes,
+                            |ix, axis| {
+                                tok(format!("[{ix}]: "))
+                                    .then(display_variation_axis_record(axis))
+                                    .indent_by(2)
+                            },
+                            conf.bookend_size,
+                            |start, stop| toks(format!("(skipping axis records {start}..{stop})")),
+                        ),
+                    )
+                    .glue(LineBreak, toks("Instances:"))
+                    .glue(
+                        LineBreak,
+                        arrayfmt::display_items_elided(
+                            &fvar.instances,
+                            |ix, instance| {
+                                tok(format!("[{ix}]: "))
+                                    .then(display_instance_record(instance, conf))
+                                    .indent_by(2)
+                            },
+                            conf.bookend_size,
+                            |start, stop| {
+                                toks(format!("(skipping instance records {start}..{stop})"))
+                            },
+                        ),
+                    )
+                    .indent_by(2),
             )
-            .println();
-            println!("\tInstances:");
-            arrayfmt::display_items_elided(
-                &fvar.instances,
-                |ix, instance| {
-                    tok(format!("\t\t[{ix}]: ")).then(display_instance_record(instance, conf))
-                },
-                conf.bookend_size,
-                |start, stop| tok(format!("\t(skipping instance records {start}..{stop})")).into(),
-            )
-            .println();
         } else {
-            // FIXME - rewrite into pure TokenStream
-            print!(
+            tok(format!(
                 "fvar: version {}",
                 format_version_major_minor(fvar.major_version, fvar.minor_version)
-            );
-            println!(
+            ))
+            .then(toks(format!(
                 "; {} axes, {} instances",
                 fvar.axes.len(),
                 fvar.instances.len()
-            );
+            )))
         }
     }
 
@@ -395,27 +427,33 @@ mod gdef {
                 format_version_major_minor(*major_version, *minor_version)
             );
             if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+                // FIXME - rewrite into single TokenStream
                 if let Some(glyph_class_def) = glyph_class_def {
                     show_glyph_class_def(glyph_class_def, conf);
                 }
                 if let Some(attach_list) = attach_list {
-                    display_attach_list(attach_list, conf).println(); // WIP
+                    display_attach_list(attach_list, conf)
+                        .indent_by(2)
+                        .println();
                 }
                 if let Some(lig_caret_list) = lig_caret_list {
-                    // WIP
-                    display_lig_caret_list(lig_caret_list, conf).println();
+                    display_lig_caret_list(lig_caret_list, conf)
+                        .indent_by(2)
+                        .println();
                 }
                 if let Some(mark_attach_class_def) = mark_attach_class_def {
                     show_mark_attach_class_def(mark_attach_class_def, conf);
                 }
                 match &data.mark_glyph_sets_def {
                     // WIP
-                    None => println!("\tMarkGlyphSet: <none>"),
-                    Some(mgs) => display_mark_glyph_set(mgs, conf).println(),
+                    None => println!("MarkGlyphSet: <none>"),
+                    Some(mgs) => display_mark_glyph_set(mgs, conf).indent_by(2).println(),
                 }
                 match &data.item_var_store {
                     None => println!("\tItemVariationStore: <none>"),
-                    Some(ivs) => display_item_variation_store(ivs, conf).println(),
+                    Some(ivs) => display_item_variation_store(ivs, conf)
+                        .indent_by(2)
+                        .println(),
                 }
             }
         }
@@ -431,10 +469,9 @@ mod gdef {
 
     fn display_attach_list(attach_list: &AttachList, conf: &Config) -> TokenStream<'static> {
         toks("AttachList:")
-            .pre_indent(2)
             .glue(
                 LineBreak,
-                display_coverage_table_full(&attach_list.coverage, conf).pre_indent(4),
+                display_coverage_table_full(&attach_list.coverage, conf).indent_by(2),
             )
             .glue(
                 LineBreak,
@@ -442,7 +479,7 @@ mod gdef {
                     &attach_list.attach_points,
                     |ix, AttachPoint { point_indices }| {
                         toks(format!("[{ix}]: "))
-                            .pre_indent(4)
+                            .indent_by(2)
                             .chain(display_attach_point(point_indices, conf))
                     },
                     conf.bookend_size,
@@ -450,7 +487,7 @@ mod gdef {
                         toks(format!(
                             "(skipping attach points for glyphs {start}..{stop})"
                         ))
-                        .pre_indent(3)
+                        .indent_by(1)
                     },
                 ),
             )
@@ -463,14 +500,14 @@ mod gdef {
         toks("LigCaretList:")
             .glue(
                 LineBreak,
-                display_coverage_table_full(&lig_caret_list.coverage, conf).pre_indent(4),
+                display_coverage_table_full(&lig_caret_list.coverage, conf).indent_by(2),
             )
             .glue(
                 LineBreak,
                 arrayfmt::display_items_elided(
                     &lig_caret_list.lig_glyphs,
                     |ix, lig_glyph| {
-                        toks(format!("[{ix}]: ")).pre_indent(4).chain(
+                        toks(format!("[{ix}]: ")).indent_by(2).chain(
                             arrayfmt::display_items_inline(
                                 &lig_glyph.caret_values,
                                 display_caret_value,
@@ -481,12 +518,10 @@ mod gdef {
                     },
                     conf.bookend_size,
                     |start, stop| {
-                        toks(format!("(skipping LigGlyphs {start}..{stop})")).pre_indent(3)
+                        toks(format!("(skipping LigGlyphs {start}..{stop})")).indent_by(1)
                     },
                 ),
             )
-
-        // NOTE - since coverage tables are used in MarkGlyphSet, we don't want to force-indent within the `show_coverage_table` function, so we do it before instead.
     }
 
     // FIXME - rewrite into pure TokenStream
@@ -511,17 +546,25 @@ mod gdef {
     }
 
     fn display_mark_glyph_set(mgs: &MarkGlyphSet, conf: &Config) -> TokenStream<'static> {
-        tok("\tMarkGlyphSet:").then(LineBreak.then(arrayfmt::display_items_elided(
-            &mgs.coverage,
-            |ix, item| match item {
-                None => toks(format!("\t\t[{ix}]: <none>")).into(),
-                Some(covt) => {
-                    tok(format!("\t\t[{ix}]: ")).then(display_coverage_table_full(covt, conf))
-                }
-            },
-            conf.bookend_size,
-            |start, stop| toks(format!("\t    (skipping coverage tables {start}..{stop})")),
-        )))
+        toks("MarkGlyphSet:").glue(
+            LineBreak,
+            arrayfmt::display_items_elided(
+                &mgs.coverage,
+                |ix, item| {
+                    (match item {
+                        None => toks(format!("[{ix}]: <none>")),
+                        Some(covt) => {
+                            tok(format!("[{ix}]: ")).then(display_coverage_table_full(covt, conf))
+                        }
+                    })
+                    .indent_by(2)
+                },
+                conf.bookend_size,
+                |start, stop| {
+                    toks(format!("(skipping coverage tables {start}..{stop})")).indent_by(1)
+                },
+            ),
+        )
     }
 
     fn display_caret_value(cv: &Option<CaretValue>) -> TokenStream<'static> {
@@ -544,84 +587,94 @@ mod gdef {
         ivs: &ItemVariationStore,
         conf: &Config,
     ) -> TokenStream<'static> {
-        tok("\tItemVariationStore:")
-            .then(LineBreak.then(display_variation_regions(&ivs.variation_region_list, conf)))
-            .chain(LineBreak.then(display_variation_data_array(
-                &ivs.item_variation_data_list,
-                conf,
-            )))
+        toks("ItemVariationStore:").glue(
+            LineBreak,
+            display_variation_regions(&ivs.variation_region_list, conf).glue(
+                LineBreak,
+                display_variation_data_array(&ivs.item_variation_data_list, conf),
+            ),
+        )
     }
+
     fn display_variation_regions(vrl: &VariationRegionList, conf: &Config) -> TokenStream<'static> {
-        tok(format!(
-            "\t    VariationRegions: {} regions ({} axes)",
+        toks(format!(
+            "VariationRegions: {} regions ({} axes)",
             vrl.0.len(),
             vrl.0[0].len()
         ))
-        .then(LineBreak.then(arrayfmt::display_items_elided(
-            &vrl.0,
-            |ix, per_region| {
-                tok(format!("\t\t[{ix}]:"))
-                    .then(LineBreak.then(display_variation_axes(per_region, conf)))
-            },
-            conf.bookend_size,
-            |start_ix, end_ix| toks(format!("\t    (skipping regions {start_ix}..{end_ix})")),
-        )))
+        .glue(
+            LineBreak,
+            arrayfmt::display_items_elided(
+                &vrl.0,
+                |ix, per_region| {
+                    toks(format!("[{ix}]:"))
+                        .glue(LineBreak, display_variation_axes(per_region, conf))
+                        .indent_by(1)
+                },
+                conf.bookend_size,
+                |start_ix, end_ix| toks(format!("(skipping regions {start_ix}..{end_ix})")),
+            ),
+        )
+        .indent_by(1)
     }
     fn display_variation_data_array(
         ivda: &[Option<ItemVariationData>],
         conf: &Config,
     ) -> TokenStream<'static> {
-        // WIP - refactor using pre-indent+glue
-        tok(format!("\t    ItemVariationData[{}]", ivda.len())).then(LineBreak.then(
+        toks(format!("ItemVariationData[{}]", ivda.len())).glue(
+            LineBreak,
             arrayfmt::display_items_elided(
                 ivda,
-                |ix, o_ivd| match o_ivd {
-                    Some(ivd) => {
-                        tok(format!("\t\t[{ix}]: ")).then(display_variation_data(ivd, conf))
+                |ix, o_ivd| {
+                    match o_ivd {
+                        Some(ivd) => {
+                            tok(format!("[{ix}]: ")).then(display_variation_data(ivd, conf))
+                        }
+                        None => toks(format!("[{ix}]: <NONE>")),
                     }
-                    None => toks(format!("\t\t[{ix}]: <NONE>")),
+                    .indent_by(2)
                 },
                 conf.bookend_size,
                 |start_ix, stop_ix| {
-                    toks(format!(
-                        "\t    ...(skipping entries {start_ix}..{stop_ix})..."
-                    ))
+                    toks(format!("...(skipping entries {start_ix}..{stop_ix})...")).indent_by(1)
                 },
-            ),
-        ))
+            )
+            .indent_by(2),
+        )
     }
     fn display_variation_data(ivd: &ItemVariationData, conf: &Config) -> TokenStream<'static> {
         let full_bits = if ivd.long_words { 32 } else { 16 };
 
-        tok("ItemVariationData:")
-            .then(LineBreak.then(
-                tok(format!("\t\t\t{} region indices: ", ivd.region_index_count)).then(
-                    arrayfmt::display_items_inline(
-                        &ivd.region_indices,
-                        |ix| toks(format!("{ix}")),
-                        conf.inline_bookend,
-                        |n_skipped| toks(format!("...({n_skipped})...")),
-                    ),
-                ),
-            ))
-            .chain(
-                tok(format!(
-                    "\t\t\t{} delta-sets ({} full [{}-bit], {} half [{}-bit]): ",
-                    ivd.item_count,
-                    ivd.word_count,
-                    full_bits,
-                    ivd.region_index_count - ivd.word_count,
-                    full_bits >> 1
+        toks("ItemVariationData:").glue(
+            LineBreak,
+            toks(format!("{} region indices: ", ivd.region_index_count))
+                .chain(arrayfmt::display_items_inline(
+                    &ivd.region_indices,
+                    |ix| toks(format!("{ix}")),
+                    conf.inline_bookend,
+                    |n_skipped| toks(format!("...({n_skipped})...")),
                 ))
-                .then(LineBreak.then(display_delta_sets(&ivd.delta_sets, conf))),
-            )
+                .glue(
+                    LineBreak,
+                    toks(format!(
+                        "{} delta-sets ({} full [{}-bit], {} half [{}-bit]): ",
+                        ivd.item_count,
+                        ivd.word_count,
+                        full_bits,
+                        ivd.region_index_count - ivd.word_count,
+                        full_bits >> 1
+                    ))
+                    .glue(LineBreak, display_delta_sets(&ivd.delta_sets, conf)),
+                )
+                .indent_by(2),
+        )
     }
 
     /// Tokenizer for DeltaSets (inline).
     // STUB - scaffolding-only implementation
     fn display_delta_sets(_sets: &DeltaSets, _conf: &Config) -> TokenStream<'static> {
         // STUB - figure out what we actually want to show
-        toks(format!("<display_delta_sets: incomplete>")).pre_indent(6)
+        toks(format!("<display_delta_sets: incomplete>"))
     }
 
     fn display_variation_axes(
@@ -636,27 +689,25 @@ mod gdef {
                     |coords| toks(format!("{:.03}", coords.start_coord)),
                     conf.inline_bookend,
                     |n_skipped| toks(format!("..{n_skipped:02}..")),
-                )
-                .pre_indent(4),
+                ),
                 arrayfmt::display_table_column_horiz(
                     "  peak |",
                     per_region,
                     |coords| toks(format!("{:.03}", coords.peak_coord)),
                     conf.inline_bookend,
                     |n_skipped| toks(format!("..{n_skipped:02}..")),
-                )
-                .pre_indent(4),
+                ),
                 arrayfmt::display_table_column_horiz(
                     "   end |",
                     per_region,
                     |coords| toks(format!("{:.03}", coords.end_coord)),
                     conf.inline_bookend,
                     |n_skipped| toks(format!("..{n_skipped:02}..")),
-                )
-                .pre_indent(4),
+                ),
             ],
             LineBreak,
         )
+        .indent_by(2)
     }
 }
 
@@ -702,10 +753,13 @@ mod layout {
                 format_version_major_minor(*major_version, *minor_version)
             ));
             if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                minimal
-                    .glue(LineBreak, display_script_list(script_list, conf))
-                    .glue(LineBreak, display_feature_list(feature_list, conf))
-                    .glue(LineBreak, display_lookup_list(lookup_list, ctxt, conf))
+                minimal.glue(
+                    LineBreak,
+                    display_script_list(script_list, conf)
+                        .glue(LineBreak, display_feature_list(feature_list, conf))
+                        .glue(LineBreak, display_lookup_list(lookup_list, ctxt, conf))
+                        .indent_by(2),
+                )
             } else {
                 minimal
             }
@@ -725,9 +779,9 @@ mod layout {
     // TODO - convert to tokenstream producer
     fn display_script_list(script_list: &ScriptList, conf: &Config) -> TokenStream<'static> {
         if script_list.is_empty() {
-            toks("ScriptList [empty]").pre_indent(2)
+            toks("ScriptList [empty]")
         } else {
-            toks("ScriptList").pre_indent(2).glue(
+            toks("ScriptList").glue(
                 LineBreak,
                 arrayfmt::display_items_elided(
                     script_list,
@@ -741,12 +795,11 @@ mod layout {
                         };
 
                         toks(format!("[{ix}]: {}", item.script_tag))
-                            .pre_indent(4)
                             .glue(LineBreak, {
                                 match default_lang_sys {
                                     None => display_lang_sys_records(lang_sys_records, conf),
                                     langsys @ Some(..) => toks("[Default LangSys]: ")
-                                        .pre_indent(5)
+                                        .indent_by(1)
                                         .chain(display_langsys(langsys, conf))
                                         .glue(
                                             LineBreak,
@@ -754,10 +807,12 @@ mod layout {
                                         ),
                                 }
                             })
+                            .indent_by(1)
                     },
                     conf.bookend_size,
                     |start, stop| toks(format!("skipping ScriptRecords {start}..{stop}")),
-                ),
+                )
+                .indent_by(1),
             )
         }
     }
@@ -766,7 +821,7 @@ mod layout {
         lang_sys_records: &[LangSysRecord],
         conf: &Config,
     ) -> TokenStream<'static> {
-        let token_stream = if lang_sys_records.is_empty() {
+        if lang_sys_records.is_empty() {
             toks("LangSysRecords: <empty list>")
         } else {
             toks("LangSysRecords:").glue(
@@ -776,16 +831,14 @@ mod layout {
                     |ix, item| {
                         toks(format!("[{ix}]: {}; ", item.lang_sys_tag))
                             .chain(display_langsys(&item.lang_sys, conf))
-                            .pre_indent(6)
+                            .indent_by(1)
                     },
                     conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping LangSysRecords {start}..{stop})")).pre_indent(5)
-                    },
-                ),
+                    |start, stop| toks(format!("(skipping LangSysRecords {start}..{stop})")),
+                )
+                .indent_by(1),
             )
-        };
-        token_stream.pre_indent(5)
+        }
     }
 
     /// Tokenizer for (optional) LangSys (inline)
@@ -816,7 +869,7 @@ mod layout {
     }
 
     fn display_feature_list(feature_list: &FeatureList, conf: &Config) -> TokenStream<'static> {
-        let stream = if feature_list.is_empty() {
+        if feature_list.is_empty() {
             toks("FeatureList [empty]")
         } else {
             toks("FeatureList").glue(
@@ -830,16 +883,14 @@ mod layout {
                      }| {
                         tok(format!("[{ix}]: {feature_tag}"))
                             .then(display_feature_table(feature, conf))
-                            .pre_indent(4)
+                            .indent_by(1)
                     },
                     conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping FeatureIndices {start}..{stop})")).pre_indent(3)
-                    },
-                ),
+                    |start, stop| toks(format!("(skipping FeatureIndices {start}..{stop})")),
+                )
+                .indent_by(1),
             )
-        };
-        stream.pre_indent(2)
+        }
     }
 
     /// Tokenizer for FeatureTable (inline)
@@ -867,23 +918,20 @@ mod layout {
         ctxt: Ctxt,
         conf: &Config,
     ) -> TokenStream<'static> {
-        toks("LookupList:")
-            .glue(
-                LineBreak,
-                arrayfmt::display_items_elided(
-                    lookup_list,
-                    move |ix, table| {
-                        toks(format!("[{ix}]: "))
-                            .chain(display_lookup_table(table, ctxt, conf))
-                            .pre_indent(4)
-                    },
-                    conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping LookupTables {start}..{stop})")).pre_indent(3)
-                    },
-                ),
+        toks("LookupList:").glue(
+            LineBreak,
+            arrayfmt::display_items_elided(
+                lookup_list,
+                move |ix, table| {
+                    toks(format!("[{ix}]: "))
+                        .chain(display_lookup_table(table, ctxt, conf))
+                        .indent_by(1)
+                },
+                conf.bookend_size,
+                |start, stop| toks(format!("(skipping LookupTables {start}..{stop})")),
             )
-            .pre_indent(2)
+            .indent_by(1),
+        )
     }
 
     /// Tokenizer for `LookupTable` (inline).
@@ -1926,113 +1974,6 @@ use kern::show_kern_metrics;
 mod kern {
     use super::*;
     pub(super) fn show_kern_metrics(kern: &Option<KernMetrics>, conf: &Config) {
-        fn display_kern_subtable(subtable: &KernSubtable, conf: &Config) -> TokenStream<'static> {
-            fn format_kern_flags(flags: KernFlags) -> String {
-                let mut params = Vec::new();
-                if flags.r#override {
-                    params.push("override");
-                }
-                if flags.cross_stream {
-                    params.push("x-stream")
-                }
-                if flags.minimum {
-                    params.push("min")
-                } else {
-                    params.push("kern")
-                }
-                if flags.horizontal {
-                    params.push("h")
-                } else {
-                    params.push("v")
-                }
-
-                params.join(" | ")
-            }
-
-            fn display_kern_subtable_data(
-                subtable_data: &KernSubtableData,
-                conf: &Config,
-            ) -> TokenStream<'static> {
-                match subtable_data {
-                    KernSubtableData::Format0(KernSubtableFormat0 { kern_pairs }) => {
-                        arrayfmt::display_items_inline(
-                            kern_pairs,
-                            |kern_pair| {
-                                toks(format!(
-                                    "({},{}) {:+}",
-                                    format_glyphid_hex(kern_pair.left, true),
-                                    format_glyphid_hex(kern_pair.right, true),
-                                    kern_pair.value
-                                ))
-                            },
-                            conf.inline_bookend,
-                            |n| toks(format!("(..{n}..)")),
-                        )
-                    }
-                    KernSubtableData::Format2(KernSubtableFormat2 {
-                        left_class,
-                        right_class,
-                        kerning_array,
-                    }) => {
-                        fn display_kern_class_table(
-                            table: &KernClassTable,
-                            conf: &Config,
-                        ) -> TokenStream<'static> {
-                            tok(format!(
-                                "Classes[first={}, nGlyphs={}]: ",
-                                format_glyphid_hex(table.first_glyph, true),
-                                table.n_glyphs,
-                            ))
-                            .then(arrayfmt::display_items_inline(
-                                &table.class_values,
-                                |id| toks(u16::to_string(id)),
-                                conf.inline_bookend,
-                                |n| toks(format!("(..{n}..)")),
-                            ))
-                        }
-                        fn display_kerning_array(
-                            array: &KerningArray,
-                            conf: &Config,
-                        ) -> TokenStream<'static> {
-                            arrayfmt::display_wec_rows_elided(
-                                &array.0,
-                                |ix, row| {
-                                    tok(format!("\t\t[{ix}]: ")).then(
-                                        arrayfmt::display_items_inline(
-                                            row,
-                                            |kern_val| toks(format!("{kern_val:+}")),
-                                            conf.inline_bookend,
-                                            |n| toks(format!("(..{n}..)")),
-                                        ),
-                                    )
-                                },
-                                conf.bookend_size / 2, // FIXME - magic constant adjustment
-                                |start, stop| {
-                                    toks(format!(
-                                        "\t\t(skipping kerning array rows {start}..{stop})"
-                                    ))
-                                },
-                            )
-                        }
-                        let left =
-                            tok("LeftClass=").then(display_kern_class_table(left_class, conf));
-
-                        let right =
-                            tok("RightClass=").then(display_kern_class_table(right_class, conf));
-                        let kern =
-                            tok("KerningArray:").then(display_kerning_array(kerning_array, conf));
-                        left.glue(tok("\t"), right).glue(tok("\t"), kern)
-                    }
-                }
-            }
-
-            tok(format!(
-                "KernSubtable ({}): ",
-                format_kern_flags(subtable.flags)
-            ))
-            .then(display_kern_subtable_data(&subtable.data, conf))
-        }
-
         if let Some(kern) = kern {
             if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
                 println!("kern");
@@ -2040,19 +1981,111 @@ mod kern {
                     &kern.subtables,
                     |ix, subtable| {
                         toks(format!("[{ix}]: "))
-                            .pre_indent(2)
+                            .indent_by(1)
                             .chain(display_kern_subtable(subtable, conf))
                     },
                     conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping kern subtables {start}..{stop})")).pre_indent(1)
-                    },
+                    |start, stop| toks(format!("(skipping kern subtables {start}..{stop})")),
                 )
-                .println();
+                .indent_by(1)
+                .println(); // WIP
             } else {
                 println!("kern: {} kerning subtables", kern.subtables.len());
             }
         }
+    }
+    fn format_kern_flags(flags: KernFlags) -> String {
+        let mut params = Vec::new();
+        if flags.r#override {
+            params.push("override");
+        }
+        if flags.cross_stream {
+            params.push("x-stream")
+        }
+        if flags.minimum {
+            params.push("min")
+        } else {
+            params.push("kern")
+        }
+        if flags.horizontal {
+            params.push("h")
+        } else {
+            params.push("v")
+        }
+
+        params.join(" | ")
+    }
+
+    fn display_kerning_array(array: &KerningArray, conf: &Config) -> TokenStream<'static> {
+        arrayfmt::display_wec_rows_elided(
+            &array.0,
+            |ix, row| {
+                tok(format!("[{ix}]: ")).then(arrayfmt::display_items_inline(
+                    row,
+                    |kern_val| toks(format!("{kern_val:+}")),
+                    conf.inline_bookend,
+                    |n| toks(format!("(..{n}..)")),
+                ))
+            },
+            conf.bookend_size / 2, // FIXME - magic constant adjustment
+            |start, stop| toks(format!("(skipping kerning array rows {start}..{stop})")),
+        ).indent_by(4) // REVIEW - check that this is the correct indentation level
+    }
+
+    fn display_kern_class_table(table: &KernClassTable, conf: &Config) -> TokenStream<'static> {
+        tok(format!(
+            "Classes[first={}, nGlyphs={}]: ",
+            format_glyphid_hex(table.first_glyph, true),
+            table.n_glyphs,
+        ))
+        .then(arrayfmt::display_items_inline(
+            &table.class_values,
+            |id| toks(u16::to_string(id)),
+            conf.inline_bookend,
+            |n| toks(format!("(..{n}..)")),
+        ))
+    }
+
+    fn display_kern_subtable_data(
+        subtable_data: &KernSubtableData,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        match subtable_data {
+            KernSubtableData::Format0(KernSubtableFormat0 { kern_pairs }) => {
+                arrayfmt::display_items_inline(
+                    kern_pairs,
+                    |kern_pair| {
+                        toks(format!(
+                            "({},{}) {:+}",
+                            format_glyphid_hex(kern_pair.left, true),
+                            format_glyphid_hex(kern_pair.right, true),
+                            kern_pair.value
+                        ))
+                    },
+                    conf.inline_bookend,
+                    |n| toks(format!("(..{n}..)")),
+                )
+            }
+            KernSubtableData::Format2(KernSubtableFormat2 {
+                left_class,
+                right_class,
+                kerning_array,
+            }) => {
+                let left = tok("LeftClass=").then(display_kern_class_table(left_class, conf));
+
+                let right = tok("RightClass=").then(display_kern_class_table(right_class, conf));
+                let kern = tok("KerningArray:").then(display_kerning_array(kerning_array, conf));
+                left.glue(tok("\t"), right).glue(tok("\t"), kern)
+            }
+        }
+    }
+
+    fn display_kern_subtable(subtable: &KernSubtable, conf: &Config) -> TokenStream<'static> {
+        tok(format!(
+            "KernSubtable ({}): ",
+            format_kern_flags(subtable.flags)
+        ))
+        .then(display_kern_subtable_data(&subtable.data, conf))
     }
 }
 
@@ -2069,8 +2102,8 @@ fn display_class_def(
         } => {
             let toks_init = match start_glyph_id {
                 0 => TokenStream::empty(),
-                1 => toks("(skipping uncovered glyph 0)").pre_indent(3),
-                n => toks(format!("(skipping uncovered glyphs 0..{n})")).pre_indent(3),
+                1 => toks("(skipping uncovered glyph 0)").indent_by(3),
+                n => toks(format!("(skipping uncovered glyphs 0..{n})")).indent_by(3),
             };
             let toks_array = arrayfmt::display_items_elided(
                 class_value_array,
@@ -2078,7 +2111,7 @@ fn display_class_def(
                     let gix = start_glyph_id as usize + ix;
                     tok(format!("Glyph {}: ", format_glyphid_hex(gix as u16, false)))
                         .then(show_fn(item))
-                        .pre_indent(4)
+                        .indent_by(4)
                 },
                 conf.bookend_size,
                 |start, stop| {
@@ -2087,7 +2120,7 @@ fn display_class_def(
                         format_glyphid_hex(start_glyph_id + start as u16, false),
                         format_glyphid_hex(start_glyph_id + stop as u16, false),
                     ))
-                    .pre_indent(3)
+                    .indent_by(3)
                 },
             );
             // WIP
@@ -2104,7 +2137,7 @@ fn display_class_def(
                     format_glyphid_hex(class_range.end_glyph_id, false),
                 ))
                 .then(show_fn(&class_range.value))
-                .pre_indent(4)
+                .indent_by(4)
             },
             conf.bookend_size,
             |start, stop| {
@@ -2113,7 +2146,7 @@ fn display_class_def(
                 toks(format!(
                     "(skipping ranges covering glyphs {low_end}..={high_end})",
                 ))
-                .pre_indent(3)
+                .indent_by(3)
             },
         ),
     }
@@ -2321,7 +2354,7 @@ mod gasp {
                                 ranges[start].range_max_ppem,
                                 ranges[stop - 1].range_max_ppem
                             ))
-                            .pre_indent(1)
+                            .indent_by(1)
                         },
                     ),
                 )
@@ -2375,7 +2408,7 @@ mod gasp {
         } else {
             Token::then(tok(format!("[PPEM <= {}]  ", range.range_max_ppem)), disp)
         }
-        .pre_indent(2)
+        .indent_by(2)
     }
 }
 
@@ -2421,7 +2454,7 @@ mod cmap {
             encoding,
             subtable: _subtable,
         } = record;
-        toks(format!("[{ix}]: platform={platform}, encoding={encoding}")).pre_indent(2)
+        toks(format!("[{ix}]: platform={platform}, encoding={encoding}")).indent_by(2)
     }
 }
 
@@ -2466,7 +2499,7 @@ mod hmtx {
                     &hmtx.0,
                     display_unified_bearing,
                     conf.bookend_size,
-                    |start, stop| toks(format!("{HT}(skipping hmetrics {start}..{stop})")),
+                    |start, stop| toks(format!("(skipping hmetrics {start}..{stop})")).indent_by(1),
                 ),
             )
         } else {
@@ -2502,7 +2535,7 @@ mod vmtx {
                         conf.bookend_size,
                         |start, stop| {
                             toks(format!("(skipping vmetrics {start}..{stop})"))
-                                .pre_indent(INDENT_LEVEL)
+                                .indent_by(INDENT_LEVEL)
                         },
                     ),
                 )
@@ -2526,7 +2559,7 @@ mod vmtx {
             // FIXME - `left` is a misnomer, should be `top`
             None => toks(format!("Glyph ID [{ix}]: tsb={}", vmet.left_side_bearing)),
         }
-        .pre_indent(INDENT_LEVEL)
+        .indent_by(INDENT_LEVEL)
     }
 }
 
@@ -2621,7 +2654,7 @@ mod glyf {
                     display_glyph_metric,
                     conf.bookend_size,
                     |start, stop| {
-                        toks(format!("(skipping glyphs {start}..{stop})")).pre_indent(INDENT_LEVEL)
+                        toks(format!("(skipping glyphs {start}..{stop})")).indent_by(INDENT_LEVEL)
                     },
                 )))
             } else {
@@ -2649,6 +2682,6 @@ mod glyf {
                     composite.components, composite.instructions, composite.bounding_box,
                 )),
             })
-            .pre_indent(INDENT_LEVEL)
+            .indent_by(INDENT_LEVEL)
     }
 }

--- a/generated/api_helper/otf_metrics/output.rs
+++ b/generated/api_helper/otf_metrics/output.rs
@@ -3,6 +3,7 @@ use super::display::{
     TokenStream, tok, toks,
 };
 use super::*;
+use log::error;
 
 // TODO - refactor into more cleanly encapsulated TokenStream producers and consumers
 
@@ -81,15 +82,21 @@ fn display_extra_tags(table_ids: &[u32]) -> TokenStream<'static> {
     TokenStream::join_with(lines, LineBreak)
 }
 
+// FIXME - rewrite into pure TokenStream
 fn show_required_metrics(required: &RequiredTableMetrics, conf: &Config) {
     display_cmap_metrics(&required.cmap, conf).println();
     // WIP - display_head_metrics(..).println();
     show_head_metrics(&required.head, conf);
     // WIP - display_hhea_metrics(..).println();
     show_hhea_metrics(&required.hhea, conf);
-    display_hmtx_metrics(&required.hmtx, conf).println();
-    // WIP - display_maxp_metrics(..).println();
-    show_maxp_metrics(&required.maxp, conf);
+    TokenStream::join_with(
+        vec![
+            display_hmtx_metrics(&required.hmtx, conf),
+            display_maxp_metrics(&required.maxp, conf),
+        ],
+        LineBreak,
+    )
+    .println();
     // WIP - display_name_metrics(..).println();
     show_name_metrics(&required.name, conf);
     // WIP - display_os2_metrics(..).println();
@@ -98,6 +105,7 @@ fn show_required_metrics(required: &RequiredTableMetrics, conf: &Config) {
     show_post_metrics(&required.post, conf);
 }
 
+// FIXME - rewrite into pure TokenStream
 fn show_optional_metrics(optional: &OptionalTableMetrics, conf: &Config) {
     // WIP - display_cvt_metrics(..).println();
     show_cvt_metrics(&optional.cvt, conf);
@@ -105,42 +113,39 @@ fn show_optional_metrics(optional: &OptionalTableMetrics, conf: &Config) {
     show_fpgm_metrics(&optional.fpgm, conf);
     // WIP - display_loca_metrics(..).println();
     show_loca_metrics(&optional.loca, conf);
-    // WIP - display_glyf_metrics(..).println();
-    glyf::show_glyf_metrics(&optional.glyf, conf);
+    display_glyf_metrics(&optional.glyf, conf).println();
     // WIP - display_prep_metrics(..).println();
     show_prep_metrics(&optional.prep, conf);
-    display_gasp_metrics(&optional.gasp, conf).println();
 
-    // STUB - anything between gasp and base go here
-
-    // TODO - refactor into proper TokenStreams
-    display_base_metrics(&optional.base, conf).println();
-    // WIP - display_gdef_metrics(..).println();
-    show_gdef_metrics(optional.gdef.as_deref(), conf);
-    display_layout_metrics(
-        optional.gpos.as_deref(),
-        Ctxt::from(TableDiscriminator::Gpos),
-        conf,
+    TokenStream::join_with(
+        vec![
+            display_gasp_metrics(&optional.gasp, conf),
+            // STUB - anything between gasp and base go here
+            display_base_metrics(&optional.base, conf),
+            display_gdef_metrics(optional.gdef.as_deref(), conf),
+            display_layout_metrics(
+                optional.gpos.as_deref(),
+                Ctxt::from(TableDiscriminator::Gpos),
+                conf,
+            ),
+            display_layout_metrics(
+                optional.gsub.as_deref(),
+                Ctxt::from(TableDiscriminator::Gsub),
+                conf,
+            ),
+            display_fvar_metrics(optional.fvar.as_deref(), conf),
+            display_gvar_metrics(optional.gvar.as_deref(), conf),
+            display_kern_metrics(&optional.kern, conf),
+        ],
+        LineBreak,
     )
     .println();
-    display_layout_metrics(
-        optional.gsub.as_deref(),
-        Ctxt::from(TableDiscriminator::Gsub),
-        conf,
-    )
-    .println();
 
-    display_fvar_metrics(optional.fvar.as_deref(), conf).println();
-    display_gvar_metrics(optional.gvar.as_deref(), conf).println();
-
-    // WIP - display_kern_metrics(..).println();
-    show_kern_metrics(&optional.kern, conf);
     // WIP - display_stat_metrics(..).println();
     show_stat_metrics(optional.stat.as_deref(), conf);
     // WIP - display_vhea_metrics(..).println();
     show_vhea_metrics(&optional.vhea, conf);
-    // WIP - display_vmtx_metrics(..).println();
-    show_vmtx_metrics(&optional.vmtx, conf);
+    display_vmtx_metrics(&optional.vmtx, conf).println();
 }
 
 use gvar::display_gvar_metrics;
@@ -155,12 +160,16 @@ mod gvar {
         let Some(gvar) = gvar else {
             return TokenStream::empty();
         };
+
+        let heading = toks(format!(
+            "gvar: version {}",
+            format_version_major_minor(gvar.major_version, gvar.minor_version)
+        ));
         if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-            toks(format!(
-                "gvar: version {}",
-                format_version_major_minor(gvar.major_version, gvar.minor_version)
-            ))
-            .glue(
+            // NOTE - Signed difference in indentation levels (measured in half-tabs) between each table field and its multiline contents
+            const ADVANCE: i8 = 1;
+
+            heading.glue(
                 LineBreak,
                 TokenStream::join_with(
                     vec![
@@ -168,23 +177,20 @@ mod gvar {
                             "Shared Tuples ({} total):",
                             gvar.shared_tuples.len()
                         )),
-                        display_shared_tuples(&gvar.shared_tuples),
+                        display_shared_tuples(&gvar.shared_tuples).indent_by(ADVANCE),
                         toks(format!(
                             "Glyph Variation Data ({} glyphs):",
                             gvar.glyph_variation_data_array.len()
                         )),
-                        display_glyph_variation_data_array(&gvar.glyph_variation_data_array),
+                        display_glyph_variation_data_array(&gvar.glyph_variation_data_array)
+                            .indent_by(ADVANCE),
                     ],
                     LineBreak,
                 )
-                .indent_by(2),
+                .indent_by(1),
             )
         } else {
-            tok(format!(
-                "gvar: version {}",
-                format_version_major_minor(gvar.major_version, gvar.minor_version)
-            ))
-            .then(toks(format!(
+            heading.chain(toks(format!(
                 "; {} shared tuples, {} glyph variation data tables",
                 gvar.shared_tuples.len(),
                 gvar.glyph_variation_data_array.len(),
@@ -192,64 +198,78 @@ mod gvar {
         }
     }
 
+    /// Tokenizer for GVAR `GvarTupleVariationHeader` (inline)
     fn display_tuple_variation_header(header: &GvarTupleVariationHeader) -> TokenStream<'static> {
         toks(format!(
             "Header (size: {} bytes)",
             header.variation_data_size
         ))
-        // STUB
+        // STUB - consider what
     }
 
+    /// Tokenizer for GVAR `GlyphVariationData` (conditionally inline/multiline)
+    ///
+    /// When there is only one tuple variation header (or none), we continue to display it inline.
+    /// When there are multiple tuple variation headers, a linebreak is inserted before displaying them in a multiline fashion.
     fn display_glyph_variation_data(table: &GlyphVariationData) -> TokenStream<'static> {
-        match &table.tuple_variation_headers[..] {
-            [] => unreachable!("empty tuple variation headers"), // FIXME - final version should not panic, but we want to figure out whether this case happens
-            [header] => {
-                display_tuple_variation_header(header)
-                // WIP - we may want to show more than just the header in future
+        let headers = match &table.tuple_variation_headers[..] {
+            [] => {
+                error!(
+                    "[display_glyph_variation_data]: empty array of tuple variation headers encountered"
+                );
+                toks("<No GlyphVariation Data>")
             }
+            [header] => display_tuple_variation_header(header),
             headers => {
+                // FIXME[epic=magic] - arbitrary local bookending const
+                const LOCAL_BOOKEND: usize = 4;
+
+                const ITEM_ADVANCE: i8 = 1;
+                const ELISION_DELTA: i8 = -1;
+
                 let headers_str = arrayfmt::display_items_elided(
                     headers,
                     |ix, header| {
-                        toks(format!("[{ix}]: "))
-                            .chain(display_tuple_variation_header(header))
-                            .indent_by(2)
+                        toks(format!("[{ix}]: ")).chain(display_tuple_variation_header(header))
                     },
-                    4,
+                    LOCAL_BOOKEND,
                     |start, stop| {
                         toks(format!(
                             "(skipping tuple variation headers {start}..{stop})"
                         ))
-                        .indent_by(1)
+                        .indent_by(ELISION_DELTA)
                     },
-                );
-                // WIP - we may want to show more than just the headers in future
+                )
+                .indent_by(ITEM_ADVANCE);
                 LineBreak.then(headers_str)
             }
-        }
+        };
+        // STUB - determine whether to emit any information for table.data
+        headers
     }
 
+    /// Tokenizer for arrays of GlyphVariationData (multiline)
     fn display_glyph_variation_data_array(
         array: &[Option<GlyphVariationData>],
     ) -> TokenStream<'static> {
+        // FIXME[epic=magic-const] - arbitrary local bookending const
         const TABLE_BOOKEND: usize = 4;
+
         arrayfmt::display_nullable(
             array,
-            |ix, table| {
-                toks(format!("[{ix}]: "))
-                    .chain(display_glyph_variation_data(table))
-                    .indent_by(2)
-            },
+            |ix, table| tok(format!("[{ix}]: ")).then(display_glyph_variation_data(table)),
             TABLE_BOOKEND,
             |n, (start, stop)| {
                 toks(format!(
                     "(skipping {n} glyph variation data tables between indices {start}..{stop})"
                 ))
-                .indent_by(1)
+                .indent_by(-1)
             },
         )
+        .indent_by(1)
     }
 
+    /// Tokenizer for GVAR shared tuple records (inline)
     fn display_shared_tuple_record(tuple: &GvarTupleRecord) -> TokenStream<'static> {
         const COORD_BOOKEND: usize = 4;
         arrayfmt::display_items_inline(
@@ -261,16 +281,16 @@ mod gvar {
     }
 
     fn display_shared_tuples(shared_tuples: &[GvarTupleRecord]) -> TokenStream<'static> {
+        // FIXME[epic=magic-const] - arbitrary local bookending const
         const RECORDS_BOOKEND: usize = 4;
+
         arrayfmt::display_items_elided(
             shared_tuples,
             |shared_tuple_ix, record| {
-                toks(format!("[{shared_tuple_ix}]: "))
-                    .chain(display_shared_tuple_record(record))
-                    .indent_by(2)
+                toks(format!("[{shared_tuple_ix}]: ")).chain(display_shared_tuple_record(record))
             },
             RECORDS_BOOKEND,
-            |start, stop| toks(format!("(skipping shared tuples {start}..{stop})")).indent_by(1),
+            |start, stop| toks(format!("(skipping shared tuples {start}..{stop})")).indent_by(-1),
         )
     }
 }
@@ -301,7 +321,7 @@ mod fvar {
                             |ix, axis| {
                                 tok(format!("[{ix}]: "))
                                     .then(display_variation_axis_record(axis))
-                                    .indent_by(2)
+                                    .indent_by(1)
                             },
                             conf.bookend_size,
                             |start, stop| toks(format!("(skipping axis records {start}..{stop})")),
@@ -315,7 +335,7 @@ mod fvar {
                             |ix, instance| {
                                 tok(format!("[{ix}]: "))
                                     .then(display_instance_record(instance, conf))
-                                    .indent_by(2)
+                                    .indent_by(1)
                             },
                             conf.bookend_size,
                             |start, stop| {
@@ -323,7 +343,7 @@ mod fvar {
                             },
                         ),
                     )
-                    .indent_by(2),
+                    .indent_by(1),
             )
         } else {
             tok(format!(
@@ -404,14 +424,16 @@ fn show_loca_metrics(loca: &Option<LocaMetrics>, _conf: &Config) {
     }
 }
 
-use gdef::show_gdef_metrics;
+use gdef::display_gdef_metrics;
 
 mod gdef {
     use super::*;
 
-    // FIXME - rewrite into pure TokenStream
-    pub(super) fn show_gdef_metrics(gdef: Option<&GdefMetrics>, conf: &Config) {
-        if let Some(GdefMetrics {
+    pub(super) fn display_gdef_metrics(
+        gdef: Option<&GdefMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(GdefMetrics {
             major_version,
             minor_version,
             glyph_class_def,
@@ -420,42 +442,43 @@ mod gdef {
             mark_attach_class_def,
             data,
         }) = gdef
-        {
-            // WIP
-            println!(
-                "GDEF: version {}",
-                format_version_major_minor(*major_version, *minor_version)
-            );
-            if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                // FIXME - rewrite into single TokenStream
-                if let Some(glyph_class_def) = glyph_class_def {
-                    show_glyph_class_def(glyph_class_def, conf);
-                }
-                if let Some(attach_list) = attach_list {
-                    display_attach_list(attach_list, conf)
-                        .indent_by(2)
-                        .println();
-                }
-                if let Some(lig_caret_list) = lig_caret_list {
-                    display_lig_caret_list(lig_caret_list, conf)
-                        .indent_by(2)
-                        .println();
-                }
-                if let Some(mark_attach_class_def) = mark_attach_class_def {
-                    show_mark_attach_class_def(mark_attach_class_def, conf);
-                }
-                match &data.mark_glyph_sets_def {
-                    // WIP
-                    None => println!("MarkGlyphSet: <none>"),
-                    Some(mgs) => display_mark_glyph_set(mgs, conf).indent_by(2).println(),
-                }
-                match &data.item_var_store {
-                    None => println!("\tItemVariationStore: <none>"),
-                    Some(ivs) => display_item_variation_store(ivs, conf)
-                        .indent_by(2)
-                        .println(),
-                }
+        else {
+            return TokenStream::empty();
+        };
+        let heading = toks(format!(
+            "GDEF: version {}",
+            format_version_major_minor(*major_version, *minor_version)
+        ));
+        if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+            let mut components = Vec::new();
+
+            if let Some(glyph_class_def) = glyph_class_def {
+                components.push(display_glyph_class_def(glyph_class_def, conf));
             }
+            if let Some(attach_list) = attach_list {
+                components.push(display_attach_list(attach_list, conf));
+            }
+            if let Some(lig_caret_list) = lig_caret_list {
+                components.push(display_lig_caret_list(lig_caret_list, conf));
+            }
+            if let Some(mark_attach_class_def) = mark_attach_class_def {
+                components.push(display_mark_attach_class_def(mark_attach_class_def, conf));
+            }
+            match &data.mark_glyph_sets_def {
+                None => components.push(toks("MarkGlyphSet: <none>")),
+                Some(mgs) => components.push(display_mark_glyph_set(mgs, conf)),
+            }
+            match &data.item_var_store {
+                None => components.push(toks("ItemVariationStore: <none>")),
+                Some(ivs) => components.push(display_item_variation_store(ivs, conf)),
+            }
+
+            heading.glue(
+                LineBreak,
+                TokenStream::join_with(components, LineBreak).indent_by(1),
+            )
+        } else {
+            heading
         }
     }
     fn display_attach_point(point_indices: &[u16], conf: &Config) -> TokenStream<'static> {
@@ -467,81 +490,104 @@ mod gdef {
         )
     }
 
+    /// Tokenizer for `AttachList` (multiline)
     fn display_attach_list(attach_list: &AttachList, conf: &Config) -> TokenStream<'static> {
-        toks("AttachList:")
-            .glue(
+        toks("AttachList:").glue(
+            LineBreak,
+            TokenStream::join_with(
+                vec![
+                    display_coverage_table_full(&attach_list.coverage, conf),
+                    display_attach_point_array(&attach_list.attach_points, conf),
+                ],
                 LineBreak,
-                display_coverage_table_full(&attach_list.coverage, conf).indent_by(2),
             )
-            .glue(
-                LineBreak,
-                arrayfmt::display_items_elided(
-                    &attach_list.attach_points,
-                    |ix, AttachPoint { point_indices }| {
-                        toks(format!("[{ix}]: "))
-                            .indent_by(2)
-                            .chain(display_attach_point(point_indices, conf))
-                    },
-                    conf.bookend_size,
-                    |start, stop| {
-                        toks(format!(
-                            "(skipping attach points for glyphs {start}..{stop})"
-                        ))
-                        .indent_by(1)
-                    },
-                ),
-            )
+            .indent_by(1),
+        )
     }
 
+    /// Tokenizer for arrays of AttachPoints (multiline)
+    fn display_attach_point_array(array: &[AttachPoint], conf: &Config) -> TokenStream<'static> {
+        arrayfmt::display_items_elided(
+            array,
+            |ix, AttachPoint { point_indices }| {
+                toks(format!("[{ix}]: "))
+                    .chain(display_attach_point(point_indices, conf))
+                    .indent_by(1)
+            },
+            conf.bookend_size,
+            |start, stop| {
+                toks(format!(
+                    "(skipping attach points for glyphs {start}..{stop})"
+                ))
+            },
+        )
+    }
+
+    /// Tokenizer for `LigCaretList` (multiline)
     fn display_lig_caret_list(
         lig_caret_list: &LigCaretList,
         conf: &Config,
     ) -> TokenStream<'static> {
-        toks("LigCaretList:")
-            .glue(
+        toks("LigCaretList:").glue(
+            LineBreak,
+            TokenStream::join_with(
+                vec![
+                    display_coverage_table_full(&lig_caret_list.coverage, conf),
+                    display_lig_glyph_array(&lig_caret_list.lig_glyphs, conf),
+                ],
                 LineBreak,
-                display_coverage_table_full(&lig_caret_list.coverage, conf).indent_by(2),
             )
-            .glue(
-                LineBreak,
-                arrayfmt::display_items_elided(
-                    &lig_caret_list.lig_glyphs,
-                    |ix, lig_glyph| {
-                        toks(format!("[{ix}]: ")).indent_by(2).chain(
-                            arrayfmt::display_items_inline(
-                                &lig_glyph.caret_values,
-                                display_caret_value,
-                                conf.inline_bookend,
-                                |num_skipped| toks(format!("...({num_skipped})...")),
-                            ),
-                        )
-                    },
-                    conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping LigGlyphs {start}..{stop})")).indent_by(1)
-                    },
-                ),
-            )
+            .indent_by(1),
+        )
     }
 
-    // FIXME - rewrite into pure TokenStream
-    fn show_mark_attach_class_def(mark_attach_class_def: &ClassDef, conf: &Config) {
-        println!("\tMarkAttachClassDef:");
-        display_class_def(mark_attach_class_def, display_mark_attach_class, conf).println();
+    /// Tokenizer for arrays of LigGlyphs (multiline)
+    fn display_lig_glyph_array(array: &[LigGlyph], conf: &Config) -> TokenStream<'static> {
+        arrayfmt::display_items_elided(
+            array,
+            |ix, lig_glyph| {
+                toks(format!("[{ix}]: "))
+                    .chain(arrayfmt::display_items_inline(
+                        &lig_glyph.caret_values,
+                        display_caret_value,
+                        conf.inline_bookend,
+                        |num_skipped| toks(format!("...({num_skipped})...")),
+                    ))
+                    .indent_by(1)
+            },
+            conf.bookend_size,
+            |start, stop| toks(format!("(skipping LigGlyphs {start}..{stop})")),
+        )
     }
 
-    // FIXME - rewrite into pure TokenStream
-    fn show_glyph_class_def(class_def: &ClassDef, conf: &Config) {
-        println!("\tGlyphClassDef:");
-        display_class_def(class_def, display_glyph_class, conf).println();
+    /// Tokenizer for GDEF mark-attach `ClassDef` (multiline)
+    fn display_mark_attach_class_def(
+        mark_attach_class_def: &ClassDef,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        toks("MarkAttachClassDef:").glue(
+            LineBreak,
+            display_class_def(mark_attach_class_def, display_mark_attach_class, conf).indent_by(1),
+        )
     }
 
+    /// Tokenizer for GDEF glyph `ClassDef` (multiline)
+    fn display_glyph_class_def(class_def: &ClassDef, conf: &Config) -> TokenStream<'static> {
+        toks("GlyphClassDef:").glue(
+            LineBreak,
+            display_class_def(class_def, display_glyph_class, conf).indent_by(1),
+        )
+    }
+
+    /// Tokenizer for MarkAttachClass (Uint16) values (inline)
     fn display_mark_attach_class(mark_attach_class: &u16) -> TokenStream<'static> {
-        // STUB - if we come up with a semantic association for specific numbers, add branches here
+        // TODO - if we come up with a semantic association for specific numbers, add branches here
         toks(format!("{mark_attach_class}"))
     }
 
+    /// Tokenizer for GlyphClass (Uint16) values (inline)
     fn display_glyph_class(class: &u16) -> TokenStream<'static> {
+        // REVIEW - consider replacing with semantically distinguished const-enum and matching on that instead of raw numbers
         toks(format_glyph_class(class))
     }
 
@@ -557,13 +603,12 @@ mod gdef {
                             tok(format!("[{ix}]: ")).then(display_coverage_table_full(covt, conf))
                         }
                     })
-                    .indent_by(2)
+                    .indent_by(1)
                 },
                 conf.bookend_size,
-                |start, stop| {
-                    toks(format!("(skipping coverage tables {start}..{stop})")).indent_by(1)
-                },
-            ),
+                |start, stop| toks(format!("(skipping coverage tables {start}..{stop})")),
+            )
+            .indent_by(1),
         )
     }
 
@@ -617,6 +662,8 @@ mod gdef {
         )
         .indent_by(1)
     }
+
+    /// Tokenizer for arrays of ItemVariationData (multiline)
     fn display_variation_data_array(
         ivda: &[Option<ItemVariationData>],
         conf: &Config,
@@ -625,18 +672,13 @@ mod gdef {
             LineBreak,
             arrayfmt::display_items_elided(
                 ivda,
-                |ix, o_ivd| {
-                    match o_ivd {
-                        Some(ivd) => {
-                            tok(format!("[{ix}]: ")).then(display_variation_data(ivd, conf))
-                        }
-                        None => toks(format!("[{ix}]: <NONE>")),
-                    }
-                    .indent_by(2)
+                |ix, o_ivd| match o_ivd {
+                    Some(ivd) => tok(format!("[{ix}]: ")).then(display_variation_data(ivd, conf)),
+                    None => toks(format!("[{ix}]: <NONE>")),
                 },
                 conf.bookend_size,
                 |start_ix, stop_ix| {
-                    toks(format!("...(skipping entries {start_ix}..{stop_ix})...")).indent_by(1)
+                    toks(format!("...(skipping entries {start_ix}..{stop_ix})...")).indent_by(-1)
                 },
             )
             .indent_by(2),
@@ -652,7 +694,7 @@ mod gdef {
                     &ivd.region_indices,
                     |ix| toks(format!("{ix}")),
                     conf.inline_bookend,
-                    |n_skipped| toks(format!("...({n_skipped})...")),
+                    |n_skipped| toks(format!("..({n_skipped})..")),
                 ))
                 .glue(
                     LineBreak,
@@ -666,7 +708,7 @@ mod gdef {
                     ))
                     .glue(LineBreak, display_delta_sets(&ivd.delta_sets, conf)),
                 )
-                .indent_by(2),
+                .indent_by(1),
         )
     }
 
@@ -738,33 +780,37 @@ mod layout {
         ctxt: Ctxt,
         conf: &Config,
     ) -> TokenStream<'static> {
-        if let Some(LayoutMetrics {
+        let Some(LayoutMetrics {
             major_version,
             minor_version,
             script_list,
             feature_list,
             lookup_list,
-            feature_variations: _feature_variations,
+            ..
         }) = layout
-        {
-            let minimal = toks(format!(
-                "{}: version {}",
-                name_for_table_disc(ctxt.get_disc().expect("Ctxt missing TableDiscriminator")),
-                format_version_major_minor(*major_version, *minor_version)
-            ));
-            if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                minimal.glue(
+        else {
+            return TokenStream::empty();
+        };
+        let minimal = toks(format!(
+            "{}: version {}",
+            name_for_table_disc(ctxt.get_disc().expect("Ctxt missing TableDiscriminator")),
+            format_version_major_minor(*major_version, *minor_version)
+        ));
+        if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+            minimal.glue(
+                LineBreak,
+                TokenStream::join_with(
+                    vec![
+                        display_script_list(script_list, conf),
+                        display_feature_list(feature_list, conf),
+                        display_lookup_list(lookup_list, ctxt, conf),
+                    ],
                     LineBreak,
-                    display_script_list(script_list, conf)
-                        .glue(LineBreak, display_feature_list(feature_list, conf))
-                        .glue(LineBreak, display_lookup_list(lookup_list, ctxt, conf))
-                        .indent_by(2),
                 )
-            } else {
-                minimal
-            }
+                .indent_by(2),
+            )
         } else {
-            TokenStream::empty()
+            minimal
         }
     }
 
@@ -785,38 +831,45 @@ mod layout {
                 LineBreak,
                 arrayfmt::display_items_elided(
                     script_list,
-                    |ix, item| {
-                        let Some(ScriptTable {
-                            default_lang_sys,
-                            lang_sys_records,
-                        }) = &item.script
-                        else {
-                            unreachable!("missing ScriptTable at index {ix} in ScriptList");
-                        };
-
-                        toks(format!("[{ix}]: {}", item.script_tag))
-                            .glue(LineBreak, {
-                                match default_lang_sys {
-                                    None => display_lang_sys_records(lang_sys_records, conf),
-                                    langsys @ Some(..) => toks("[Default LangSys]: ")
-                                        .indent_by(1)
-                                        .chain(display_langsys(langsys, conf))
-                                        .glue(
-                                            LineBreak,
-                                            display_lang_sys_records(lang_sys_records, conf),
-                                        ),
-                                }
-                            })
-                            .indent_by(1)
-                    },
+                    |ix, item| display_script_record(ix, item, conf),
                     conf.bookend_size,
-                    |start, stop| toks(format!("skipping ScriptRecords {start}..{stop}")),
+                    |start, stop| {
+                        toks(format!("skipping ScriptRecords {start}..{stop}")).indent_by(-1)
+                    },
                 )
-                .indent_by(1),
+                .indent_by(2),
             )
         }
     }
 
+    /// Tokenizer for ScriptRecord (multiline)
+    fn display_script_record(
+        ix: usize,
+        item: &ScriptRecord,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(ScriptTable {
+            default_lang_sys,
+            lang_sys_records,
+        }) = &item.script
+        else {
+            // REVIEW - should this be a panic?
+            unreachable!("missing ScriptTable at index {ix} in ScriptList");
+        };
+
+        let ix_display = toks(format!("[{ix}]: {}", item.script_tag));
+        let extra = match default_lang_sys {
+            None => display_lang_sys_records(lang_sys_records, conf),
+            langsys @ Some(..) => toks("[Default LangSys]: ")
+                .chain(display_langsys(langsys, conf))
+                .glue(LineBreak, display_lang_sys_records(lang_sys_records, conf))
+                .indent_by(1),
+        };
+
+        ix_display.glue(LineBreak, extra)
+    }
+
+    /// Tokenizer for LangSysRecords (multiline)
     fn display_lang_sys_records(
         lang_sys_records: &[LangSysRecord],
         conf: &Config,
@@ -831,12 +884,13 @@ mod layout {
                     |ix, item| {
                         toks(format!("[{ix}]: {}; ", item.lang_sys_tag))
                             .chain(display_langsys(&item.lang_sys, conf))
-                            .indent_by(1)
                     },
                     conf.bookend_size,
-                    |start, stop| toks(format!("(skipping LangSysRecords {start}..{stop})")),
+                    |start, stop| {
+                        toks(format!("(skipping LangSysRecords {start}..{stop})")).indent_by(-1)
+                    },
                 )
-                .indent_by(1),
+                .indent_by(2),
             )
         }
     }
@@ -883,12 +937,13 @@ mod layout {
                      }| {
                         tok(format!("[{ix}]: {feature_tag}"))
                             .then(display_feature_table(feature, conf))
-                            .indent_by(1)
                     },
                     conf.bookend_size,
-                    |start, stop| toks(format!("(skipping FeatureIndices {start}..{stop})")),
+                    |start, stop| {
+                        toks(format!("(skipping FeatureIndices {start}..{stop})")).indent_by(-1)
+                    },
                 )
-                .indent_by(1),
+                .indent_by(2),
             )
         }
     }
@@ -923,14 +978,14 @@ mod layout {
             arrayfmt::display_items_elided(
                 lookup_list,
                 move |ix, table| {
-                    toks(format!("[{ix}]: "))
-                        .chain(display_lookup_table(table, ctxt, conf))
-                        .indent_by(1)
+                    toks(format!("[{ix}]: ")).chain(display_lookup_table(table, ctxt, conf))
                 },
                 conf.bookend_size,
-                |start, stop| toks(format!("(skipping LookupTables {start}..{stop})")),
+                |start, stop| {
+                    toks(format!("(skipping LookupTables {start}..{stop})")).indent_by(-1)
+                },
             )
-            .indent_by(1),
+            .indent_by(2),
         )
     }
 
@@ -1970,28 +2025,38 @@ mod stat {
     }
 }
 
-use kern::show_kern_metrics;
+use kern::display_kern_metrics;
 mod kern {
     use super::*;
-    pub(super) fn show_kern_metrics(kern: &Option<KernMetrics>, conf: &Config) {
-        if let Some(kern) = kern {
-            if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                println!("kern");
+
+    /// Tokenizer for KernMEtrics
+    pub(super) fn display_kern_metrics(
+        kern: &Option<KernMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(kern) = kern else {
+            return TokenStream::empty();
+        };
+
+        let heading = toks(format!("kern: {} kerning subtables", kern.subtables.len()));
+
+        if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+            heading.glue(
+                LineBreak,
                 arrayfmt::display_items_elided(
                     &kern.subtables,
                     |ix, subtable| {
-                        toks(format!("[{ix}]: "))
-                            .indent_by(1)
-                            .chain(display_kern_subtable(subtable, conf))
+                        toks(format!("[{ix}]: ")).chain(display_kern_subtable(subtable, conf))
                     },
                     conf.bookend_size,
-                    |start, stop| toks(format!("(skipping kern subtables {start}..{stop})")),
+                    |start, stop| {
+                        toks(format!("(skipping kern subtables {start}..{stop})")).indent_by(-1)
+                    },
                 )
-                .indent_by(1)
-                .println(); // WIP
-            } else {
-                println!("kern: {} kerning subtables", kern.subtables.len());
-            }
+                .indent_by(2),
+            )
+        } else {
+            heading
         }
     }
     fn format_kern_flags(flags: KernFlags) -> String {
@@ -2016,6 +2081,7 @@ mod kern {
         params.join(" | ")
     }
 
+    /// Tokenizer for KerningArray (multiline).
     fn display_kerning_array(array: &KerningArray, conf: &Config) -> TokenStream<'static> {
         arrayfmt::display_wec_rows_elided(
             &array.0,
@@ -2028,10 +2094,14 @@ mod kern {
                 ))
             },
             conf.bookend_size / 2, // FIXME - magic constant adjustment
-            |start, stop| toks(format!("(skipping kerning array rows {start}..{stop})")),
-        ).indent_by(4) // REVIEW - check that this is the correct indentation level
+            |start, stop| {
+                toks(format!("(skipping kerning array rows {start}..{stop})")).indent_by(-1)
+            },
+        )
+        .indent_by(1)
     }
 
+    /// Tokenizer for KernClassTable (inline).
     fn display_kern_class_table(table: &KernClassTable, conf: &Config) -> TokenStream<'static> {
         tok(format!(
             "Classes[first={}, nGlyphs={}]: ",
@@ -2046,6 +2116,7 @@ mod kern {
         ))
     }
 
+    /// Tokenizer for KernSubtableData (inline or multiline).
     fn display_kern_subtable_data(
         subtable_data: &KernSubtableData,
         conf: &Config,
@@ -2071,10 +2142,13 @@ mod kern {
                 right_class,
                 kerning_array,
             }) => {
+                // REVIEW - consider whether we are using too much horizontal space for the inline display
                 let left = tok("LeftClass=").then(display_kern_class_table(left_class, conf));
-
                 let right = tok("RightClass=").then(display_kern_class_table(right_class, conf));
-                let kern = tok("KerningArray:").then(display_kerning_array(kerning_array, conf));
+                let kern = toks("KerningArray:").glue(
+                    LineBreak,
+                    display_kerning_array(kerning_array, conf).indent_by(1),
+                );
                 left.glue(tok("\t"), right).glue(tok("\t"), kern)
             }
         }
@@ -2102,8 +2176,8 @@ fn display_class_def(
         } => {
             let toks_init = match start_glyph_id {
                 0 => TokenStream::empty(),
-                1 => toks("(skipping uncovered glyph 0)").indent_by(3),
-                n => toks(format!("(skipping uncovered glyphs 0..{n})")).indent_by(3),
+                1 => toks("(skipping uncovered glyph 0)"),
+                n => toks(format!("(skipping uncovered glyphs 0..{n})")),
             };
             let toks_array = arrayfmt::display_items_elided(
                 class_value_array,
@@ -2111,7 +2185,6 @@ fn display_class_def(
                     let gix = start_glyph_id as usize + ix;
                     tok(format!("Glyph {}: ", format_glyphid_hex(gix as u16, false)))
                         .then(show_fn(item))
-                        .indent_by(4)
                 },
                 conf.bookend_size,
                 |start, stop| {
@@ -2120,11 +2193,11 @@ fn display_class_def(
                         format_glyphid_hex(start_glyph_id + start as u16, false),
                         format_glyphid_hex(start_glyph_id + stop as u16, false),
                     ))
-                    .indent_by(3)
+                    .indent_by(-1)
                 },
-            );
-            // WIP
-            TokenStream::join_with(vec![toks_init, toks_array], LineBreak)
+            )
+            .indent_by(1);
+            TokenStream::join_with(vec![toks_init, toks_array.indent_by(1)], LineBreak)
         }
         ClassDef::Format2 {
             ref class_range_records,
@@ -2137,7 +2210,6 @@ fn display_class_def(
                     format_glyphid_hex(class_range.end_glyph_id, false),
                 ))
                 .then(show_fn(&class_range.value))
-                .indent_by(4)
             },
             conf.bookend_size,
             |start, stop| {
@@ -2146,9 +2218,10 @@ fn display_class_def(
                 toks(format!(
                     "(skipping ranges covering glyphs {low_end}..={high_end})",
                 ))
-                .indent_by(3)
+                .indent_by(-1)
             },
-        ),
+        )
+        .indent_by(2),
     }
 }
 
@@ -2436,8 +2509,11 @@ mod cmap {
                     &cmap.encoding_records,
                     display_encoding_record,
                     conf.bookend_size,
-                    |start, stop| toks(format!("\t(skipping encoding records {start}..{stop})")),
-                ),
+                    |start, stop| {
+                        toks(format!("(skipping encoding records {start}..{stop})")).indent_by(-1)
+                    },
+                )
+                .indent_by(2),
             )
         } else {
             heading.chain(toks(format!(
@@ -2447,6 +2523,7 @@ mod cmap {
         }
     }
 
+    /// Tokenizer for an indexed `EncodingRecord` (inline).
     fn display_encoding_record(ix: usize, record: &EncodingRecord) -> TokenStream<'static> {
         // TODO[epic=enrichment]: if we implement subtables and more verbosity levels, show subtable details
         let EncodingRecord {
@@ -2454,7 +2531,7 @@ mod cmap {
             encoding,
             subtable: _subtable,
         } = record;
-        toks(format!("[{ix}]: platform={platform}, encoding={encoding}")).indent_by(2)
+        toks(format!("[{ix}]: platform={platform}, encoding={encoding}"))
     }
 }
 
@@ -2493,14 +2570,17 @@ mod hmtx {
 
     pub(crate) fn display_hmtx_metrics(hmtx: &HmtxMetrics, conf: &Config) -> TokenStream<'static> {
         if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-            toks("hmtx").glue(
+            toks("hmtx:").glue(
                 LineBreak,
                 arrayfmt::display_items_elided(
                     &hmtx.0,
                     display_unified_bearing,
                     conf.bookend_size,
-                    |start, stop| toks(format!("(skipping hmetrics {start}..{stop})")).indent_by(1),
-                ),
+                    |start, stop| {
+                        toks(format!("(skipping hmetrics {start}..{stop})")).indent_by(-1)
+                    },
+                )
+                .indent_by(2),
             )
         } else {
             toks(format!("hmtx: {} hmetrics", hmtx.0.len()))
@@ -2509,47 +2589,49 @@ mod hmtx {
     fn display_unified_bearing(ix: usize, hmet: &UnifiedBearing) -> TokenStream<'static> {
         match &hmet.advance_width {
             Some(width) => toks(format!(
-                "\tGlyph ID [{ix}]: advanceWidth={width}, lsb={}",
+                "Glyph ID [{ix}]: advanceWidth={width}, lsb={}",
                 hmet.left_side_bearing
             )),
-            None => toks(format!("\tGlyph ID [{ix}]: lsb={}", hmet.left_side_bearing)),
+            None => toks(format!("Glyph ID [{ix}]: lsb={}", hmet.left_side_bearing)),
         }
     }
 }
 
-use vmtx::show_vmtx_metrics;
+use vmtx::display_vmtx_metrics;
 mod vmtx {
     use super::*;
 
     // FIXME - refactor into pure TokenStream
-    pub(crate) fn show_vmtx_metrics(vmtx: &Option<VmtxMetrics>, conf: &Config) {
-        // TODO - add mechanism for auto-computation of current indent level
-        const INDENT_LEVEL: u8 = 1;
-        if let Some(vmtx) = vmtx {
-            let disp = if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                toks("vmtx").glue(
-                    LineBreak,
-                    arrayfmt::display_items_elided(
-                        &vmtx.0,
-                        display_unified_bearing,
-                        conf.bookend_size,
-                        |start, stop| {
-                            toks(format!("(skipping vmetrics {start}..{stop})"))
-                                .indent_by(INDENT_LEVEL)
-                        },
-                    ),
+    pub(crate) fn display_vmtx_metrics(
+        vmtx: &Option<VmtxMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(vmtx) = vmtx else {
+            return TokenStream::empty();
+        };
+
+        let heading = toks(format!("vmtx: {} vmetrics", vmtx.0.len()));
+
+        if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+            heading.glue(
+                LineBreak,
+                arrayfmt::display_items_elided(
+                    &vmtx.0,
+                    display_unified_bearing,
+                    conf.bookend_size,
+                    |start, stop| {
+                        toks(format!("(skipping vmetrics {start}..{stop})")).indent_by(-1)
+                    },
                 )
-            } else {
-                toks(format!("vmtx: {} vmetrics", vmtx.0.len()))
-            };
-            disp.println()
+                .indent_by(2),
+            )
+        } else {
+            heading
         }
     }
 
+    /// Tokenizer for a `vmtx` UnifiedBearing (inline)
     fn display_unified_bearing(ix: usize, vmet: &UnifiedBearing) -> TokenStream<'static> {
-        // TODO - add mechanism for auto-computation of current indent level
-        const INDENT_LEVEL: u8 = 2;
-
         // FIXME - `_width` is a misnomer, should be `_height`
         match &vmet.advance_width {
             Some(height) => toks(format!(
@@ -2559,26 +2641,24 @@ mod vmtx {
             // FIXME - `left` is a misnomer, should be `top`
             None => toks(format!("Glyph ID [{ix}]: tsb={}", vmet.left_side_bearing)),
         }
-        .indent_by(INDENT_LEVEL)
     }
 }
 
-// FIXME - rewrite into pure TokenStream
-fn show_maxp_metrics(maxp: &MaxpMetrics, _conf: &Config) {
+fn display_maxp_metrics(maxp: &MaxpMetrics, _conf: &Config) -> TokenStream<'static> {
     match maxp {
-        MaxpMetrics::Postscript { version } => println!(
+        MaxpMetrics::Postscript { version } => toks(format!(
             "maxp: version {} (PostScript)",
             format_version16dot16(*version)
-        ),
-        MaxpMetrics::UnknownVersion { version } => println!(
+        )),
+        MaxpMetrics::UnknownVersion { version } => toks(format!(
             "maxp: version {} (not recognized)",
             format_version16dot16(*version)
-        ),
+        )),
         // STUB - currently limited by definition of Version1 variant, but the information available in the type may be enriched later
-        MaxpMetrics::Version1 { version } => println!(
+        MaxpMetrics::Version1 { version } => toks(format!(
             "maxp: version {} (contents omitted)",
             format_version16dot16(*version)
-        ),
+        )),
     }
 }
 
@@ -2638,38 +2718,32 @@ fn show_post_metrics(post: &PostMetrics, _conf: &Config) {
     );
 }
 
-use glyf::show_glyf_metrics;
+use glyf::display_glyf_metrics;
 mod glyf {
     use super::*;
 
     // FIXME - refactor into pure TokenStream
-    pub(crate) fn show_glyf_metrics(glyf: &Option<GlyfMetrics>, conf: &Config) {
-        // TODO - add mechanism for auto-computation of current indent level
-        const INDENT_LEVEL: u8 = 1;
-        let disp = if let Some(glyf) = glyf.as_ref() {
-            let hdr = tok(format!("glyf: {} glyphs", glyf.num_glyphs));
-            if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
-                hdr.then(LineBreak.then(arrayfmt::display_items_elided(
-                    glyf.glyphs.as_slice(),
-                    display_glyph_metric,
-                    conf.bookend_size,
-                    |start, stop| {
-                        toks(format!("(skipping glyphs {start}..{stop})")).indent_by(INDENT_LEVEL)
-                    },
-                )))
-            } else {
-                hdr.into()
-            }
-        } else {
-            toks("glyf: <not present>")
+    pub(crate) fn display_glyf_metrics(
+        glyf: &Option<GlyfMetrics>,
+        conf: &Config,
+    ) -> TokenStream<'static> {
+        let Some(glyf) = glyf.as_ref() else {
+            return TokenStream::empty();
         };
-        disp.println()
+        let hdr = tok(format!("glyf: {} glyphs", glyf.num_glyphs));
+        if conf.verbosity.is_at_least(VerboseLevel::Detailed) {
+            hdr.then(LineBreak.then(arrayfmt::display_items_elided(
+                glyf.glyphs.as_slice(),
+                display_glyph_metric,
+                conf.bookend_size,
+                |start, stop| toks(format!("(skipping glyphs {start}..{stop})")),
+            )))
+        } else {
+            hdr.into()
+        }
     }
 
     fn display_glyph_metric(ix: usize, glyf: &GlyphMetric) -> TokenStream<'static> {
-        // TODO - add mechanism for auto-computation of current indent level
-        const INDENT_LEVEL: u8 = 2;
-
         tok(format!("[{ix}]: "))
             .then(match glyf {
                 GlyphMetric::Empty => toks("<empty>"),
@@ -2682,6 +2756,6 @@ mod glyf {
                     composite.components, composite.instructions, composite.bounding_box,
                 )),
             })
-            .indent_by(INDENT_LEVEL)
+            .indent_by(1)
     }
 }

--- a/generated/bin/fontinfo.rs
+++ b/generated/bin/fontinfo.rs
@@ -30,6 +30,7 @@ type RunError = Box<dyn std::error::Error + Sync + Send + 'static>;
 type RunResult<T> = Result<T, RunError>;
 
 pub fn main() -> RunResult<()> {
+    stderrlog::new().module(module_path!()).init()?;
     let mut conf_builder = ConfigBuilder::default();
     let params = Params::parse();
     conf_builder.extra_only(params.extra_only);


### PR DESCRIPTION
Extends `Token` with new variants `IncreaseIndent` and `DecreaseIndent` that act as control-tokens for the new helper-iterator `IndentIter`, which acts as a runner for `TokenStream`.

Fixes some, but not all of the local-absolute indent-levels in `otf_metrics::output` (ongoing).