### PR TITLE
Use signed-int constructions in Opentype format definition

### DIFF
--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -6839,7 +6839,7 @@ pub(crate) mod head {
         ]);
 
         // NOTE - Should be 2 for modern fonts but we shouldn't enforce that too strongly
-        /* ConstEnum(s16be) {
+        /* ConstEnum(i16be) {
          *     Mixed    =  0,
          *     StrongLR =  1,
          *     WeakLR   =  2,

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -284,13 +284,6 @@ mod util {
         fmt_variant("F2Dot14", u16be())
     }
 
-    /// Parses a big-endian u16 (2-byte) value that the specification indicates should be interpreted as a signed value.
-    ///
-    /// Does not actually perform type-conversion to i16.
-    pub(crate) fn s16be() -> Format {
-        u16be()
-    }
-
     /// Helper function for parsing a big-endian u24 (3-byte) value
     pub(crate) fn u24be() -> Format {
         // REVIEW - should U24Be be a CommonOp?
@@ -6854,7 +6847,21 @@ pub(crate) mod head {
          *     WeakRL   = -2,
          * }
          */
-        let glyph_dir_hint = util::s16be();
+        let glyph_dir_hint = chain(
+            i16be(),
+            "disc",
+            compute(interpret_as_enum(
+                var("disc"),
+                [
+                    (Pattern::z_const(0), "Mixed"),
+                    (Pattern::z_const(1), "StrongLR"),
+                    (Pattern::z_const(2), "WeakLR"),
+                    (Pattern::z_const(-1), "StrongRL"),
+                    (Pattern::z_const(-2), "WeakRL"),
+                ],
+                Some("UnknownDirHint"),
+            )),
+        );
 
         module.define_format(
             "opentype.head_table",

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -284,24 +284,11 @@ mod util {
         fmt_variant("F2Dot14", u16be())
     }
 
-    /// Parses a u8 value and performs a bitwise cast to i8.
-    pub(crate) fn s8() -> Format {
-        u8()
-    }
-
-    /// Parses a u16 value and performs a bitwise cast to i16.
+    /// Parses a big-endian u16 (2-byte) value that the specification indicates should be interpreted as a signed value.
+    ///
+    /// Does not actually perform type-conversion to i16.
     pub(crate) fn s16be() -> Format {
         u16be()
-    }
-
-    /// Parses a u32 value and performs a bitwise cast to i32.
-    pub(crate) fn s32be() -> Format {
-        u32be()
-    }
-
-    /// Parses a u64 value and performs a bitwise cast to i64.
-    pub(crate) fn s64be() -> Format {
-        u64be()
     }
 
     /// Helper function for parsing a big-endian u24 (3-byte) value

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -1,6 +1,8 @@
+use doodle::numeric::core::MachineRep;
+use doodle::numeric::helper as num;
 use doodle::{
-    BaseType, Expr, Format, FormatModule, FormatRef, Label, Pattern, ValueType, ViewExpr,
-    bounds::Bounds, helper::*,
+    BaseType, DepFormat, Expr, Format, FormatModule, FormatRef, Label, Pattern, ValueType,
+    ViewExpr, bounds::Bounds, helper::*,
 };
 
 mod util {
@@ -259,20 +261,18 @@ mod util {
         mul(as_u32(half), Expr::U32(2))
     }
 
-    /// Converts a `u8` value to an `i16` value within the `Expr` model
-    /// according to a bit-flag for signedness `pos_bit` (`1` for positive, `0` for negative).
-    // FIXME - this currently yields the u16 value with the same machine-rep as the nominal i16 value we want
-    pub(crate) fn u8_to_i16(x: Expr, is_positive: Expr) -> Expr {
+    /// Given a variable identifier `var_name` representing a `u8` value, along with a bit-flag `is_positive` (`1` for positive, `0` for negative),
+    /// yields an expression of type `i16` with the magnitude of the original `u8` value and the appropriate signedness.
+    pub(crate) fn map_var_u8_to_i16(var_name: &'static str, is_positive: Expr) -> Expr {
+        use doodle::numeric::BasicUnaryOp;
         expr_if_else(
             is_positive,
-            as_u16(x.clone()),
-            expr_match(
-                x,
-                [
-                    (Pattern::U8(0), Expr::U16(0)),
-                    (bind("n"), sub(Expr::U16(u16::MAX), pred(as_u16(var("n"))))),
-                ],
-            ),
+            numeric(num::cast_bitwise(MachineRep::I16, num::num_var(var_name))),
+            numeric(num::unary_with_rep(
+                BasicUnaryOp::Negate,
+                Some(MachineRep::I16),
+                num::num_var(var_name),
+            )),
         )
     }
 
@@ -286,28 +286,24 @@ mod util {
         fmt_variant("F2Dot14", u16be())
     }
 
-    // FIXME[epic=signedness-hack]
-    /// Scaffolding to signal intent to use i8 format before it is implemented.
+    /// Parses a u8 value and performs a bitwise cast to i8.
     pub(crate) fn s8() -> Format {
-        u8()
+        i8()
     }
 
-    // FIXME[epic=signedness-hack]
-    /// Scaffolding to signal intent to use i16 format before it is implemented.
+    /// Parses a u16 value and performs a bitwise cast to i16.
     pub(crate) fn s16be() -> Format {
-        u16be()
+        i16be()
     }
 
-    // FIXME[epic=signedness-hack]
-    /// Scaffolding to signal intent to use i32 format before it is implemented.
+    /// Parses a u32 value and performs a bitwise cast to i32.
     pub(crate) fn s32be() -> Format {
-        u32be()
+        i32be()
     }
 
-    // FIXME[epic=signedness-hack]
-    /// Scaffolding to signal intent to use i64 format before it is implemented.
+    /// Parses a u64 value and performs a bitwise cast to i64.
     pub(crate) fn s64be() -> Format {
-        u64be()
+        i64be()
     }
 
     /// Helper function for parsing a big-endian u24 (3-byte) value
@@ -1222,7 +1218,7 @@ mod gvar {
             is_finished,
             update_totlen,
             Expr::U16(0),
-            ValueType::Base(BaseType::U16),
+            ValueType::U16,
             run,
         )
     }
@@ -1253,13 +1249,13 @@ mod gvar {
     /// - `array_start :~ U32`: absolute position corresponding to the logical start-of-array (which offsets are implicitly relative to)
     /// - `this_offset32 :~ U32`: relative offset where the GlyphVariationData table begins
     /// - `next_offset32 :~ U32`: relative offset where the immediately following GlyphVariationData table begins
-    /// - `data_table`: Format definition for GlyphVariationData table
+    /// - `data_table`: Format definition for GlyphVariationData table, parametric over `axis_count`
     fn data_table_array_entry(
         axis_count: Expr,
         array_view: ViewExpr,
         this_offset32: Expr,
         next_offset32: Expr,
-        data_table: FormatRef,
+        data_table: DepFormat<1, 0>,
     ) -> Format {
         cond_maybe(
             // NOTE - checks that the GlyphVariationData table is non-zero length
@@ -1270,7 +1266,7 @@ mod gvar {
                 // FIXME[epic=eager-view-parse] - this parse is more eager than we actually want
                 parse_from_view(
                     array_view.offset(this_offset32),
-                    slice(var("len"), data_table.call_args(vec![axis_count])),
+                    slice(var("len"), data_table.invoke_args([axis_count])),
                 ),
             ),
         )
@@ -1283,8 +1279,8 @@ mod gvar {
     ///
     /// - `axis_count :~ U16`: axis-count passed in from the gvar header
     /// - `offsets :~ Offsets16([U16]) | Offsets32([U32])`: array of offsets stored in the gvar header
-    /// - `data_table`: Format definition for GlyphVariationData table
-    fn data_table_array(axis_count: Expr, offsets: Expr, data_table: FormatRef) -> Format {
+    /// - `data_table`: Format definition for GlyphVariationData table, parametric in `axis_count`
+    fn data_table_array(axis_count: Expr, offsets: Expr, data_table: DepFormat<1, 0>) -> Format {
         let_view(
             "array_view",
             Format::Match(
@@ -1366,7 +1362,7 @@ mod gvar {
                             vvar("table_view"),
                             repeat_count(
                                 var("shared_tuple_count"),
-                                tuple_record.call_args(vec![var("axis_count")]),
+                                tuple_record.invoke_args([var("axis_count")]),
                             ),
                         ),
                     ),
@@ -1400,7 +1396,10 @@ mod gvar {
     /// GlyphVariationData table format definition
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gvar#the-glyphvariationdata-table-array
-    fn glyph_variation_data(module: &mut FormatModule, tuple_record: FormatRef) -> FormatRef {
+    fn glyph_variation_data(
+        module: &mut FormatModule,
+        tuple_record: DepFormat<1, 0>,
+    ) -> DepFormat<1, 0> {
         use BitFieldKind::*;
         let tuple_variation_header = tuple_variation_header(module, tuple_record);
         let packed_point_numbers = packed_point_numbers(module);
@@ -1418,12 +1417,9 @@ mod gvar {
             },
         ]);
 
-        module.define_format_args(
+        module.register_format_args(
             "opentype.gvar.glyph_variation_data",
-            vec![(
-                Label::Borrowed("axis_count"),
-                ValueType::Base(BaseType::U16),
-            )],
+            [(Label::Borrowed("axis_count"), ValueType::U16)],
             let_view(
                 "data_view",
                 record_auto([
@@ -1434,7 +1430,7 @@ mod gvar {
                         "tuple_variation_headers",
                         repeat_count(
                             record_proj(var("tuple_variation_count"), "tuple_count"),
-                            tuple_variation_header.call_args(vec![var("axis_count")]),
+                            tuple_variation_header.invoke_args([var("axis_count")]),
                         ),
                     ),
                     (
@@ -1462,7 +1458,7 @@ mod gvar {
     fn serialized_data(
         module: &mut FormatModule,
         packed_point_numbers: FormatRef,
-        tuple_variation_header: FormatRef,
+        tuple_variation_header: DepFormat<1, 0>,
     ) -> FormatRef {
         let header_type = module
             .get_format_type(tuple_variation_header.get_level())
@@ -1575,7 +1571,7 @@ mod gvar {
     ///
     /// If the `point_count` is only satisfied after reading a run that contains more than enough point-numbers
     /// proceeds no differently than if the exact count of point-number values were read.
-    fn point_number_runs(module: &mut FormatModule) -> FormatRef {
+    fn point_number_runs(module: &mut FormatModule) -> DepFormat<1, 0> {
         let run = point_number_run(module);
         let update_totlen = lambda_tuple(
             ["acc", "run"],
@@ -1588,9 +1584,9 @@ mod gvar {
                 ))),
             ),
         );
-        module.define_format_args(
+        module.register_format_args(
             "opentype.var.packed-point-numbers.runs",
-            vec![(Label::Borrowed("point_count"), ValueType::U16)],
+            [(Label::Borrowed("point_count"), ValueType::U16)],
             accum_until(
                 lambda_tuple(
                     ["totlen", "_seq"],
@@ -1598,7 +1594,7 @@ mod gvar {
                 ),
                 update_totlen,
                 Expr::U16(0),
-                ValueType::Base(BaseType::U16),
+                ValueType::U16,
                 run.call(),
             ),
         )
@@ -1620,22 +1616,26 @@ mod gvar {
                 chain(
                     byte_in(1..=127),
                     "point_count",
-                    runs.call_args(vec![as_u16(var("point_count"))]),
+                    runs.invoke_args([as_u16(var("point_count"))]),
                 ),
                 chain(
                     byte_in(128..=255),
                     "hi",
-                    chain(
-                        u8(),
-                        "lo",
-                        runs.call_args(vec![u15be(var("hi"), var("lo"))]),
-                    ),
+                    chain(u8(), "lo", runs.invoke_args([u15be(var("hi"), var("lo"))])),
                 ),
             ]),
         )
     }
 
-    fn tuple_variation_header(module: &mut FormatModule, tuple_record: FormatRef) -> FormatRef {
+    /// GVAR TupleVariationHeader format definition
+    ///
+    /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuplevariationheader
+    ///
+    /// Parametric over `axis_count :~ U16`.
+    fn tuple_variation_header(
+        module: &mut FormatModule,
+        tuple_record: DepFormat<1, 0>,
+    ) -> DepFormat<1, 0> {
         use BitFieldKind::*;
         const SHOULD_CHECK_ZERO: bool = false;
         let tuple_index = bit_fields_u16([
@@ -1651,9 +1651,9 @@ mod gvar {
                 field_name: "tuple_index",
             },
         ]);
-        module.define_format_args(
+        module.register_format_args(
             "opentype.gvar.tuple_variation_header",
-            vec![(Label::Borrowed("axis_count"), ValueType::U16)],
+            [(Label::Borrowed("axis_count"), ValueType::U16)],
             record([
                 ("variation_data_size", u16be()), // size, in bytes, of serialized data for this tuple variation table
                 ("tuple_index", tuple_index),
@@ -1661,7 +1661,7 @@ mod gvar {
                     "peak_tuple",
                     cond_maybe(
                         record_proj(var("tuple_index"), "embedded_peak_tuple"),
-                        tuple_record.call_args(vec![var("axis_count")]),
+                        tuple_record.invoke_args([var("axis_count")]),
                     ),
                 ),
                 (
@@ -1670,7 +1670,7 @@ mod gvar {
                         record_proj(var("tuple_index"), "intermediate_region"),
                         record_repeat(
                             ["start_tuple", "end_tuple"],
-                            tuple_record.call_args(vec![var("axis_count")]),
+                            tuple_record.invoke_args([var("axis_count")]),
                         ),
                     ),
                 ),
@@ -1681,11 +1681,13 @@ mod gvar {
     /// Definition for Tuple Records used in variation tables
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/otvarcommonformats#tuple-records
-    /// TODO - change namespace from `gvar` to `var`, move to common submodule for multi-table sub-formats
-    fn tuple_record(module: &mut FormatModule) -> FormatRef {
-        module.define_format_args(
+    ///
+    /// Parametric over `axis_count :~ U16`.
+    // TODO - change namespace from `gvar` to `var`, move to common submodule for multi-table sub-formats
+    fn tuple_record(module: &mut FormatModule) -> DepFormat<1, 0> {
+        module.register_format_args(
             "opentype.gvar.tuple_record",
-            vec![(Label::Borrowed("axis_count"), ValueType::U16)],
+            [(Label::Borrowed("axis_count"), ValueType::U16)],
             record([(
                 "coordinates",
                 repeat_count(var("axis_count"), util::f2dot14()),
@@ -1695,6 +1697,8 @@ mod gvar {
 }
 
 pub(crate) mod fvar {
+    use doodle::DepFormat;
+
     use super::*;
 
     pub(crate) fn table(module: &mut FormatModule, tag: FormatRef) -> FormatRef {
@@ -1750,8 +1754,7 @@ pub(crate) mod fvar {
                         var("instance_count"),
                         slice(
                             var("instance_size"),
-                            instance_record
-                                .call_args(vec![var("axis_count"), var("instance_size")]),
+                            instance_record.invoke_args([var("axis_count"), var("instance_size")]),
                         ),
                     ),
                 )),
@@ -1770,18 +1773,20 @@ pub(crate) mod fvar {
     /// InstanceRecord format implementation
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#instancerecord
-    fn instance_record(module: &mut FormatModule) -> FormatRef {
+    ///
+    /// Parametric over `axis_count :~ U16` and `instance_size :~ U16`.
+    fn instance_record(module: &mut FormatModule) -> DepFormat<2, 0> {
         let user_tuple = user_tuple(module);
-        module.define_format_args(
+        module.register_format_args(
             "opentype.fvar.instance_record",
-            vec![
+            [
                 (Label::Borrowed("axis_count"), ValueType::U16),
                 (Label::Borrowed("instance_size"), ValueType::U16),
             ],
             record([
                 ("subfamily_nameid", u16be()),
                 ("flags", util::expect_u16be(0)), // reserved for future use, should be set to 0,
-                ("coordinates", user_tuple.call_args(vec![var("axis_count")])),
+                ("coordinates", user_tuple.invoke_args([var("axis_count")])),
                 (
                     "postscript_nameid",
                     cond_maybe(
@@ -1797,10 +1802,12 @@ pub(crate) mod fvar {
     /// UserTuple record (part of `InstanceRecord`)
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/fvar#instancerecord
-    fn user_tuple(module: &mut FormatModule) -> FormatRef {
-        module.define_format_args(
+    ///
+    /// Parametric over `axis_count :~ U16`.
+    fn user_tuple(module: &mut FormatModule) -> DepFormat<1, 0> {
+        module.register_format_args(
             "opentype.fvar.user_tuple",
-            vec![(Label::Borrowed("axis_count"), ValueType::U16)],
+            [(Label::Borrowed("axis_count"), ValueType::U16)],
             record([(
                 "coordinates",
                 repeat_count(var("axis_count"), util::fixed32be()),
@@ -1943,10 +1950,10 @@ pub(crate) mod kern {
         /// The indices in ClassTables are scaled (J = 2 x j ; I = 2 x M x i) to facilitate offset-arithmetic for random access (TargetOffset(i,j) = BaseOffset + I + J)
         ///
         /// Requires additional parameters `table_view` and `class_table` to correctly parse the content at each class offset
-        pub(super) fn kerning_array(module: &mut FormatModule) -> FormatRef {
-            module.define_format_args(
+        pub(super) fn kerning_array(module: &mut FormatModule) -> DepFormat<2, 0> {
+            module.register_format_args(
                 "opentype.kern.kerning_array",
-                vec![
+                [
                     (Label::Borrowed("left_glyph_count"), ValueType::U16),
                     (Label::Borrowed("right_glyph_count"), ValueType::U16),
                 ],
@@ -2024,7 +2031,7 @@ pub(crate) mod kern {
                                         ),
                                     ),
                                 ],
-                                kerning_array.call_args(vec![
+                                kerning_array.invoke_args([
                                     expr_unwrap(var("left_glyph_count")),
                                     expr_unwrap(var("right_glyph_count")),
                                 ]),
@@ -2317,10 +2324,12 @@ mod gpos {
     use doodle::DepFormat;
 
     /// GPOS-specific LookupSubtable implementation
+    ///
+    /// Parametric over `lookup_type :~ U16`.
     fn lookup_subtable(
         module: &mut FormatModule,
         pos_extension: FormatRef,
-        ground_pos: FormatRef,
+        ground_pos: DepFormat<1, 0>,
     ) -> DepFormat<1, 0> {
         const EXTENSION_TYPE: u16 = 9;
         module.register_format_args(
@@ -2337,7 +2346,7 @@ mod gpos {
                     (
                         Pattern::Wildcard,
                         "GroundPos",
-                        ground_pos.call_args(vec![var("lookup_type")]),
+                        ground_pos.invoke_args([var("lookup_type")]),
                     ),
                 ],
             ),
@@ -2768,10 +2777,10 @@ mod gpos {
         anchor_table: FormatRef,
         mark_array: FormatRef,
     ) -> FormatRef {
-        let base_record = module.define_format_args_views(
+        let base_record = module.register_format_args_views(
             "opentype.layout.base_array.base_record",
-            vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
-            vec![Label::Borrowed("_array_view")],
+            [(Label::Borrowed("mark_class_count"), ValueType::U16)],
+            [Label::Borrowed("_array_view")],
             // REVIEW[epic=many-offsets-design-pattern] - for-each style
             record_auto([
                 (
@@ -2793,9 +2802,9 @@ mod gpos {
                 ),
             ]),
         );
-        let base_array = module.define_format_args(
+        let base_array = module.register_format_args(
             "opentype.layout.base_array",
-            vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
+            [(Label::Borrowed("mark_class_count"), ValueType::U16)],
             let_view(
                 "array_view",
                 record_auto([
@@ -2805,10 +2814,8 @@ mod gpos {
                         "base_records",
                         repeat_count(
                             var("base_count"),
-                            base_record.call_args_views(
-                                vec![var("mark_class_count")],
-                                vec![vvar("array_view")],
-                            ),
+                            base_record
+                                .invoke_args_views([var("mark_class_count")], [vvar("array_view")]),
                         ),
                     ),
                 ]),
@@ -2846,7 +2853,7 @@ mod gpos {
                             "base_array",
                             util::read_phantom_view_offset16(
                                 vvar("table_view"),
-                                base_array.call_args(vec![var("mark_class_count")]),
+                                base_array.invoke_args([var("mark_class_count")]),
                             ),
                         ),
                     ],
@@ -2860,11 +2867,17 @@ mod gpos {
 
     mod mark_lig {
         use super::*;
-        fn component_record(module: &mut FormatModule, anchor_table: FormatRef) -> FormatRef {
-            module.define_format_args_views(
+
+        /// Opentype Component Record (GPOS Mark-Lig Attachment) format definition
+        ///
+        /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-5-subtable-mark-to-ligature-attachment-positioning
+        ///
+        /// Parametric in `mark_class_count :~ U16` and `table_view ~ <LigatureAttach table frame>`.
+        fn component_record(module: &mut FormatModule, anchor_table: FormatRef) -> DepFormat<1, 1> {
+            module.register_format_args_views(
                 "opentype.layout.ligature_attach.component_record",
-                vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
-                vec![Label::Borrowed("table_view")],
+                [(Label::Borrowed("mark_class_count"), ValueType::U16)],
+                [Label::Borrowed("table_view")],
                 record_auto([
                     // REVIEW[epic=nested-format-reify-layer] - INNER(local)
                     ("record_scope", reify_view(vvar("table_view"))),
@@ -2890,12 +2903,17 @@ mod gpos {
             )
         }
 
-        fn ligature_attach(module: &mut FormatModule, anchor_table: FormatRef) -> FormatRef {
+        /// Opentype Ligature Attach (GPOS Mark-Lig Attachment) format definition
+        ///
+        /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-5-subtable-mark-to-ligature-attachment-positioning
+        ///
+        /// Parametric in `mark_class_count :~ U16`
+        fn ligature_attach(module: &mut FormatModule, anchor_table: FormatRef) -> DepFormat<1, 0> {
             let component_record = component_record(module, anchor_table);
 
-            module.define_format_args(
+            module.register_format_args(
                 "opentype.layout.ligature_attach",
-                vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
+                [(Label::Borrowed("mark_class_count"), ValueType::U16)],
                 let_view(
                     "table_view",
                     record([
@@ -2905,9 +2923,9 @@ mod gpos {
                             "component_records",
                             repeat_count(
                                 var("component_count"),
-                                component_record.call_args_views(
-                                    vec![var("mark_class_count")],
-                                    vec![vvar("table_view")],
+                                component_record.invoke_args_views(
+                                    [var("mark_class_count")],
+                                    [vvar("table_view")],
                                 ),
                             ),
                         ),
@@ -2920,12 +2938,12 @@ mod gpos {
         pub(super) fn ligature_array(
             module: &mut FormatModule,
             anchor_table: FormatRef,
-        ) -> FormatRef {
+        ) -> DepFormat<1, 0> {
             let ligature_attach = ligature_attach(module, anchor_table);
 
-            module.define_format_args(
+            module.register_format_args(
                 "opentype.layout.ligature_array",
-                vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
+                [(Label::Borrowed("mark_class_count"), ValueType::U16)],
                 let_view(
                     "array_view",
                     record_auto([
@@ -2946,7 +2964,7 @@ mod gpos {
                                 util::parse_view_offset::<U16>(
                                     vvar("array_view"),
                                     var("offset"),
-                                    ligature_attach.call_args(vec![var("mark_class_count")]),
+                                    ligature_attach.invoke_args([var("mark_class_count")]),
                                 ),
                             )),
                         ),
@@ -3001,7 +3019,7 @@ mod gpos {
                             "ligature_array",
                             util::read_phantom_view_offset16(
                                 vvar("table_view"),
-                                ligature_array.call_args(vec![var("mark_class_count")]),
+                                ligature_array.invoke_args([var("mark_class_count")]),
                             ),
                         ),
                     ],
@@ -3016,11 +3034,16 @@ mod gpos {
     mod mark_mark {
         use super::*;
 
-        fn mark2_record(module: &mut FormatModule, anchor_table: FormatRef) -> FormatRef {
-            module.define_format_args_views(
+        /// Opentype Mark2 Record (GPOS Mark-to-Mark Attachment) format definition
+        ///
+        /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-6-subtable-mark-to-mark-attachment-positioning
+        ///
+        /// Parametric in `mark_class_count :~ U16` and `view ~ <Mark2Array table frame>`
+        fn mark2_record(module: &mut FormatModule, anchor_table: FormatRef) -> DepFormat<1, 1> {
+            module.register_format_args_views(
                 "opentype.layout.mark2_array.mark2_record",
-                vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
-                vec![Label::Borrowed("_array_view")],
+                [(Label::Borrowed("mark_class_count"), ValueType::U16)],
+                [Label::Borrowed("_array_view")],
                 record_auto([
                     // REVIEW[epic=many-offsets-design-pattern] - for-each style
                     (
@@ -3044,12 +3067,17 @@ mod gpos {
             )
         }
 
-        pub(super) fn mark2_array(module: &mut FormatModule, anchor_table: FormatRef) -> FormatRef {
+        /// Mark2Array (GPOS Mark-to-Mark Attachment) format definition
+        ///
+        /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-6-subtable-mark-to-mark-attachment-positioning
+        ///
+        /// Parametric in `mark_class_count :~ U16`
+        pub(super) fn mark2_array(module: &mut FormatModule, anchor_table: FormatRef) -> DepFormat<1, 0> {
             let mark2_record = mark2_record(module, anchor_table);
 
-            module.define_format_args(
+            module.register_format_args(
                 "opentype.layout.mark2_array",
-                vec![(Label::Borrowed("mark_class_count"), ValueType::U16)],
+                [(Label::Borrowed("mark_class_count"), ValueType::U16)],
                 let_view(
                     "array_view",
                     record([
@@ -3060,9 +3088,9 @@ mod gpos {
                             "mark2_records",
                             repeat_count(
                                 var("mark2_count"),
-                                mark2_record.call_args_views(
-                                    vec![var("mark_class_count")],
-                                    vec![vvar("array_view")],
+                                mark2_record.invoke_args_views(
+                                    [var("mark_class_count")],
+                                    [vvar("array_view")],
                                 ),
                             ),
                         ),
@@ -3114,7 +3142,7 @@ mod gpos {
                             "mark2_array",
                             util::read_phantom_view_offset16(
                                 vvar("table_view"),
-                                mark2_array.call_args(vec![var("mark_class_count")]),
+                                mark2_array.invoke_args([var("mark_class_count")]),
                             ),
                         ),
                     ],
@@ -3127,6 +3155,8 @@ mod gpos {
     }
 
     /// Ground (non-recursive) GPOS lookup subtable type enumeration
+    ///
+    /// Parametric over `lookup_type :~ U16`
     pub(crate) fn ground_pos(
         module: &mut FormatModule,
         class_def: FormatRef,
@@ -3136,7 +3166,7 @@ mod gpos {
         anchor_table: FormatRef,
         sequence_context: FormatRef,
         chained_sequence_context: FormatRef,
-    ) -> FormatRef {
+    ) -> DepFormat<1, 0> {
         let single_pos = single_pos(module, coverage_table, value_format_flags, value_record);
         let pair_pos = pair_pos(
             module,
@@ -3150,9 +3180,10 @@ mod gpos {
         let mark_base_pos = mark_base_pos(module, coverage_table, anchor_table, mark_array);
         let mark_lig_pos = mark_lig_pos(module, coverage_table, anchor_table, mark_array);
         let mark_mark_pos = mark_mark_pos(module, coverage_table, anchor_table, mark_array);
-        module.define_format_args(
+
+        module.register_format_args(
             "opentype.layout.ground_pos",
-            vec![(Label::from("lookup_type"), ValueType::Base(BaseType::U16))],
+            [(Label::from("lookup_type"), ValueType::U16)],
             match_variant(
                 var("lookup_type"),
                 [
@@ -3178,7 +3209,7 @@ mod gpos {
     /// Lookup type 9 subtable: positioning suhbtable extension
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-9-subtable-positioning-subtable-extension
-    pub(crate) fn pos_extension(module: &mut FormatModule, ground_pos: FormatRef) -> FormatRef {
+    pub(crate) fn pos_extension(module: &mut FormatModule, ground_pos: DepFormat<1, 0>) -> FormatRef {
         module.define_format(
             "opentype.layout.pos_extension",
             let_view(
@@ -3196,7 +3227,7 @@ mod gpos {
                             "extension_offset",
                             util::read_phantom_view_offset32(
                                 vvar("table_view"),
-                                ground_pos.call_args(vec![var("extension_lookup_type")]),
+                                ground_pos.invoke_args([var("extension_lookup_type")]),
                             ),
                         ),
                     ],
@@ -3212,7 +3243,7 @@ mod gpos {
         module: &mut FormatModule,
         script_list: FormatRef,
         feature_list: FormatRef,
-        ground_pos: FormatRef,
+        ground_pos: DepFormat<1, 0>,
         pos_extension: FormatRef,
         feature_variations: FormatRef,
     ) -> FormatRef {
@@ -3599,7 +3630,7 @@ mod gsub {
         let reverse_chain_single_subst = reverse_chain_single_subst(module, coverage_table);
         module.register_format_args(
             "opentype.layout.ground_subst",
-            [(Label::from("lookup_type"), ValueType::Base(BaseType::U16))],
+            [(Label::from("lookup_type"), ValueType::U16)],
             match_variant(
                 var("lookup_type"),
                 [
@@ -5401,6 +5432,8 @@ mod gasp {
 }
 
 mod glyf {
+    use doodle::numeric::BasicUnaryOp;
+
     use super::*;
 
     mod simple {
@@ -5475,7 +5508,7 @@ mod glyf {
                     is_finished,
                     update_totlen,
                     Expr::U16(0),
-                    ValueType::Base(BaseType::U16),
+                    ValueType::U16,
                     flag_list_entry,
                 ),
                 lambda_tuple(["_len", "flags"], var("flags")),
@@ -5505,21 +5538,21 @@ mod glyf {
         fn x_coords(field_set: Expr) -> Format {
             if_then_else(
                 record_proj(field_set.clone(), "x_short_vector"),
-                // this wants to be i16
+                // overall type is i16
                 map(
                     u8(),
                     lambda(
                         "abs",
-                        util::u8_to_i16(
-                            var("abs"),
+                        util::map_var_u8_to_i16(
+                            "abs",
                             record_proj(field_set.clone(), "x_is_same_or_positive_x_short_vector"),
                         ),
                     ),
                 ),
                 if_then_else(
                     record_proj(field_set.clone(), "x_is_same_or_positive_x_short_vector"),
-                    // this wants to be i16
-                    compute(Expr::U16(0)),
+                    // type is i16
+                    compute(poly_zero()),
                     util::s16be(),
                 ),
             )
@@ -5530,34 +5563,31 @@ mod glyf {
         fn y_coords(field_set: Expr) -> Format {
             if_then_else(
                 record_proj(field_set.clone(), "y_short_vector"),
-                // this wants to be i16
+                // overall type is i16
                 map(
                     u8(),
                     lambda(
                         "abs",
-                        util::u8_to_i16(
-                            var("abs"),
+                        util::map_var_u8_to_i16(
+                            "abs",
                             record_proj(field_set.clone(), "y_is_same_or_positive_y_short_vector"),
                         ),
                     ),
                 ),
                 if_then_else(
                     record_proj(field_set.clone(), "y_is_same_or_positive_y_short_vector"),
-                    // this wants to be i16
-                    compute(Expr::U16(0)),
+                    //  type is i16
+                    compute(poly_zero()),
                     util::s16be(),
                 ),
             )
         }
 
-        pub(crate) fn table(module: &mut FormatModule) -> FormatRef {
+        pub(crate) fn table(module: &mut FormatModule) -> DepFormat<1, 0> {
             let simple_flags_raw = flags_raw(module);
-            module.define_format_args(
+            module.register_format_args(
                 "opentype.glyf.simple",
-                vec![(
-                    Label::Borrowed("n_contours"),
-                    ValueType::Base(BaseType::U16),
-                )],
+                [(Label::Borrowed("n_contours"), ValueType::U16)],
                 record([
                     (
                         "end_points_of_contour",
@@ -5758,14 +5788,8 @@ mod glyf {
             let mk_branch = |elem_t: ValueType| ValueType::Seq(Box::new(elem_t));
             let mut branches = std::collections::BTreeMap::new();
             // NOTE - at this layer, the u16-valued offsets are still half-value
-            branches.insert(
-                Label::Borrowed("Offsets16"),
-                mk_branch(ValueType::Base(BaseType::U16)),
-            );
-            branches.insert(
-                Label::Borrowed("Offsets32"),
-                mk_branch(ValueType::Base(BaseType::U32)),
-            );
+            branches.insert(Label::Borrowed("Offsets16"), mk_branch(ValueType::U16));
+            branches.insert(Label::Borrowed("Offsets32"), mk_branch(ValueType::U32));
             ValueType::Union(branches)
         };
 
@@ -5840,25 +5864,28 @@ mod glyf {
         )
     }
 
+    /// Glyph description (empty, simple or composite) format definition
+    ///
+    /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/glyf#table-organization
+    ///
+    /// Parametric in `n_contours :~ I16`
     fn glyf_description(
         module: &mut FormatModule,
-        simple_glyf_table: FormatRef,
+        simple_glyf_table: DepFormat<1, 0>,
         composite_glyf_table: FormatRef,
     ) -> FormatRef {
         module.define_format_args(
             "opentype.glyf.description",
-            vec![(
-                Label::Borrowed("n_contours"),
-                ValueType::Base(BaseType::U16),
-            )],
+            // actually I16 but we don't hjave that yet
+            vec![(Label::Borrowed("n_contours"), ValueType::UnknownNumeric)],
             match_variant(
                 var("n_contours"),
                 [
-                    (Pattern::U16(0), "HeaderOnly", Format::EMPTY),
+                    (Pattern::z_const(0), "HeaderOnly", Format::EMPTY),
                     (
-                        Pattern::Int(Bounds::new(1, i16::MAX as usize)),
+                        Pattern::z_range(1, i16::MAX),
                         "Simple",
-                        simple_glyf_table.call_args(vec![var("n_contours")]),
+                        simple_glyf_table.invoke_args([numeric(num::unary_with_rep(BasicUnaryOp::AbsVal, Some(MachineRep::U16), num::num_var("n_contours")))]),
                     ),
                     (Pattern::Wildcard, "Composite", composite_glyf_table.call()),
                 ],
@@ -5874,14 +5901,8 @@ pub(crate) mod loca {
         module.define_format_args(
             "opentype.loca.table",
             vec![
-                (
-                    Label::Borrowed("num_glyphs"),
-                    ValueType::Base(BaseType::U16),
-                ),
-                (
-                    Label::Borrowed("index_to_loc_format"),
-                    ValueType::Base(BaseType::U16),
-                ),
+                (Label::Borrowed("num_glyphs"), ValueType::U16),
+                (Label::Borrowed("index_to_loc_format"), ValueType::U16),
             ],
             record([(
                 "offsets",
@@ -6302,14 +6323,8 @@ pub(crate) mod hmtx {
         module.define_format_args(
             "opentype.hmtx.table",
             vec![
-                (
-                    Label::Borrowed("num_long_metrics"),
-                    ValueType::Base(BaseType::U16),
-                ),
-                (
-                    Label::Borrowed("num_glyphs"),
-                    ValueType::Base(BaseType::U16),
-                ),
+                (Label::Borrowed("num_long_metrics"), ValueType::U16),
+                (Label::Borrowed("num_glyphs"), ValueType::U16),
             ],
             record([
                 (
@@ -6465,7 +6480,7 @@ pub(crate) mod cmap {
 
         let cmap_subtable = module.define_format_args(
             "opentype.cmap.subtable",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             let_view(
                 "table_view",
                 record([
@@ -6570,7 +6585,7 @@ pub(crate) mod cmap {
     fn subtable_format0(module: &mut FormatModule) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format0",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6598,7 +6613,7 @@ pub(crate) mod cmap {
         // Format 2: High-byte mapping through table
         module.define_format_args(
             "opentype.cmap_subtable.format2",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6635,7 +6650,7 @@ pub(crate) mod cmap {
     fn subtable_format4(module: &mut FormatModule) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format4",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6666,7 +6681,7 @@ pub(crate) mod cmap {
     fn subtable_format6(module: &mut FormatModule) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format6",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             /* Previously defined as a slice_record but sufficiently large `entry_count` values
              * could cause length to wrap around mod 65536 and lead to slice boundary violation
              * while reading `glyph_id_array`
@@ -6685,7 +6700,7 @@ pub(crate) mod cmap {
     fn subtable_format8(module: &mut FormatModule, sequential_map_group: FormatRef) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format8",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6708,7 +6723,7 @@ pub(crate) mod cmap {
     fn subtable_format10(module: &mut FormatModule) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format10",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6727,7 +6742,7 @@ pub(crate) mod cmap {
     fn subtable_format12(module: &mut FormatModule, sequential_map_group: FormatRef) -> FormatRef {
         module.define_format_args(
             "opentype.cmap_subtable.format12",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [
@@ -6750,7 +6765,7 @@ pub(crate) mod cmap {
 
         module.define_format_args(
             "opentype.cmap_subtable.format13",
-            vec![(Label::Borrowed("_platform"), ValueType::Base(BaseType::U16))],
+            vec![(Label::Borrowed("_platform"), ValueType::U16)],
             util::slice_record(
                 "length",
                 [

--- a/doodle-formats/src/format/opentype.rs
+++ b/doodle-formats/src/format/opentype.rs
@@ -261,18 +261,16 @@ mod util {
         mul(as_u32(half), Expr::U32(2))
     }
 
-    /// Given a variable identifier `var_name` representing a `u8` value, along with a bit-flag `is_positive` (`1` for positive, `0` for negative),
-    /// yields an expression of type `i16` with the magnitude of the original `u8` value and the appropriate signedness.
-    pub(crate) fn map_var_u8_to_i16(var_name: &'static str, is_positive: Expr) -> Expr {
+    /// Given a bit-flag `is_positive` (`1` for positive, `0` for negative),
+    /// parses a `u8` value and maps it into an expression of type `i16` with the magnitude of the original `u8` value and the appropriate signedness.
+    pub(crate) fn parse_u8_to_i16(is_positive: Expr) -> Format {
         use doodle::numeric::BasicUnaryOp;
-        expr_if_else(
+        if_then_else(
             is_positive,
-            numeric(num::cast_bitwise(MachineRep::I16, num::num_var(var_name))),
-            numeric(num::unary_with_rep(
-                BasicUnaryOp::Negate,
-                Some(MachineRep::I16),
-                num::num_var(var_name),
-            )),
+            map_numeric(u8(), |v| num::cast(MachineRep::I16, v)),
+            map_numeric(u8(), |v| {
+                num::unary_with_rep(BasicUnaryOp::Negate, Some(MachineRep::I16), v)
+            }),
         )
     }
 
@@ -288,22 +286,22 @@ mod util {
 
     /// Parses a u8 value and performs a bitwise cast to i8.
     pub(crate) fn s8() -> Format {
-        i8()
+        u8()
     }
 
     /// Parses a u16 value and performs a bitwise cast to i16.
     pub(crate) fn s16be() -> Format {
-        i16be()
+        u16be()
     }
 
     /// Parses a u32 value and performs a bitwise cast to i32.
     pub(crate) fn s32be() -> Format {
-        i32be()
+        u32be()
     }
 
     /// Parses a u64 value and performs a bitwise cast to i64.
     pub(crate) fn s64be() -> Format {
-        i64be()
+        u64be()
     }
 
     /// Helper function for parsing a big-endian u24 (3-byte) value
@@ -1196,8 +1194,8 @@ mod gvar {
                         fmt_variant("Delta0", compute(var("run_length"))),
                         if_then_else(
                             record_proj(var("control"), "deltas_are_words"),
-                            fmt_variant("Delta16", repeat_count(var("run_length"), util::s16be())),
-                            fmt_variant("Delta8", repeat_count(var("run_length"), util::s8())),
+                            fmt_variant("Delta16", repeat_count(var("run_length"), i16be())),
+                            fmt_variant("Delta8", repeat_count(var("run_length"), i8())),
                         ),
                     )),
                 ),
@@ -1900,9 +1898,9 @@ pub(crate) mod kern {
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/kern#format-0
     fn subtable_format0(module: &mut FormatModule) -> FormatRef {
         let kern_pair = record([
-            ("left", u16be()),        // glyph index for left-hand glyph in kerning pair
-            ("right", u16be()),       // glyph index for right-hand glyph in kerning pair
-            ("value", util::s16be()), // kerning value for given pair, in design-units. Positive values move characters apart, negative values move characters closer together.
+            ("left", u16be()),  // glyph index for left-hand glyph in kerning pair
+            ("right", u16be()), // glyph index for right-hand glyph in kerning pair
+            ("value", i16be()), // kerning value for given pair, in design-units. Positive values move characters apart, negative values move characters closer together.
         ]);
         module.define_format(
             "opentype.kern.subtable.format0",
@@ -1967,7 +1965,7 @@ pub(crate) mod kern {
                             var("left_glyph_count"), // N rows where there are N left-hand classes
                             repeat_count(
                                 var("right_glyph_count"), // M columns
-                                util::s16be(),            // FWORD value at index (i, j)
+                                i16be(),                  // FWORD value at index (i, j)
                             ),
                         ),
                     ),
@@ -2296,7 +2294,7 @@ mod base {
                     // WIP
                     ("table_scope", reify_view(vvar("table_view"))),
                     ("format", u16be()),
-                    ("coordinate", util::s16be()),
+                    ("coordinate", i16be()),
                     (
                         "data",
                         match_variant(
@@ -3072,7 +3070,10 @@ mod gpos {
         /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-6-subtable-mark-to-mark-attachment-positioning
         ///
         /// Parametric in `mark_class_count :~ U16`
-        pub(super) fn mark2_array(module: &mut FormatModule, anchor_table: FormatRef) -> DepFormat<1, 0> {
+        pub(super) fn mark2_array(
+            module: &mut FormatModule,
+            anchor_table: FormatRef,
+        ) -> DepFormat<1, 0> {
             let mark2_record = mark2_record(module, anchor_table);
 
             module.register_format_args(
@@ -3209,7 +3210,10 @@ mod gpos {
     /// Lookup type 9 subtable: positioning suhbtable extension
     ///
     /// C.f. https://learn.microsoft.com/en-us/typography/opentype/spec/gpos#lookup-type-9-subtable-positioning-subtable-extension
-    pub(crate) fn pos_extension(module: &mut FormatModule, ground_pos: DepFormat<1, 0>) -> FormatRef {
+    pub(crate) fn pos_extension(
+        module: &mut FormatModule,
+        ground_pos: DepFormat<1, 0>,
+    ) -> FormatRef {
         module.define_format(
             "opentype.layout.pos_extension",
             let_view(
@@ -3309,7 +3313,7 @@ mod gsub {
                     "coverage",
                     util::read_phantom_view_offset16(vvar("table_view"), coverage_table.call()),
                 ),
-                ("delta_glyph_id", util::s16be()),
+                ("delta_glyph_id", i16be()),
             ]),
         );
         // Single substitution format 2
@@ -4389,10 +4393,10 @@ mod layout {
             vec![(Label::Borrowed("flags"), vf_flags_type.clone())],
             vec![Label::Borrowed("table_view")],
             record([
-                opt_field("x_placement", util::s16be()),
-                opt_field("y_placement", util::s16be()),
-                opt_field("x_advance", util::s16be()),
-                opt_field("y_advance", util::s16be()),
+                opt_field("x_placement", i16be()),
+                opt_field("y_placement", i16be()),
+                opt_field("x_advance", i16be()),
+                opt_field("y_advance", i16be()),
                 opt_field(
                     "x_placement_device",
                     util::read_phantom_view_offset16(
@@ -4470,13 +4474,10 @@ mod layout {
         device_or_variation_index_table: FormatRef,
     ) -> FormatRef {
         // REVIEW - should formats 1 and 2 be defined as well?
-        let anchor_format1 = record([
-            ("x_coordinate", util::s16be()),
-            ("y_coordinate", util::s16be()),
-        ]);
+        let anchor_format1 = record([("x_coordinate", i16be()), ("y_coordinate", i16be())]);
         let anchor_format2 = record([
-            ("x_coordinate", util::s16be()),
-            ("y_coordinate", util::s16be()),
+            ("x_coordinate", i16be()),
+            ("y_coordinate", i16be()),
             ("anchor_point", u16be()),
         ]);
         // REVIEW[epic=closure-dep-formats] - should this be a Dep-Format registration (module.define_format_args) instead?
@@ -4485,8 +4486,8 @@ mod layout {
             vec![Label::Borrowed("table_view")],
             record_auto([
                 ("table_scope", reify_view(vvar("table_view"))),
-                ("x_coordinate", util::s16be()),
-                ("y_coordinate", util::s16be()),
+                ("x_coordinate", i16be()),
+                ("y_coordinate", i16be()),
                 // REVIEW - each offset below is individually nullable if the other is set, but it may be invalid for them to both be null simultaneously...?
                 (
                     "x_device",
@@ -4923,7 +4924,7 @@ mod gdef {
         device_or_variation_index_table: FormatRef,
     ) -> FormatRef {
         // REVIEW - should we make formatrefs for formats 1 and 2 for consistency?
-        let caret_value_format_1 = record([("coordinate", util::s16be())]);
+        let caret_value_format_1 = record([("coordinate", i16be())]);
 
         let caret_value_format_2 = record([("caret_value_point_index", u16be())]);
 
@@ -4933,7 +4934,7 @@ mod gdef {
             record([
                 // REVIEW[epic=nested-format-reify-layer] - reified into local scope
                 ("table_scope", reify_view(vvar("table_view"))),
-                ("coordinate", util::s16be()),
+                ("coordinate", i16be()),
                 (
                     "table",
                     util::read_phantom_view_offset16(
@@ -5123,8 +5124,8 @@ mod common {
                     repeat_count(
                         item_count.clone(),
                         deltas(
-                            util::s32be(),
-                            util::s16be(),
+                            i32be(),
+                            i16be(),
                             record_proj(word_delta_count.clone(), "word_count"),
                             region_index_count.clone(),
                         ),
@@ -5135,8 +5136,8 @@ mod common {
                     repeat_count(
                         item_count,
                         deltas(
-                            util::s16be(),
-                            util::s8(),
+                            i16be(),
+                            i8(),
                             record_proj(word_delta_count.clone(), "word_count"),
                             region_index_count,
                         ),
@@ -5437,6 +5438,8 @@ mod glyf {
     use super::*;
 
     mod simple {
+        use doodle::numeric::TypedConst;
+
         use super::*;
 
         pub(crate) fn flags_raw(module: &mut FormatModule) -> FormatRef {
@@ -5538,22 +5541,14 @@ mod glyf {
         fn x_coords(field_set: Expr) -> Format {
             if_then_else(
                 record_proj(field_set.clone(), "x_short_vector"),
-                // overall type is i16
-                map(
-                    u8(),
-                    lambda(
-                        "abs",
-                        util::map_var_u8_to_i16(
-                            "abs",
-                            record_proj(field_set.clone(), "x_is_same_or_positive_x_short_vector"),
-                        ),
-                    ),
-                ),
+                parse_u8_to_i16(record_proj(
+                    field_set.clone(),
+                    "x_is_same_or_positive_x_short_vector",
+                )),
                 if_then_else(
                     record_proj(field_set.clone(), "x_is_same_or_positive_x_short_vector"),
-                    // type is i16
                     compute(poly_zero()),
-                    util::s16be(),
+                    i16be(),
                 ),
             )
         }
@@ -5563,22 +5558,14 @@ mod glyf {
         fn y_coords(field_set: Expr) -> Format {
             if_then_else(
                 record_proj(field_set.clone(), "y_short_vector"),
-                // overall type is i16
-                map(
-                    u8(),
-                    lambda(
-                        "abs",
-                        util::map_var_u8_to_i16(
-                            "abs",
-                            record_proj(field_set.clone(), "y_is_same_or_positive_y_short_vector"),
-                        ),
-                    ),
-                ),
+                parse_u8_to_i16(record_proj(
+                    field_set.clone(),
+                    "y_is_same_or_positive_y_short_vector",
+                )),
                 if_then_else(
                     record_proj(field_set.clone(), "y_is_same_or_positive_y_short_vector"),
-                    //  type is i16
                     compute(poly_zero()),
-                    util::s16be(),
+                    i16be(),
                 ),
             )
         }
@@ -5629,12 +5616,12 @@ mod glyf {
                     are_words,
                     if_then_else(
                         are_xy_values.clone(),
-                        fmt_variant("Int16", util::s16be()),
+                        fmt_variant("Int16", i16be()),
                         fmt_variant("Uint16", u16be()),
                     ),
                     if_then_else(
                         are_xy_values,
-                        fmt_variant("Int8", util::s8()),
+                        fmt_variant("Int8", i8()),
                         fmt_variant("Uint8", u8()),
                     ),
                 )
@@ -5847,18 +5834,18 @@ mod glyf {
         )
     }
 
-    fn glyf_entry(module: &mut FormatModule, glyf_description: FormatRef) -> FormatRef {
+    fn glyf_entry(module: &mut FormatModule, glyf_description: DepFormat<1, 0>) -> FormatRef {
         module.define_format(
             "opentype.glyf.entry",
             record([
-                ("number_of_contours", util::s16be()),
-                ("x_min", util::s16be()),
-                ("y_min", util::s16be()),
-                ("x_max", util::s16be()),
-                ("y_max", util::s16be()),
+                ("number_of_contours", i16be()),
+                ("x_min", i16be()),
+                ("y_min", i16be()),
+                ("x_max", i16be()),
+                ("y_max", i16be()),
                 (
                     "description",
-                    glyf_description.call_args(vec![var("number_of_contours")]),
+                    glyf_description.invoke_args([var("number_of_contours")]),
                 ),
             ]),
         )
@@ -5873,11 +5860,11 @@ mod glyf {
         module: &mut FormatModule,
         simple_glyf_table: DepFormat<1, 0>,
         composite_glyf_table: FormatRef,
-    ) -> FormatRef {
-        module.define_format_args(
+    ) -> DepFormat<1, 0> {
+        module.register_format_args(
             "opentype.glyf.description",
-            // actually I16 but we don't hjave that yet
-            vec![(Label::Borrowed("n_contours"), ValueType::UnknownNumeric)],
+            // actually I16 but we don't have that yet
+            [(Label::Borrowed("n_contours"), ValueType::UnknownNumeric)],
             match_variant(
                 var("n_contours"),
                 [
@@ -5885,7 +5872,11 @@ mod glyf {
                     (
                         Pattern::z_range(1, i16::MAX),
                         "Simple",
-                        simple_glyf_table.invoke_args([numeric(num::unary_with_rep(BasicUnaryOp::AbsVal, Some(MachineRep::U16), num::num_var("n_contours")))]),
+                        simple_glyf_table.invoke_args([numeric(num::unary_with_rep(
+                            BasicUnaryOp::AbsVal,
+                            Some(MachineRep::U16),
+                            num::num_var("n_contours"),
+                        ))]),
                     ),
                     (Pattern::Wildcard, "Composite", composite_glyf_table.call()),
                 ],
@@ -5940,7 +5931,7 @@ pub(crate) mod cvt {
     use super::*;
 
     pub(crate) fn table(_module: &mut FormatModule) -> Format {
-        repeat(util::s16be())
+        repeat(i16be())
     }
 }
 pub(crate) mod post {
@@ -6014,7 +6005,7 @@ pub(crate) mod post {
         let postv2dot5 = record([
             ("num_glyphs", u16be()),
             // TODO - ReadArray<'_, I8> would work here if we had a model compatible with it
-            ("offset", repeat_count(var("num_glyphs"), util::s8())),
+            ("offset", repeat_count(var("num_glyphs"), i8())),
         ]);
 
         module.define_format(
@@ -6022,8 +6013,8 @@ pub(crate) mod post {
             record([
                 ("version", util::version16_16()),
                 ("italic_angle", util::fixed32be()),
-                ("underline_position", util::s16be()),
-                ("underline_thickness", util::s16be()),
+                ("underline_position", i16be()),
+                ("underline_thickness", i16be()),
                 ("is_fixed_pitch", u32be()), // nonzero <=> fixed pitch
                 ("min_mem_type42", u32be()),
                 ("max_mem_type42", u32be()),
@@ -6079,9 +6070,9 @@ mod os2 {
                 expr_gte(table_length, Expr::U32(V0_MIN_LENGTH)),
             ),
             record([
-                ("s_typo_ascender", util::s16be()),
-                ("s_typo_descender", util::s16be()),
-                ("s_typo_line_gap", util::s16be()),
+                ("s_typo_ascender", i16be()),
+                ("s_typo_descender", i16be()),
+                ("s_typo_line_gap", i16be()),
                 ("us_win_ascent", u16be()),
                 ("us_win_descent", u16be()),
                 (
@@ -6096,8 +6087,8 @@ mod os2 {
                                 cond_maybe(
                                     is_within(var(version_ident), Bounds::at_least(2)),
                                     record([
-                                        ("sx_height", util::s16be()),
-                                        ("s_cap_height", util::s16be()),
+                                        ("sx_height", i16be()),
+                                        ("s_cap_height", i16be()),
                                         ("us_default_char", u16be()),
                                         ("us_break_char", u16be()),
                                         ("us_max_context", u16be()),
@@ -6130,21 +6121,21 @@ mod os2 {
             )],
             record([
                 ("version", u16be()),
-                ("x_avg_char_width", util::s16be()),
+                ("x_avg_char_width", i16be()),
                 ("us_weight_class", u16be()),
                 ("us_width_class", u16be()),
                 ("fs_type", u16be()),
-                ("y_subscript_x_size", util::s16be()),
-                ("y_subscript_y_size", util::s16be()),
-                ("y_subscript_x_offset", util::s16be()),
-                ("y_subscript_y_offset", util::s16be()),
-                ("y_superscript_x_size", util::s16be()),
-                ("y_superscript_y_size", util::s16be()),
-                ("y_superscript_x_offset", util::s16be()),
-                ("y_superscript_y_offset", util::s16be()),
-                ("y_strikeout_size", util::s16be()),
-                ("y_strikeout_position", util::s16be()),
-                ("s_family_class", util::s16be()),
+                ("y_subscript_x_size", i16be()),
+                ("y_subscript_y_size", i16be()),
+                ("y_subscript_x_offset", i16be()),
+                ("y_subscript_y_offset", i16be()),
+                ("y_superscript_x_size", i16be()),
+                ("y_superscript_y_size", i16be()),
+                ("y_superscript_x_offset", i16be()),
+                ("y_superscript_y_offset", i16be()),
+                ("y_strikeout_size", i16be()),
+                ("y_strikeout_position", i16be()),
+                ("s_family_class", i16be()),
                 ("panose", repeat_count(Expr::U8(10), u8())),
                 ("ul_unicode_range1", u32be()),
                 ("ul_unicode_range2", u32be()),
@@ -6315,10 +6306,8 @@ pub(crate) mod hmtx {
     use super::*;
 
     pub(crate) fn table(module: &mut FormatModule) -> FormatRef {
-        let long_horizontal_metric = record([
-            ("advance_width", u16be()),
-            ("left_side_bearing", util::s16be()),
-        ]);
+        let long_horizontal_metric =
+            record([("advance_width", u16be()), ("left_side_bearing", i16be())]);
 
         module.define_format_args(
             "opentype.hmtx.table",
@@ -6333,10 +6322,7 @@ pub(crate) mod hmtx {
                 ),
                 (
                     "left_side_bearings", // REVIEW - 'top_side_bearings' in vmtx
-                    repeat_count(
-                        sub(var("num_glyphs"), var("num_long_metrics")),
-                        util::s16be(),
-                    ),
+                    repeat_count(sub(var("num_glyphs"), var("num_long_metrics")), i16be()),
                 ),
             ]),
         )
@@ -6400,16 +6386,16 @@ pub(crate) mod hhea {
                 "minor_version",
                 util::expects_u16be([0x0000, 0x1000]), // NOTE - due to how versions are encoded for hhea/vhea tables v1.1 is `00 01 . 10 00`
             ), // FIXME - hhea only has 1.0, but vhea has 1.1 as well, so we compromise by allowing it in both to re-use it properly
-            ("ascent", util::s16be()), // distance from baseline to highest ascender, in font design units
-            ("descent", util::s16be()), // distance from baseline to lowest descender, in font design units
-            ("line_gap", util::s16be()), // intended gap between baselines, in font design units
+            ("ascent", i16be()), // distance from baseline to highest ascender, in font design units
+            ("descent", i16be()), // distance from baseline to lowest descender, in font design units
+            ("line_gap", i16be()), // intended gap between baselines, in font design units
             ("advance_width_max", u16be()), // must be consistent with horizontal metrics
-            ("min_left_side_bearing", util::s16be()), // must be consistent with horizontal metrics
-            ("min_right_side_bearing", util::s16be()), // must be consistent with horizontal metrics
-            ("x_max_extent", util::s16be()), // `max(left_side_bearing + (x_max - x_min))`
+            ("min_left_side_bearing", i16be()), // must be consistent with horizontal metrics
+            ("min_right_side_bearing", i16be()), // must be consistent with horizontal metrics
+            ("x_max_extent", i16be()), // `max(left_side_bearing + (x_max - x_min))`
             // slope of the caret (rise/run), (1/0) for vertical caret
-            ("caret_slope", record_repeat(["rise", "run"], util::s16be())),
-            ("caret_offset", util::s16be()), // 0 for non-slanted fonts
+            ("caret_slope", record_repeat(["rise", "run"], i16be())),
+            ("caret_offset", i16be()), // 0 for non-slanted fonts
             ("__reservedX4", tuple_repeat(4, util::expect_u16be(0))), // NOTE: 4 separate isolated fields in fathom
             ("metric_data_format", util::expect_u16be(0)),
             // number of `long_horizontal_metric` records in the `htmx_table`, `long_vertical_metrics` in `vmtx_table`
@@ -6605,8 +6591,7 @@ pub(crate) mod cmap {
         let subheader = record([
             ("first_code", u16be()),
             ("entry_count", u16be()),
-            // FIXME - this is actually a signed 16-bit value but we don't support that; it can be unsigned as long as we do the right wrapping addition
-            ("id_delta", util::s16be()),
+            ("id_delta", i16be()),
             ("id_range_offset", u16be()),
         ]);
 
@@ -6852,9 +6837,9 @@ pub(crate) mod head {
         // FIXME - replace with bit_fields_u16 if appropriate
         let head_table_flags = u16be();
 
-        let long_date_time = module.define_format("opentype.types.long_date_time", util::s64be());
+        let long_date_time = module.define_format("opentype.types.long_date_time", i64be());
 
-        let xy_min_max = record_repeat(["x_min", "y_min", "x_max", "y_max"], util::s16be());
+        let xy_min_max = record_repeat(["x_min", "y_min", "x_max", "y_max"], i16be());
 
         // REVIEW[epic=check-zero] - determine whether we should check for zeroing of reserved bit-fields positions
         const SHOULD_CHECK_ZERO: bool = false;

--- a/generated/api_helper/otf_metrics.rs
+++ b/generated/api_helper/otf_metrics.rs
@@ -6632,28 +6632,30 @@ impl Ctxt {
 // !SECTION
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-#[repr(u16)]
 enum DirectionHint {
-    FullyMixed = 0,
-    StrongLR = 1,
-    NeutralLR = 2,
-    StrongRL = -1i16 as u16,
-    NeutralRL = -2i16 as u16,
+    FullyMixed, // 0
+    StrongLR,   // 1,
+    NeutralLR,  // 2,
+    StrongRL,   // -1
+    NeutralRL,  // -2
 }
 
-impl TryFrom<u16> for DirectionHint {
-    type Error = Local<UnknownValueError<u16>>;
+pub type OpentypeDirectionHint = opentype_head_table_font_direction_hint;
 
-    fn try_from(value: u16) -> Result<Self, Self::Error> {
-        match value as i16 {
-            0 => Ok(DirectionHint::FullyMixed),
-            1 => Ok(DirectionHint::StrongLR),
-            2 => Ok(DirectionHint::NeutralLR),
-            -1 => Ok(DirectionHint::StrongRL),
-            -2 => Ok(DirectionHint::NeutralRL),
-            _ => Err(UnknownValueError {
+impl TryFrom<OpentypeDirectionHint> for DirectionHint {
+    type Error = Local<UnknownValueError<i16>>;
+
+    fn try_from(value: OpentypeDirectionHint) -> Result<Self, Self::Error> {
+        use opentype_head_table_font_direction_hint::*;
+        match value {
+            Mixed => Ok(DirectionHint::FullyMixed),
+            StrongLR => Ok(DirectionHint::StrongLR),
+            WeakLR => Ok(DirectionHint::NeutralLR),
+            StrongRL => Ok(DirectionHint::StrongRL),
+            WeakRL => Ok(DirectionHint::NeutralRL),
+            UnknownDirHint(bad_value) => Err(UnknownValueError {
                 what: String::from("direction-hint"),
-                bad_value: value,
+                bad_value,
             }),
         }
     }

--- a/generated/api_helper/otf_metrics.rs
+++ b/generated/api_helper/otf_metrics.rs
@@ -2796,16 +2796,8 @@ impl Promote<OpentypeDeltaSets> for DeltaSets {
                     .iter()
                     .map(|delta_set| {
                         (
-                            delta_set
-                                .delta_data_full_word
-                                .iter()
-                                .map(|u: &u32| *u as i32)
-                                .collect(),
-                            delta_set
-                                .delta_data_half_word
-                                .iter()
-                                .map(|u: &u16| *u as i16)
-                                .collect(),
+                            delta_set.delta_data_full_word.clone(),
+                            delta_set.delta_data_half_word.clone(),
                         )
                     })
                     .collect(),
@@ -2815,16 +2807,8 @@ impl Promote<OpentypeDeltaSets> for DeltaSets {
                     .iter()
                     .map(|delta_set| {
                         (
-                            delta_set
-                                .delta_data_full_word
-                                .iter()
-                                .map(|u: &u16| *u as i16)
-                                .collect(),
-                            delta_set
-                                .delta_data_half_word
-                                .iter()
-                                .map(|u: &u8| *u as i8)
-                                .collect(),
+                            delta_set.delta_data_full_word.clone(),
+                            delta_set.delta_data_half_word.clone(),
                         )
                     })
                     .collect(),
@@ -3460,10 +3444,10 @@ enum DeviceOrVariationIndexTable {
 
 #[derive(Clone, Debug)]
 enum CaretValue {
-    DesignUnits(u16),  // Format1
+    DesignUnits(i16),  // Format1
     ContourPoint(u16), // Format2
     DesignUnitsWithTable {
-        coordinate: u16,
+        coordinate: i16,
         device: Link<DeviceOrVariationIndexTable>,
     }, // Format3
 }
@@ -4807,7 +4791,7 @@ impl<'input> Promote<OpentypeSingleSubstFormat1<'input>> for SingleSubstFormat1 
 #[derive(Debug, Clone)]
 struct SingleSubstFormat1 {
     coverage: CoverageTable,
-    delta_glyph_id: s16,
+    delta_glyph_id: i16,
 }
 
 frame!(OpentypeSingleSubstFormat2);
@@ -5562,11 +5546,6 @@ enum AnchorTable {
     Format3(AnchorTableFormat3),
 }
 
-// TODO - s16be Format , so change to i16 when appropriate
-#[allow(non_camel_case_types)]
-/// Scaffolding type to allow for convenient switch-over from u16 to i16 on field parsed as s16[be]
-type s16 = u16;
-
 impl Promote<OpentypeAnchorTableFormat1> for AnchorTableFormat1 {
     fn promote(orig: &OpentypeAnchorTableFormat1) -> Self {
         AnchorTableFormat1 {
@@ -5622,21 +5601,21 @@ impl<'input> TryPromote<OpentypeAnchorTableFormat3<'input>> for AnchorTableForma
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct AnchorTableFormat1 {
-    x_coordinate: s16,
-    y_coordinate: s16,
+    x_coordinate: i16,
+    y_coordinate: i16,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct AnchorTableFormat2 {
-    x_coordinate: s16,
-    y_coordinate: s16,
+    x_coordinate: i16,
+    y_coordinate: i16,
     anchor_point: u16,
 }
 
 #[derive(Debug, Clone)]
 struct AnchorTableFormat3 {
-    x_coordinate: s16,
-    y_coordinate: s16,
+    x_coordinate: i16,
+    y_coordinate: i16,
     x_device: Option<DeviceOrVariationIndexTable>,
     y_device: Option<DeviceOrVariationIndexTable>,
 }
@@ -6041,10 +6020,10 @@ impl TryPromoteView<OpentypeValueRecord> for ValueRecord {
             .map_err(ValueParseError::value)
         };
         Ok(ValueRecord {
-            x_placement: orig.x_placement.map(as_s16),
-            y_placement: orig.y_placement.map(as_s16),
-            x_advance: orig.x_advance.map(as_s16),
-            y_advance: orig.y_advance.map(as_s16),
+            x_placement: orig.x_placement,
+            y_placement: orig.y_placement,
+            x_advance: orig.x_advance,
+            y_advance: orig.y_advance,
             x_placement_device: follow(OpentypeValueRecord::IX_X_PLACEMENT_DEVICE)?,
             y_placement_device: follow(OpentypeValueRecord::IX_Y_PLACEMENT_DEVICE)?,
             x_advance_device: follow(OpentypeValueRecord::IX_X_ADVANCE_DEVICE)?,
@@ -6418,7 +6397,7 @@ impl Promote<OpentypeKernPair> for KernPair {
         KernPair {
             left: orig.left,
             right: orig.right,
-            value: as_s16(orig.value),
+            value: orig.value,
         }
     }
 }
@@ -6539,7 +6518,7 @@ impl Promote<OpentypeKerningArray> for KerningArray {
         let size = height * width;
         let mut accum = Wec::with_capacity(width, size);
         for row in orig.kerning_values.iter() {
-            accum.extend(row.iter().map(|u| as_s16(*u)));
+            accum.extend(row.iter().copied());
         }
         KerningArray(accum)
     }
@@ -6651,12 +6630,6 @@ impl Ctxt {
     }
 }
 // !SECTION
-
-// NOTE - scaffolding to mark the values we currently parse into u16 but which are logically i16, to flag changes to the gencode API as they crop up
-#[inline(always)]
-const fn as_s16(v: u16) -> i16 {
-    v as i16
-}
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[repr(u16)]
@@ -6818,13 +6791,16 @@ pub fn analyze_table_directory(dir: &OpentypeFontDirectory) -> TestResult<Single
             for hmet in hmtx.long_metrics.iter() {
                 accum.push(UnifiedBearing {
                     advance_width: Some(hmet.advance_width),
-                    left_side_bearing: as_s16(hmet.left_side_bearing),
+                    left_side_bearing: hmet.left_side_bearing,
                 });
             }
             for lsb in hmtx.left_side_bearings.iter() {
                 accum.push(UnifiedBearing {
                     advance_width: None,
-                    left_side_bearing: as_s16(*lsb),
+                    left_side_bearing: {
+                        let v = *lsb;
+                        v
+                    },
                 });
             }
             Heap::new(HmtxMetrics(accum))
@@ -6997,7 +6973,7 @@ pub fn analyze_table_directory(dir: &OpentypeFontDirectory) -> TestResult<Single
                     accum.push(UnifiedBearing {
                         advance_width: Some(vmet.advance_width),
                         // FIXME - if name gets changed to top_side_bearing, correct accordingly
-                        left_side_bearing: as_s16(vmet.left_side_bearing),
+                        left_side_bearing: vmet.left_side_bearing,
                     });
                 }
                 // FIXME - if name gets changed to top_side_bearings, correct accordingly
@@ -7005,7 +6981,7 @@ pub fn analyze_table_directory(dir: &OpentypeFontDirectory) -> TestResult<Single
                     accum.push(UnifiedBearing {
                         advance_width: None,
                         // FIXME - if name gets changed to top_side_bearing, correct accordingly
-                        left_side_bearing: as_s16(*tsb),
+                        left_side_bearing: *tsb,
                     });
                 }
                 VmtxMetrics(accum)
@@ -7246,10 +7222,10 @@ fn is_extra(table_id: &u32) -> bool {
 
 fn bounding_box(gl: &GlyphHeader) -> BoundingBox {
     BoundingBox {
-        x_min: as_s16(gl.x_min),
-        y_min: as_s16(gl.y_min),
-        x_max: as_s16(gl.x_max),
-        y_max: as_s16(gl.y_max),
+        x_min: gl.x_min,
+        y_min: gl.y_min,
+        x_max: gl.x_max,
+        y_max: gl.y_max,
     }
 }
 

--- a/generated/api_helper/otf_metrics/output.rs
+++ b/generated/api_helper/otf_metrics/output.rs
@@ -1688,16 +1688,10 @@ mod layout {
             AnchorTable::Format1(AnchorTableFormat1 {
                 x_coordinate,
                 y_coordinate,
-            }) => toks(format!(
-                "({}, {})",
-                as_s16(*x_coordinate),
-                as_s16(*y_coordinate)
-            )),
+            }) => toks(format!("({}, {})", x_coordinate, y_coordinate)),
             AnchorTable::Format2(f2) => toks(format!(
                 "({}, {})@[{}]",
-                as_s16(f2.x_coordinate),
-                as_s16(f2.y_coordinate),
-                f2.anchor_point
+                f2.x_coordinate, f2.y_coordinate, f2.anchor_point
             )),
             AnchorTable::Format3(AnchorTableFormat3 {
                 x_coordinate,
@@ -1724,12 +1718,7 @@ mod layout {
                         y_tokens,
                     )))
                 };
-                tok(format!(
-                    "({}, {})",
-                    as_s16(*x_coordinate),
-                    as_s16(*y_coordinate),
-                ))
-                .then(extra)
+                tok(format!("({}, {})", x_coordinate, y_coordinate,)).then(extra)
             }
         }
     }

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -21,7 +21,7 @@ Decoder_elf_header_ident(p)
 }
 
 /// expected size: 5
-/// trait-ready: unique decoder function (d#212)
+/// trait-ready: unique decoder function (d#214)
 #[derive(Debug, Copy, Clone)]
 pub struct elf_header_ident {
 class: u8,
@@ -43,7 +43,7 @@ Decoder_elf_types_elf_addr(p, is_be, class)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#201)
+/// trait-ready: unique decoder function (d#203)
 #[derive(Debug, Copy, Clone)]
 pub enum elf_types_elf_addr { Addr32(u32), Addr64(u64) }
 
@@ -59,7 +59,7 @@ Decoder_elf_types_elf_off(p, is_be, class)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#202)
+/// trait-ready: unique decoder function (d#204)
 #[derive(Debug, Copy, Clone)]
 pub enum elf_types_elf_off { Off32(u32), Off64(u64) }
 
@@ -74,7 +74,7 @@ Decoder_elf_header(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#193)
+/// trait-ready: unique decoder function (d#195)
 #[derive(Debug, Copy, Clone)]
 pub struct elf_header {
 ident: elf_header_ident,
@@ -105,7 +105,7 @@ Decoder_elf_types_elf_full(p, is_be, class)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#200)
+/// trait-ready: unique decoder function (d#202)
 #[derive(Debug, Copy, Clone)]
 pub enum elf_types_elf_full { Full32(u32), Full64(u64) }
 
@@ -121,7 +121,7 @@ Decoder_elf_phdr(p, is_be, class)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#209)
+/// trait-ready: unique decoder function (d#211)
 #[derive(Debug, Copy, Clone)]
 pub struct elf_phdr {
 r#type: u32,
@@ -147,7 +147,7 @@ Decoder_elf_shdr(p, is_be, class)
 }
 
 /// expected size: 112
-/// trait-ready: unique decoder function (d#197)
+/// trait-ready: unique decoder function (d#199)
 #[derive(Debug, Copy, Clone)]
 pub struct elf_shdr {
 name: u32,
@@ -193,7 +193,7 @@ Decoder_gif_header(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#429)
+/// trait-ready: unique decoder function (d#431)
 #[derive(Debug, Clone)]
 pub struct gif_header {
 signature: (u8, u8, u8),
@@ -211,7 +211,7 @@ Decoder_gif_logical_screen_descriptor_flags(p)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#449)
+/// trait-ready: unique decoder function (d#451)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_logical_screen_descriptor_flags {
 table_flag: bool,
@@ -231,7 +231,7 @@ Decoder_gif_logical_screen_descriptor(p)
 }
 
 /// expected size: 10
-/// trait-ready: unique decoder function (d#448)
+/// trait-ready: unique decoder function (d#450)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_logical_screen_descriptor {
 screen_width: u16,
@@ -242,7 +242,7 @@ pixel_aspect_ratio: u8
 }
 
 /// expected size: 3
-/// trait-unready: multiple (2) decoders exist (d#{409, 444})
+/// trait-unready: multiple (2) decoders exist (d#{411, 446})
 #[derive(Debug, Copy, Clone)]
 pub struct gif_color_table_entry {
 r: u8,
@@ -261,7 +261,7 @@ Decoder_gif_logical_screen(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#430)
+/// trait-ready: unique decoder function (d#432)
 #[derive(Debug, Clone)]
 pub struct gif_logical_screen {
 descriptor: gif_logical_screen_descriptor,
@@ -279,7 +279,7 @@ Decoder_gif_graphic_control_extension_flags(p)
 }
 
 /// expected size: 3
-/// trait-ready: unique decoder function (d#447)
+/// trait-ready: unique decoder function (d#449)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_graphic_control_extension_flags {
 disposal_method: u8,
@@ -298,7 +298,7 @@ Decoder_gif_graphic_control_extension(p)
 }
 
 /// expected size: 10
-/// trait-ready: unique decoder function (d#439)
+/// trait-ready: unique decoder function (d#441)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_graphic_control_extension {
 separator: u8,
@@ -321,7 +321,7 @@ Decoder_gif_subblock(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#437)
+/// trait-ready: unique decoder function (d#439)
 #[derive(Debug, Clone)]
 pub struct gif_subblock {
 len_bytes: u8,
@@ -339,7 +339,7 @@ Decoder_gif_plain_text_extension(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#442)
+/// trait-ready: unique decoder function (d#444)
 #[derive(Debug, Clone)]
 pub struct gif_plain_text_extension {
 separator: u8,
@@ -368,7 +368,7 @@ Decoder_gif_image_descriptor_flags(p)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#446)
+/// trait-ready: unique decoder function (d#448)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_image_descriptor_flags {
 table_flag: bool,
@@ -388,7 +388,7 @@ Decoder_gif_image_descriptor(p)
 }
 
 /// expected size: 14
-/// trait-ready: unique decoder function (d#443)
+/// trait-ready: unique decoder function (d#445)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_image_descriptor {
 separator: u8,
@@ -410,7 +410,7 @@ Decoder_gif_table_based_image_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#445)
+/// trait-ready: unique decoder function (d#447)
 #[derive(Debug, Clone)]
 pub struct gif_table_based_image_data {
 lzw_min_code_size: u8,
@@ -429,7 +429,7 @@ Decoder_gif_table_based_image(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#441)
+/// trait-ready: unique decoder function (d#443)
 #[derive(Debug, Clone)]
 pub struct gif_table_based_image {
 descriptor: gif_image_descriptor,
@@ -448,7 +448,7 @@ Decoder_gif_graphic_rendering_block(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#440)
+/// trait-ready: unique decoder function (d#442)
 #[derive(Debug, Clone)]
 pub enum gif_graphic_rendering_block { plain_text_extension(gif_plain_text_extension), table_based_image(gif_table_based_image) }
 
@@ -463,7 +463,7 @@ Decoder_gif_graphic_block(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#433)
+/// trait-ready: unique decoder function (d#435)
 #[derive(Debug, Clone)]
 pub struct gif_graphic_block {
 graphic_control_extension: Option<gif_graphic_control_extension>,
@@ -481,7 +481,7 @@ Decoder_gif_application_extension(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#435)
+/// trait-ready: unique decoder function (d#437)
 #[derive(Debug, Clone)]
 pub struct gif_application_extension {
 separator: u8,
@@ -504,7 +504,7 @@ Decoder_gif_comment_extension(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#436)
+/// trait-ready: unique decoder function (d#438)
 #[derive(Debug, Clone)]
 pub struct gif_comment_extension {
 separator: u8,
@@ -524,7 +524,7 @@ Decoder_gif_special_purpose_block(p)
 }
 
 /// expected size: 88
-/// trait-ready: unique decoder function (d#434)
+/// trait-ready: unique decoder function (d#436)
 #[derive(Debug, Clone)]
 pub enum gif_special_purpose_block { application_extension(gif_application_extension), comment_extension(gif_comment_extension) }
 
@@ -539,7 +539,7 @@ Decoder_gif_block(p)
 }
 
 /// expected size: 104
-/// trait-ready: unique decoder function (d#431)
+/// trait-ready: unique decoder function (d#433)
 #[derive(Debug, Clone)]
 pub enum gif_block { graphic_block(gif_graphic_block), special_purpose_block(gif_special_purpose_block) }
 
@@ -554,7 +554,7 @@ Decoder_gif_trailer(p)
 }
 
 /// expected size: 1
-/// trait-ready: unique decoder function (d#432)
+/// trait-ready: unique decoder function (d#434)
 #[derive(Debug, Copy, Clone)]
 pub struct gif_trailer {
 separator: u8
@@ -591,7 +591,7 @@ Decoder_gzip_header_file_flags(p)
 }
 
 /// expected size: 5
-/// trait-ready: unique decoder function (d#424)
+/// trait-ready: unique decoder function (d#426)
 #[derive(Debug, Copy, Clone)]
 pub struct gzip_header_file_flags {
 fcomment: bool,
@@ -612,7 +612,7 @@ Decoder_gzip_header(p)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#417)
+/// trait-ready: unique decoder function (d#419)
 #[derive(Debug, Copy, Clone)]
 pub struct gzip_header {
 magic: (u8, u8),
@@ -634,7 +634,7 @@ Decoder_gzip_fextra_subfield(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#423)
+/// trait-ready: unique decoder function (d#425)
 #[derive(Debug, Clone)]
 pub struct gzip_fextra_subfield {
 si1: u8,
@@ -654,7 +654,7 @@ Decoder_gzip_fextra(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#418)
+/// trait-ready: unique decoder function (d#420)
 #[derive(Debug, Clone)]
 pub struct gzip_fextra {
 xlen: u16,
@@ -662,7 +662,7 @@ subfields: Vec<gzip_fextra_subfield>
 }
 
 /// expected size: 24
-/// trait-unready: multiple (2) decoders exist (d#{420, 428})
+/// trait-unready: multiple (2) decoders exist (d#{422, 430})
 #[derive(Debug, Clone)]
 pub struct gzip_fcomment {
 comment: Vec<u8>
@@ -679,7 +679,7 @@ Decoder_gzip_fhcrc(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#421)
+/// trait-ready: unique decoder function (d#423)
 #[derive(Debug, Copy, Clone)]
 pub struct gzip_fhcrc {
 crc: u16
@@ -694,7 +694,7 @@ extra: u8
 }
 
 /// expected size: 4
-/// trait-unready: multiple (2) decoders exist (d#{247, 248})
+/// trait-unready: multiple (2) decoders exist (d#{249, 250})
 #[derive(Debug, Copy, Clone)]
 pub struct deflate_distance_record0 {
 distance_extra_bits: u16,
@@ -743,7 +743,7 @@ Decoder_deflate_dynamic_huffman(p)
 }
 
 /// expected size: 176
-/// trait-ready: unique decoder function (d#245)
+/// trait-ready: unique decoder function (d#247)
 #[derive(Debug, Clone)]
 pub struct deflate_dynamic_huffman {
 hlit: u8,
@@ -787,7 +787,7 @@ Decoder_deflate_fixed_huffman(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#244)
+/// trait-ready: unique decoder function (d#246)
 #[derive(Debug, Clone)]
 pub struct deflate_fixed_huffman {
 codes: Vec<deflate_fixed_huffman_codes>,
@@ -805,7 +805,7 @@ Decoder_deflate_uncompressed(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#243)
+/// trait-ready: unique decoder function (d#245)
 #[derive(Debug, Clone)]
 pub struct deflate_uncompressed {
 len: u16,
@@ -832,7 +832,7 @@ Decoder_deflate_block(p)
 
 /// expected size: 192
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [Noop, Noop, InDef(InEnum { variants: [DirectHeap, Noop, Noop] })] }, Layout { size: 64, align: 8 (1 << 3) })
-/// trait-ready: unique decoder function (d#242)
+/// trait-ready: unique decoder function (d#244)
 #[derive(Debug, Clone)]
 pub struct deflate_block {
 r#final: u8,
@@ -851,7 +851,7 @@ Decoder_deflate_main(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#241)
+/// trait-ready: unique decoder function (d#243)
 #[derive(Debug, Clone)]
 pub struct deflate_main {
 blocks: Vec<deflate_block>,
@@ -870,7 +870,7 @@ Decoder_gzip_footer(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#422)
+/// trait-ready: unique decoder function (d#424)
 #[derive(Debug, Copy, Clone)]
 pub struct gzip_footer {
 crc: u32,
@@ -891,7 +891,7 @@ footer: gzip_footer
 }
 
 /// expected size: 1
-/// trait-unready: multiple (10) decoders exist (d#{339, 341, 352, 353, 354, 355, 356, 357, 358, 359})
+/// trait-unready: multiple (10) decoders exist (d#{341, 343, 354, 355, 356, 357, 358, 359, 360, 361})
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_soi {
 marker: u8
@@ -908,7 +908,7 @@ Decoder_jpeg_app0_jfif(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#408)
+/// trait-ready: unique decoder function (d#410)
 #[derive(Debug, Clone)]
 pub struct jpeg_app0_jfif {
 version_major: u8,
@@ -932,7 +932,7 @@ Decoder_jpeg_app0_data_data(p, identifier)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#407)
+/// trait-ready: unique decoder function (d#409)
 #[derive(Debug, Clone)]
 pub enum jpeg_app0_data_data { jfif(jpeg_app0_jfif), other(Vec<u8>) }
 
@@ -947,7 +947,7 @@ Decoder_jpeg_app0_data(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#406)
+/// trait-ready: unique decoder function (d#408)
 #[derive(Debug, Clone)]
 pub struct jpeg_app0_data {
 identifier: Vec<u8>,
@@ -965,7 +965,7 @@ Decoder_jpeg_app0(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#385)
+/// trait-ready: unique decoder function (d#387)
 #[derive(Debug, Clone)]
 pub struct jpeg_app0 {
 marker: jpeg_soi,
@@ -984,7 +984,7 @@ Decoder_tiff_byte_order(p)
 }
 
 /// expected size: 3
-/// trait-ready: unique decoder function (d#228)
+/// trait-ready: unique decoder function (d#230)
 #[derive(Debug, Copy, Clone)]
 pub enum tiff_byte_order { be(u8, u8), le(u8, u8) }
 
@@ -999,7 +999,7 @@ offset_or_data: u32
 }
 
 /// expected size: 56
-/// trait-unready: multiple (3) decoders exist (d#{229, 230, 231})
+/// trait-unready: multiple (3) decoders exist (d#{231, 232, 233})
 #[derive(Debug, Clone)]
 pub struct tiff_ifd_le {
 num_fields: u16,
@@ -1040,7 +1040,7 @@ Decoder_jpeg_app1_exif(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#404)
+/// trait-ready: unique decoder function (d#406)
 #[derive(Debug, Clone)]
 pub struct jpeg_app1_exif {
 padding: u8,
@@ -1058,7 +1058,7 @@ Decoder_jpeg_app1_xmp(p)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#405)
+/// trait-ready: unique decoder function (d#407)
 #[derive(Debug, Clone)]
 pub struct jpeg_app1_xmp {
 xmp: Vec<u8>
@@ -1075,7 +1075,7 @@ Decoder_jpeg_app1_data_data(p, identifier)
 }
 
 /// expected size: 88
-/// trait-ready: unique decoder function (d#403)
+/// trait-ready: unique decoder function (d#405)
 #[derive(Debug, Clone)]
 pub enum jpeg_app1_data_data { exif(jpeg_app1_exif), other(Vec<u8>), xmp(jpeg_app1_xmp) }
 
@@ -1090,7 +1090,7 @@ Decoder_jpeg_app1_data(p)
 }
 
 /// expected size: 112
-/// trait-ready: unique decoder function (d#402)
+/// trait-ready: unique decoder function (d#404)
 #[derive(Debug, Clone)]
 pub struct jpeg_app1_data {
 identifier: Vec<u8>,
@@ -1108,7 +1108,7 @@ Decoder_jpeg_app1(p)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#386)
+/// trait-ready: unique decoder function (d#388)
 #[derive(Debug, Clone)]
 pub struct jpeg_app1 {
 marker: jpeg_soi,
@@ -1127,12 +1127,12 @@ Decoder_jpeg_frame_initial_segment(p)
 }
 
 /// expected size: 128
-/// trait-ready: unique decoder function (d#342)
+/// trait-ready: unique decoder function (d#344)
 #[derive(Debug, Clone)]
 pub enum jpeg_frame_initial_segment { app0(jpeg_app0), app1(jpeg_app1) }
 
 /// expected size: 32
-/// trait-unready: multiple (16) decoders exist (d#{387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 457})
+/// trait-unready: multiple (16) decoders exist (d#{389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 459})
 #[derive(Debug, Clone)]
 pub struct jpeg_app2 {
 marker: jpeg_soi,
@@ -1151,7 +1151,7 @@ Decoder_jpeg_class_table_id(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#412)
+/// trait-ready: unique decoder function (d#414)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_class_table_id {
 class: u8,
@@ -1169,7 +1169,7 @@ Decoder_jpeg_dac_data(p)
 }
 
 /// expected size: 3
-/// trait-ready: unique decoder function (d#411)
+/// trait-ready: unique decoder function (d#413)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dac_data {
 class_table_id: jpeg_class_table_id,
@@ -1187,7 +1187,7 @@ Decoder_jpeg_dac(p)
 }
 
 /// expected size: 6
-/// trait-ready: unique decoder function (d#383)
+/// trait-ready: unique decoder function (d#385)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dac {
 marker: jpeg_soi,
@@ -1206,7 +1206,7 @@ Decoder_jpeg_dht_data(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#413)
+/// trait-ready: unique decoder function (d#415)
 #[derive(Debug, Clone)]
 pub struct jpeg_dht_data {
 class_table_id: jpeg_class_table_id,
@@ -1225,7 +1225,7 @@ Decoder_jpeg_dht(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#382)
+/// trait-ready: unique decoder function (d#384)
 #[derive(Debug, Clone)]
 pub struct jpeg_dht {
 marker: jpeg_soi,
@@ -1244,7 +1244,7 @@ Decoder_jpeg_precision_table_id(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#415)
+/// trait-ready: unique decoder function (d#417)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_precision_table_id {
 precision: u8,
@@ -1262,7 +1262,7 @@ Decoder_jpeg_dqt_data_elements(p, precision)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#416)
+/// trait-ready: unique decoder function (d#418)
 #[derive(Debug, Clone)]
 pub enum jpeg_dqt_data_elements { Bytes(Vec<u8>), Shorts(Vec<u16>) }
 
@@ -1277,7 +1277,7 @@ Decoder_jpeg_dqt_data(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#414)
+/// trait-ready: unique decoder function (d#416)
 #[derive(Debug, Clone)]
 pub struct jpeg_dqt_data {
 precision_table_id: jpeg_precision_table_id,
@@ -1295,7 +1295,7 @@ Decoder_jpeg_dqt(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#381)
+/// trait-ready: unique decoder function (d#383)
 #[derive(Debug, Clone)]
 pub struct jpeg_dqt {
 marker: jpeg_soi,
@@ -1314,7 +1314,7 @@ Decoder_jpeg_dri_data(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#410)
+/// trait-ready: unique decoder function (d#412)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dri_data {
 restart_interval: u16
@@ -1331,7 +1331,7 @@ Decoder_jpeg_dri(p)
 }
 
 /// expected size: 6
-/// trait-ready: unique decoder function (d#384)
+/// trait-ready: unique decoder function (d#386)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dri {
 marker: jpeg_soi,
@@ -1350,12 +1350,12 @@ Decoder_jpeg_table_or_misc(p)
 }
 
 /// expected size: 128
-/// trait-ready: unique decoder function (d#343)
+/// trait-ready: unique decoder function (d#345)
 #[derive(Debug, Clone)]
 pub enum jpeg_table_or_misc { app0(jpeg_app0), app1(jpeg_app1), app10(jpeg_app2), app11(jpeg_app2), app12(jpeg_app2), app13(jpeg_app2), app14(jpeg_app2), app15(jpeg_app2), app2(jpeg_app2), app3(jpeg_app2), app4(jpeg_app2), app5(jpeg_app2), app6(jpeg_app2), app7(jpeg_app2), app8(jpeg_app2), app9(jpeg_app2), com(jpeg_app2), dac(jpeg_dac), dht(jpeg_dht), dqt(jpeg_dqt), dri(jpeg_dri) }
 
 /// expected size: 2
-/// trait-unready: multiple (2) decoders exist (d#{451, 453})
+/// trait-unready: multiple (2) decoders exist (d#{453, 455})
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dhp_image_component_sampling_factor {
 horizontal: u8,
@@ -1363,7 +1363,7 @@ vertical: u8
 }
 
 /// expected size: 4
-/// trait-unready: multiple (3) decoders exist (d#{380, 452, 455})
+/// trait-unready: multiple (3) decoders exist (d#{382, 454, 457})
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_sof_image_component {
 id: u8,
@@ -1372,7 +1372,7 @@ quantization_table_id: u8
 }
 
 /// expected size: 32
-/// trait-unready: multiple (3) decoders exist (d#{379, 454, 459})
+/// trait-unready: multiple (3) decoders exist (d#{381, 456, 461})
 #[derive(Debug, Clone)]
 pub struct jpeg_sof_data {
 sample_precision: u8,
@@ -1383,7 +1383,7 @@ image_components: Vec<jpeg_sof_image_component>
 }
 
 /// expected size: 40
-/// trait-unready: multiple (14) decoders exist (d#{366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 458})
+/// trait-unready: multiple (14) decoders exist (d#{368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 460})
 #[derive(Debug, Clone)]
 pub struct jpeg_sof0 {
 marker: jpeg_soi,
@@ -1402,7 +1402,7 @@ Decoder_jpeg_frame_header(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#344)
+/// trait-ready: unique decoder function (d#346)
 #[derive(Debug, Clone)]
 pub enum jpeg_frame_header { sof0(jpeg_sof0), sof1(jpeg_sof0), sof10(jpeg_sof0), sof11(jpeg_sof0), sof13(jpeg_sof0), sof14(jpeg_sof0), sof15(jpeg_sof0), sof2(jpeg_sof0), sof3(jpeg_sof0), sof5(jpeg_sof0), sof6(jpeg_sof0), sof7(jpeg_sof0), sof9(jpeg_sof0) }
 
@@ -1417,7 +1417,7 @@ Decoder_jpeg_sos_image_component_entropy_coding_table_ids(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#363)
+/// trait-ready: unique decoder function (d#365)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_sos_image_component_entropy_coding_table_ids {
 dc_entropy_coding_table_id: u8,
@@ -1435,7 +1435,7 @@ Decoder_jpeg_sos_image_component(p)
 }
 
 /// expected size: 3
-/// trait-ready: unique decoder function (d#361)
+/// trait-ready: unique decoder function (d#363)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_sos_image_component {
 component_selector: u8,
@@ -1453,7 +1453,7 @@ Decoder_jpeg_sos_data_approximation_bit_position(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#362)
+/// trait-ready: unique decoder function (d#364)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_sos_data_approximation_bit_position {
 high: u8,
@@ -1471,7 +1471,7 @@ Decoder_jpeg_sos_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#360)
+/// trait-ready: unique decoder function (d#362)
 #[derive(Debug, Clone)]
 pub struct jpeg_sos_data {
 num_image_components: u8,
@@ -1492,7 +1492,7 @@ Decoder_jpeg_sos(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#348)
+/// trait-ready: unique decoder function (d#350)
 #[derive(Debug, Clone)]
 pub struct jpeg_sos {
 marker: jpeg_soi,
@@ -1511,12 +1511,12 @@ Decoder_jpeg_scan_data_entropy_coded_segment(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#350)
+/// trait-ready: unique decoder function (d#352)
 #[derive(Debug, Copy, Clone)]
 pub enum jpeg_scan_data_entropy_coded_segment { mcu(u8), rst0(jpeg_soi), rst1(jpeg_soi), rst2(jpeg_soi), rst3(jpeg_soi), rst4(jpeg_soi), rst5(jpeg_soi), rst6(jpeg_soi), rst7(jpeg_soi) }
 
 /// expected size: 48
-/// trait-unready: multiple (2) decoders exist (d#{349, 365})
+/// trait-unready: multiple (2) decoders exist (d#{351, 367})
 #[derive(Debug, Clone)]
 pub struct jpeg_scan_data {
 scan_data: Vec<jpeg_scan_data_entropy_coded_segment>,
@@ -1524,7 +1524,7 @@ scan_data_stream: Vec<u8>
 }
 
 /// expected size: 112
-/// trait-unready: multiple (2) decoders exist (d#{345, 347})
+/// trait-unready: multiple (2) decoders exist (d#{347, 349})
 #[derive(Debug, Clone)]
 pub struct jpeg_scan {
 segments: Vec<jpeg_table_or_misc>,
@@ -1543,7 +1543,7 @@ Decoder_jpeg_dnl_data(p)
 }
 
 /// expected size: 2
-/// trait-ready: unique decoder function (d#364)
+/// trait-ready: unique decoder function (d#366)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dnl_data {
 num_lines: u16
@@ -1560,7 +1560,7 @@ Decoder_jpeg_dnl(p)
 }
 
 /// expected size: 6
-/// trait-ready: unique decoder function (d#346)
+/// trait-ready: unique decoder function (d#348)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_dnl {
 marker: jpeg_soi,
@@ -1579,7 +1579,7 @@ Decoder_jpeg_frame(p)
 }
 
 /// expected size: 344
-/// trait-ready: unique decoder function (d#340)
+/// trait-ready: unique decoder function (d#342)
 #[derive(Debug, Clone)]
 pub struct jpeg_frame {
 initial_segment: jpeg_frame_initial_segment,
@@ -1620,7 +1620,7 @@ Decoder_mpeg4_ftyp_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#285)
+/// trait-ready: unique decoder function (d#287)
 #[derive(Debug, Clone)]
 pub struct mpeg4_ftyp_data {
 major_brand: (u8, u8, u8, u8),
@@ -1629,7 +1629,7 @@ compatible_brands: Vec<(u8, u8, u8, u8)>
 }
 
 /// expected size: 40
-/// trait-unready: multiple (2) decoders exist (d#{314, 316})
+/// trait-unready: multiple (2) decoders exist (d#{316, 318})
 #[derive(Debug, Clone)]
 pub struct mpeg4_dref_data_data {
 size_field: u32,
@@ -1649,7 +1649,7 @@ Decoder_mpeg4_dref_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#315)
+/// trait-ready: unique decoder function (d#317)
 #[derive(Debug, Clone)]
 pub struct mpeg4_dref_data {
 version: u8,
@@ -1674,7 +1674,7 @@ Decoder_mpeg4_dinf_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#300)
+/// trait-ready: unique decoder function (d#302)
 #[derive(Debug, Clone)]
 pub struct mpeg4_dinf_atom {
 size_field: u32,
@@ -1694,7 +1694,7 @@ Decoder_mpeg4_meta_hdlr_data(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#320)
+/// trait-ready: unique decoder function (d#322)
 #[derive(Debug, Clone)]
 pub struct mpeg4_meta_hdlr_data {
 version: u8,
@@ -1716,7 +1716,7 @@ Decoder_mpeg4_infe_data_fields_version_lt2(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#334)
+/// trait-ready: unique decoder function (d#336)
 #[derive(Debug, Clone)]
 pub struct mpeg4_infe_data_fields_version_lt2 {
 item_ID: u16,
@@ -1737,7 +1737,7 @@ Decoder_mpeg4_infe_atom_data_extra_fields_mime(p)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#337)
+/// trait-ready: unique decoder function (d#339)
 #[derive(Debug, Clone)]
 pub struct mpeg4_infe_atom_data_extra_fields_mime {
 content_type: Vec<u8>
@@ -1754,7 +1754,7 @@ Decoder_mpeg4_infe_atom_data_extra_fields_uri(p)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#338)
+/// trait-ready: unique decoder function (d#340)
 #[derive(Debug, Clone)]
 pub struct mpeg4_infe_atom_data_extra_fields_uri {
 item_uri_type: Vec<u8>
@@ -1771,7 +1771,7 @@ Decoder_mpeg4_infe_atom_data_extra_fields(p, item_type)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#336)
+/// trait-ready: unique decoder function (d#338)
 #[derive(Debug, Clone)]
 pub enum mpeg4_infe_atom_data_extra_fields { mime(mpeg4_infe_atom_data_extra_fields_mime), unknown, uri(mpeg4_infe_atom_data_extra_fields_uri) }
 
@@ -1786,7 +1786,7 @@ Decoder_mpeg4_infe_data_fields_version_gte2(p, version)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#335)
+/// trait-ready: unique decoder function (d#337)
 #[derive(Debug, Clone)]
 pub struct mpeg4_infe_data_fields_version_gte2 {
 item_ID: u32,
@@ -1807,7 +1807,7 @@ Decoder_mpeg4_infe_data_fields(p, version)
 }
 
 /// expected size: 88
-/// trait-ready: unique decoder function (d#333)
+/// trait-ready: unique decoder function (d#335)
 #[derive(Debug, Clone)]
 pub enum mpeg4_infe_data_fields { Version1(mpeg4_infe_data_fields_version_lt2), Version2(mpeg4_infe_data_fields_version_gte2) }
 
@@ -1822,7 +1822,7 @@ Decoder_mpeg4_iinf_atom_data_infe(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#332)
+/// trait-ready: unique decoder function (d#334)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iinf_atom_data_infe {
 version: u8,
@@ -1846,7 +1846,7 @@ Decoder_mpeg4_iinf_atom(p)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#331)
+/// trait-ready: unique decoder function (d#333)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iinf_atom {
 size_field: u32,
@@ -1866,7 +1866,7 @@ Decoder_mpeg4_iinf(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#322)
+/// trait-ready: unique decoder function (d#324)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iinf {
 version: u8,
@@ -1887,7 +1887,7 @@ Decoder_mpeg4_iloc_extent(p, offset_size, length_size, index_size)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#328)
+/// trait-ready: unique decoder function (d#330)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_iloc_extent {
 extent_index: u64,
@@ -1918,7 +1918,7 @@ Decoder_mpeg4_iloc_atom_data(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#324)
+/// trait-ready: unique decoder function (d#326)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iloc_atom_data {
 version: u8,
@@ -1942,7 +1942,7 @@ Decoder_mpeg4_tool_atom_data_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#327)
+/// trait-ready: unique decoder function (d#329)
 #[derive(Debug, Clone)]
 pub struct mpeg4_tool_atom_data_data {
 type_indicator: u32,
@@ -1966,7 +1966,7 @@ Decoder_mpeg4_tool_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#326)
+/// trait-ready: unique decoder function (d#328)
 #[derive(Debug, Clone)]
 pub struct mpeg4_tool_atom {
 size_field: u32,
@@ -1991,7 +1991,7 @@ Decoder_mpeg4_ilst_atom(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#325)
+/// trait-ready: unique decoder function (d#327)
 #[derive(Debug, Clone)]
 pub struct mpeg4_ilst_atom {
 size_field: u32,
@@ -2020,7 +2020,7 @@ Decoder_mpeg4_iref_data_single_item_reference_large(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#330)
+/// trait-ready: unique decoder function (d#332)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iref_data_single_item_reference_large {
 size_field: u32,
@@ -2049,7 +2049,7 @@ Decoder_mpeg4_iref_data_single_item_reference_small(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#329)
+/// trait-ready: unique decoder function (d#331)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iref_data_single_item_reference_small {
 size_field: u32,
@@ -2074,7 +2074,7 @@ Decoder_mpeg4_iref_data(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#323)
+/// trait-ready: unique decoder function (d#325)
 #[derive(Debug, Clone)]
 pub struct mpeg4_iref_data {
 version: u8,
@@ -2098,7 +2098,7 @@ Decoder_mpeg4_pitm_atom_data(p)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#321)
+/// trait-ready: unique decoder function (d#323)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_pitm_atom_data {
 version: u8,
@@ -2117,7 +2117,7 @@ Decoder_mpeg4_meta_atom_data(p, r#type)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#319)
+/// trait-ready: unique decoder function (d#321)
 #[derive(Debug, Clone)]
 pub enum mpeg4_meta_atom_data { dinf(Vec<mpeg4_dinf_atom>), hdlr(mpeg4_meta_hdlr_data), idat(Vec<u8>), iinf(mpeg4_iinf), iloc(mpeg4_iloc_atom_data), ilst(Vec<mpeg4_ilst_atom>), iref(mpeg4_iref_data), pitm(mpeg4_pitm_atom_data), unknown(Vec<u8>) }
 
@@ -2132,7 +2132,7 @@ Decoder_mpeg4_meta_atom(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#286)
+/// trait-ready: unique decoder function (d#288)
 #[derive(Debug, Clone)]
 pub struct mpeg4_meta_atom {
 size_field: u32,
@@ -2177,7 +2177,7 @@ Decoder_mpeg4_mvhd_data(p)
 }
 
 /// expected size: 112
-/// trait-ready: unique decoder function (d#288)
+/// trait-ready: unique decoder function (d#290)
 #[derive(Debug, Clone)]
 pub struct mpeg4_mvhd_data {
 version: u8,
@@ -2203,7 +2203,7 @@ Decoder_mpeg4_elst_data_entry(p)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#318)
+/// trait-ready: unique decoder function (d#320)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_elst_data_entry {
 track_duration: u32,
@@ -2222,7 +2222,7 @@ Decoder_mpeg4_elst_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#317)
+/// trait-ready: unique decoder function (d#319)
 #[derive(Debug, Clone)]
 pub struct mpeg4_elst_data {
 version: u8,
@@ -2247,7 +2247,7 @@ Decoder_mpeg4_edts_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#292)
+/// trait-ready: unique decoder function (d#294)
 #[derive(Debug, Clone)]
 pub struct mpeg4_edts_atom {
 size_field: u32,
@@ -2267,7 +2267,7 @@ Decoder_mpeg4_mdia_hdlr_data(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#295)
+/// trait-ready: unique decoder function (d#297)
 #[derive(Debug, Clone)]
 pub struct mpeg4_mdia_hdlr_data {
 version: u8,
@@ -2291,7 +2291,7 @@ Decoder_mpeg4_mdhd_data(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#296)
+/// trait-ready: unique decoder function (d#298)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_mdhd_data {
 version: u8,
@@ -2312,7 +2312,7 @@ Decoder_mpeg4_smhd_data(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#299)
+/// trait-ready: unique decoder function (d#301)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_smhd_data {
 version: u8,
@@ -2332,7 +2332,7 @@ Decoder_mpeg4_co64_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#309)
+/// trait-ready: unique decoder function (d#311)
 #[derive(Debug, Clone)]
 pub struct mpeg4_co64_data {
 version: u8,
@@ -2352,7 +2352,7 @@ Decoder_mpeg4_ctts_sample_entry(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#312)
+/// trait-ready: unique decoder function (d#314)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_ctts_sample_entry {
 sample_count: u32,
@@ -2370,7 +2370,7 @@ Decoder_mpeg4_ctts_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#304)
+/// trait-ready: unique decoder function (d#306)
 #[derive(Debug, Clone)]
 pub struct mpeg4_ctts_data {
 version: u8,
@@ -2398,7 +2398,7 @@ Decoder_mpeg4_sbgp_data(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#311)
+/// trait-ready: unique decoder function (d#313)
 #[derive(Debug, Clone)]
 pub struct mpeg4_sbgp_data {
 version: u8,
@@ -2428,7 +2428,7 @@ Decoder_mpeg4_sgpd_data(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#310)
+/// trait-ready: unique decoder function (d#312)
 #[derive(Debug, Clone)]
 pub struct mpeg4_sgpd_data {
 version: u8,
@@ -2450,7 +2450,7 @@ Decoder_mpeg4_stco_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#308)
+/// trait-ready: unique decoder function (d#310)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stco_data {
 version: u8,
@@ -2479,7 +2479,7 @@ Decoder_mpeg4_stsc_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#306)
+/// trait-ready: unique decoder function (d#308)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stsc_data {
 version: u8,
@@ -2499,7 +2499,7 @@ Decoder_mpeg4_stsd_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#302)
+/// trait-ready: unique decoder function (d#304)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stsd_data {
 version: u8,
@@ -2519,7 +2519,7 @@ Decoder_mpeg4_stss_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#305)
+/// trait-ready: unique decoder function (d#307)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stss_data {
 version: u8,
@@ -2539,7 +2539,7 @@ Decoder_mpeg4_stsz_data(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#307)
+/// trait-ready: unique decoder function (d#309)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stsz_data {
 version: u8,
@@ -2560,7 +2560,7 @@ Decoder_mpeg4_stts_sample_entry(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#313)
+/// trait-ready: unique decoder function (d#315)
 #[derive(Debug, Copy, Clone)]
 pub struct mpeg4_stts_sample_entry {
 sample_count: u32,
@@ -2578,7 +2578,7 @@ Decoder_mpeg4_stts_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#303)
+/// trait-ready: unique decoder function (d#305)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stts_data {
 version: u8,
@@ -2603,7 +2603,7 @@ Decoder_mpeg4_stbl_atom(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#301)
+/// trait-ready: unique decoder function (d#303)
 #[derive(Debug, Clone)]
 pub struct mpeg4_stbl_atom {
 size_field: u32,
@@ -2623,7 +2623,7 @@ Decoder_mpeg4_vmhd_data(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#298)
+/// trait-ready: unique decoder function (d#300)
 #[derive(Debug, Clone)]
 pub struct mpeg4_vmhd_data {
 version: u8,
@@ -2648,7 +2648,7 @@ Decoder_mpeg4_minf_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#297)
+/// trait-ready: unique decoder function (d#299)
 #[derive(Debug, Clone)]
 pub struct mpeg4_minf_atom {
 size_field: u32,
@@ -2668,7 +2668,7 @@ Decoder_mpeg4_mdia_atom_data(p, r#type)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#294)
+/// trait-ready: unique decoder function (d#296)
 #[derive(Debug, Clone)]
 pub enum mpeg4_mdia_atom_data { hdlr(mpeg4_mdia_hdlr_data), mdhd(mpeg4_mdhd_data), minf(Vec<mpeg4_minf_atom>), unknown(Vec<u8>) }
 
@@ -2683,7 +2683,7 @@ Decoder_mpeg4_mdia_atom(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#293)
+/// trait-ready: unique decoder function (d#295)
 #[derive(Debug, Clone)]
 pub struct mpeg4_mdia_atom {
 size_field: u32,
@@ -2730,7 +2730,7 @@ Decoder_mpeg4_tkhd_data(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#291)
+/// trait-ready: unique decoder function (d#293)
 #[derive(Debug, Clone)]
 pub struct mpeg4_tkhd_data {
 version: u8,
@@ -2762,7 +2762,7 @@ Decoder_mpeg4_trak_atom(p)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#289)
+/// trait-ready: unique decoder function (d#291)
 #[derive(Debug, Clone)]
 pub struct mpeg4_trak_atom {
 size_field: u32,
@@ -2787,7 +2787,7 @@ Decoder_mpeg4_udta_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#290)
+/// trait-ready: unique decoder function (d#292)
 #[derive(Debug, Clone)]
 pub struct mpeg4_udta_atom {
 size_field: u32,
@@ -2812,7 +2812,7 @@ Decoder_mpeg4_moov_atom(p)
 }
 
 /// expected size: 136
-/// trait-ready: unique decoder function (d#287)
+/// trait-ready: unique decoder function (d#289)
 #[derive(Debug, Clone)]
 pub struct mpeg4_moov_atom {
 size_field: u32,
@@ -2837,7 +2837,7 @@ Decoder_mpeg4_atom(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#283)
+/// trait-ready: unique decoder function (d#285)
 #[derive(Debug, Clone)]
 pub struct mpeg4_atom {
 size_field: u32,
@@ -2863,6 +2863,38 @@ pub struct mpeg4_main {
 atoms: Vec<mpeg4_atom>
 }
 
+impl CommonObject for numbers_num_value {
+type Args<'x> = ();
+
+type Output<'x> = numbers_num_value;
+
+fn parse<'input>(p: &mut Parser<'input>, _: ()) -> Result<Self::Output<'input>, ParseError> {
+Decoder_numbers_num_value(p)
+}
+}
+
+/// expected size: 16
+/// trait-ready: unique decoder function (d#26)
+#[derive(Debug, Copy, Clone)]
+pub enum numbers_num_value { I16BEValue(i16), I32BEValue(i32), I64BEValue(i64), I8Value(i8), U16BEValue(u16), U32BEValue(u32), U64BEValue(u64), U8Value(u8) }
+
+impl CommonObject for numbers_main {
+type Args<'x> = ();
+
+type Output<'x> = numbers_main;
+
+fn parse<'input>(p: &mut Parser<'input>, _: ()) -> Result<Self::Output<'input>, ParseError> {
+Decoder_numbers_main(p)
+}
+}
+
+/// expected size: 24
+/// trait-ready: unique decoder function (d#15)
+#[derive(Debug, Clone)]
+pub struct numbers_main {
+values: Vec<numbers_num_value>
+}
+
 impl CommonObject for opentype_table_record {
 type Args<'x> = ();
 
@@ -2874,7 +2906,7 @@ Decoder_opentype_table_record(p)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#27)
+/// trait-ready: unique decoder function (d#29)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_table_record {
 table_id: u32,
@@ -2894,7 +2926,7 @@ Decoder_opentype_cmap_subtable_format0(p, _platform)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#182)
+/// trait-ready: unique decoder function (d#184)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format0 {
 format: u16,
@@ -2914,7 +2946,7 @@ Decoder_opentype_cmap_subtable_format10(p, _platform)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#187)
+/// trait-ready: unique decoder function (d#189)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format10 {
 format: u16,
@@ -2936,7 +2968,7 @@ Decoder_opentype_types_sequential_map_record(p)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#192)
+/// trait-ready: unique decoder function (d#194)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_types_sequential_map_record {
 start_char_code: u32,
@@ -2945,7 +2977,7 @@ start_glyph_id: u32
 }
 
 /// expected size: 40
-/// trait-unready: multiple (2) decoders exist (d#{188, 189})
+/// trait-unready: multiple (2) decoders exist (d#{190, 191})
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format12 {
 format: u16,
@@ -3014,7 +3046,7 @@ Decoder_opentype_variation_selector(p, table_view)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#191)
+/// trait-ready: unique decoder function (d#193)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_variation_selector {
 var_selector: u32,
@@ -3033,7 +3065,7 @@ Decoder_opentype_cmap_subtable_format14(p, table_view)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#190)
+/// trait-ready: unique decoder function (d#192)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format14 {
 format: u16,
@@ -3048,7 +3080,7 @@ var_selector: Vec<opentype_variation_selector>
 pub struct opentype_cmap_subtable_format2_sub_headers {
 first_code: u16,
 entry_count: u16,
-id_delta: u16,
+id_delta: i16,
 id_range_offset: u16
 }
 
@@ -3063,7 +3095,7 @@ Decoder_opentype_cmap_subtable_format2(p, _platform)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#183)
+/// trait-ready: unique decoder function (d#185)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format2 {
 format: u16,
@@ -3085,7 +3117,7 @@ Decoder_opentype_cmap_subtable_format4(p, _platform)
 }
 
 /// expected size: 136
-/// trait-ready: unique decoder function (d#184)
+/// trait-ready: unique decoder function (d#186)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format4 {
 format: u16,
@@ -3113,7 +3145,7 @@ Decoder_opentype_cmap_subtable_format6(p, _platform)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#185)
+/// trait-ready: unique decoder function (d#187)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format6 {
 format: u16,
@@ -3135,7 +3167,7 @@ Decoder_opentype_cmap_subtable_format8(p, _platform)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#186)
+/// trait-ready: unique decoder function (d#188)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable_format8 {
 format: u16,
@@ -3162,7 +3194,7 @@ Decoder_opentype_cmap_subtable(p, _platform)
 }
 
 /// expected size: 176
-/// trait-ready: unique decoder function (d#181)
+/// trait-ready: unique decoder function (d#183)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_subtable<'input> {
 table_scope: View<'input>,
@@ -3189,7 +3221,7 @@ Decoder_opentype_encoding_record(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#180)
+/// trait-ready: unique decoder function (d#182)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_encoding_record<'input> {
 platform: u16,
@@ -3208,7 +3240,7 @@ Decoder_opentype_cmap_table(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#29)
+/// trait-ready: unique decoder function (d#31)
 #[derive(Debug, Clone)]
 pub struct opentype_cmap_table<'input> {
 table_scope: View<'input>,
@@ -3226,10 +3258,10 @@ pub enum opentype_head_table_font_revision { Fixed32(u32) }
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_head_table_glyph_extents {
-x_min: u16,
-y_min: u16,
-x_max: u16,
-y_max: u16
+x_min: i16,
+y_min: i16,
+x_max: i16,
+y_max: i16
 }
 
 /// expected size: 7
@@ -3256,7 +3288,7 @@ Decoder_opentype_head_table(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#30)
+/// trait-ready: unique decoder function (d#32)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_head_table {
 major_version: u16,
@@ -3266,8 +3298,8 @@ checksum_adjustment: u32,
 magic_number: (u8, u8, u8, u8),
 flags: u16,
 units_per_em: u16,
-created: u64,
-modified: u64,
+created: i64,
+modified: i64,
 glyph_extents: opentype_head_table_glyph_extents,
 mac_style: opentype_head_table_mac_style,
 lowest_rec_ppem: u16,
@@ -3280,25 +3312,25 @@ glyph_data_format: u16
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_hhea_table_caret_slope {
-rise: u16,
-run: u16
+rise: i16,
+run: i16
 }
 
 /// expected size: 28
-/// trait-unready: multiple (2) decoders exist (d#{31, 48})
+/// trait-unready: multiple (2) decoders exist (d#{33, 50})
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_hhea_table {
 major_version: u16,
 minor_version: u16,
-ascent: u16,
-descent: u16,
-line_gap: u16,
+ascent: i16,
+descent: i16,
+line_gap: i16,
 advance_width_max: u16,
-min_left_side_bearing: u16,
-min_right_side_bearing: u16,
-x_max_extent: u16,
+min_left_side_bearing: i16,
+min_right_side_bearing: i16,
+x_max_extent: i16,
 caret_slope: opentype_hhea_table_caret_slope,
-caret_offset: u16,
+caret_offset: i16,
 metric_data_format: u16,
 number_of_long_metrics: u16
 }
@@ -3314,7 +3346,7 @@ Decoder_opentype_maxp_version1(p)
 }
 
 /// expected size: 26
-/// trait-ready: unique decoder function (d#178)
+/// trait-ready: unique decoder function (d#180)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_maxp_version1 {
 max_points: u16,
@@ -3348,7 +3380,7 @@ Decoder_opentype_maxp_table(p)
 }
 
 /// expected size: 36
-/// trait-ready: unique decoder function (d#32)
+/// trait-ready: unique decoder function (d#34)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_maxp_table {
 version: u32,
@@ -3361,15 +3393,15 @@ data: opentype_maxp_table_data
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_hmtx_table_long_metrics {
 advance_width: u16,
-left_side_bearing: u16
+left_side_bearing: i16
 }
 
 /// expected size: 48
-/// trait-unready: multiple (2) decoders exist (d#{33, 49})
+/// trait-unready: multiple (2) decoders exist (d#{35, 51})
 #[derive(Debug, Clone)]
 pub struct opentype_hmtx_table {
 long_metrics: Vec<opentype_hmtx_table_long_metrics>,
-left_side_bearings: Vec<u16>
+left_side_bearings: Vec<i16>
 }
 
 /// expected size: 16
@@ -3391,7 +3423,7 @@ Decoder_opentype_name_name_record(p, storage_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#175)
+/// trait-ready: unique decoder function (d#177)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_name_name_record<'input> {
 platform: u16,
@@ -3413,7 +3445,7 @@ Decoder_opentype_name_lang_tag_record(p, storage_view)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#177)
+/// trait-ready: unique decoder function (d#179)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_name_lang_tag_record<'input> {
 length: u16,
@@ -3431,7 +3463,7 @@ Decoder_opentype_name_name_version_1(p, storage_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#176)
+/// trait-ready: unique decoder function (d#178)
 #[derive(Debug, Clone)]
 pub struct opentype_name_name_version_1<'input> {
 lang_tag_count: u16,
@@ -3454,7 +3486,7 @@ Decoder_opentype_name_table(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#34)
+/// trait-ready: unique decoder function (d#36)
 #[derive(Debug, Clone)]
 pub struct opentype_name_table<'input> {
 table_scope: View<'input>,
@@ -3477,8 +3509,8 @@ us_upper_optical_point_size: u16
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_os2_table_data_extra_fields_v1_extra_fields_v2 {
-sx_height: u16,
-s_cap_height: u16,
+sx_height: i16,
+s_cap_height: i16,
 us_default_char: u16,
 us_break_char: u16,
 us_max_context: u16,
@@ -3498,9 +3530,9 @@ extra_fields_v2: Option<opentype_os2_table_data_extra_fields_v1_extra_fields_v2>
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_os2_table_data {
-s_typo_ascender: u16,
-s_typo_descender: u16,
-s_typo_line_gap: u16,
+s_typo_ascender: i16,
+s_typo_descender: i16,
+s_typo_line_gap: i16,
 us_win_ascent: u16,
 us_win_descent: u16,
 extra_fields_v1: Option<opentype_os2_table_data_extra_fields_v1>
@@ -3517,25 +3549,25 @@ Decoder_opentype_os2_table(p, table_length)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#35)
+/// trait-ready: unique decoder function (d#37)
 #[derive(Debug, Clone)]
 pub struct opentype_os2_table {
 version: u16,
-x_avg_char_width: u16,
+x_avg_char_width: i16,
 us_weight_class: u16,
 us_width_class: u16,
 fs_type: u16,
-y_subscript_x_size: u16,
-y_subscript_y_size: u16,
-y_subscript_x_offset: u16,
-y_subscript_y_offset: u16,
-y_superscript_x_size: u16,
-y_superscript_y_size: u16,
-y_superscript_x_offset: u16,
-y_superscript_y_offset: u16,
-y_strikeout_size: u16,
-y_strikeout_position: u16,
-s_family_class: u16,
+y_subscript_x_size: i16,
+y_subscript_y_size: i16,
+y_subscript_x_offset: i16,
+y_subscript_y_offset: i16,
+y_superscript_x_size: i16,
+y_superscript_y_size: i16,
+y_superscript_x_offset: i16,
+y_superscript_y_offset: i16,
+y_strikeout_size: i16,
+y_strikeout_position: i16,
+s_family_class: i16,
 panose: Vec<u8>,
 ul_unicode_range1: u32,
 ul_unicode_range2: u32,
@@ -3559,7 +3591,7 @@ Decoder_opentype_post_pascal_string(p)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#174)
+/// trait-ready: unique decoder function (d#176)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_post_pascal_string<'input> {
 length: u8,
@@ -3577,7 +3609,7 @@ Decoder_opentype_post_version2(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#173)
+/// trait-ready: unique decoder function (d#175)
 #[derive(Debug, Clone)]
 pub struct opentype_post_version2<'input> {
 num_glyphs: u16,
@@ -3590,7 +3622,7 @@ string_data: Vec<opentype_post_pascal_string<'input>>
 #[derive(Debug, Clone)]
 pub struct opentype_post_table_names_Version2Dot5 {
 num_glyphs: u16,
-offset: Vec<u8>
+offset: Vec<i8>
 }
 
 /// expected size: 64
@@ -3609,13 +3641,13 @@ Decoder_opentype_post_table(p)
 }
 
 /// expected size: 104
-/// trait-ready: unique decoder function (d#36)
+/// trait-ready: unique decoder function (d#38)
 #[derive(Debug, Clone)]
 pub struct opentype_post_table<'input> {
 version: u32,
 italic_angle: opentype_head_table_font_revision,
-underline_position: u16,
-underline_thickness: u16,
+underline_position: i16,
+underline_thickness: i16,
 is_fixed_pitch: u32,
 min_mem_type42: u32,
 max_mem_type42: u32,
@@ -3641,7 +3673,7 @@ Decoder_opentype_loca_table(p, num_glyphs, index_to_loc_format)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#37)
+/// trait-ready: unique decoder function (d#39)
 #[derive(Debug, Clone)]
 pub struct opentype_loca_table {
 offsets: opentype_loca_table_offsets
@@ -3668,7 +3700,7 @@ arg_1_and_2_are_words: bool
 /// expected size: 4
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
-pub enum opentype_glyf_composite_acc_glyphs_argument1 { Int16(u16), Int8(u8), Uint16(u16), Uint8(u8) }
+pub enum opentype_glyf_composite_acc_glyphs_argument1 { Int16(i16), Int8(i8), Uint16(u16), Uint8(u8) }
 
 /// expected size: 4
 /// trait-orphaned: no decoder functions provided
@@ -3710,7 +3742,7 @@ Decoder_opentype_glyf_composite(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#171)
+/// trait-ready: unique decoder function (d#173)
 #[derive(Debug, Clone)]
 pub struct opentype_glyf_composite {
 glyphs: Vec<opentype_glyf_composite_acc_glyphs>,
@@ -3740,7 +3772,7 @@ Decoder_opentype_glyf_simple(p, n_contours)
 }
 
 /// expected size: 128
-/// trait-ready: unique decoder function (d#170)
+/// trait-ready: unique decoder function (d#172)
 #[derive(Debug, Clone)]
 pub struct opentype_glyf_simple {
 end_points_of_contour: Vec<u16>,
@@ -3748,12 +3780,12 @@ instruction_length: u16,
 instructions: Vec<u8>,
 number_of_coordinates: u16,
 flags: Vec<opentype_glyf_simple_flags>,
-x_coordinates: Vec<u16>,
-y_coordinates: Vec<u16>
+x_coordinates: Vec<i16>,
+y_coordinates: Vec<i16>
 }
 
 impl CommonObject for opentype_glyf_description {
-type Args<'x> = u16;
+type Args<'x> = i16;
 
 type Output<'x> = opentype_glyf_description;
 
@@ -3764,7 +3796,7 @@ Decoder_opentype_glyf_description(p, n_contours)
 
 /// expected size: 136
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InEnum { variants: [Noop, Noop, DirectHeap] }, Layout { size: 48, align: 8 (1 << 3) })
-/// trait-ready: unique decoder function (d#169)
+/// trait-ready: unique decoder function (d#171)
 #[derive(Debug, Clone)]
 pub enum opentype_glyf_description { Composite(opentype_glyf_composite), HeaderOnly, Simple(opentype_glyf_simple) }
 
@@ -3780,14 +3812,14 @@ Decoder_opentype_glyf_entry(p)
 
 /// expected size: 152
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [Noop, Noop, Noop, Noop, Noop, InDef(InEnum { variants: [Noop, Noop, DirectHeap] })] }, Layout { size: 64, align: 8 (1 << 3) })
-/// trait-ready: unique decoder function (d#168)
+/// trait-ready: unique decoder function (d#170)
 #[derive(Debug, Clone)]
 pub struct opentype_glyf_entry {
-number_of_contours: u16,
-x_min: u16,
-y_min: u16,
-x_max: u16,
-y_max: u16,
+number_of_contours: i16,
+x_min: i16,
+y_min: i16,
+x_max: i16,
+y_max: i16,
 description: opentype_glyf_description
 }
 
@@ -3815,7 +3847,7 @@ Decoder_opentype_glyf_table(p, offsets)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#38)
+/// trait-ready: unique decoder function (d#40)
 #[derive(Debug, Clone)]
 pub struct opentype_glyf_table<'input> {
 table_scope: View<'input>,
@@ -3864,7 +3896,7 @@ Decoder_opentype_gasp_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#39)
+/// trait-ready: unique decoder function (d#41)
 #[derive(Debug, Clone)]
 pub struct opentype_gasp_table {
 version: u16,
@@ -3927,7 +3959,7 @@ Decoder_opentype_common_device_or_variation_index_table(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#128)
+/// trait-ready: unique decoder function (d#130)
 #[derive(Debug, Clone)]
 pub enum opentype_common_device_or_variation_index_table { DeviceTable(opentype_common_device_or_variation_index_table_DeviceTable), OtherTable(opentype_common_device_or_variation_index_table_OtherTable), VariationIndexTable(opentype_common_device_or_variation_index_table_VariationIndexTable) }
 
@@ -3970,12 +4002,12 @@ Decoder_opentype_layout_base_coord(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#166)
+/// trait-ready: unique decoder function (d#168)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_base_coord<'input> {
 table_scope: View<'input>,
 format: u16,
-coordinate: u16,
+coordinate: i16,
 data: opentype_layout_base_coord_data
 }
 
@@ -3998,7 +4030,7 @@ Decoder_opentype_layout_base_values(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#163)
+/// trait-ready: unique decoder function (d#165)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_base_values<'input> {
 table_scope: View<'input>,
@@ -4026,7 +4058,7 @@ Decoder_opentype_layout_feat_min_max(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#167)
+/// trait-ready: unique decoder function (d#169)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_feat_min_max<'input> {
 feature_tag: u32,
@@ -4045,7 +4077,7 @@ Decoder_opentype_layout_min_max(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#164)
+/// trait-ready: unique decoder function (d#166)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_min_max<'input> {
 table_scope: View<'input>,
@@ -4074,7 +4106,7 @@ Decoder_opentype_base_base_langsys(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#165)
+/// trait-ready: unique decoder function (d#167)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_base_base_langsys<'input> {
 base_lang_sys_tag: u32,
@@ -4092,7 +4124,7 @@ Decoder_opentype_layout_base_script(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#162)
+/// trait-ready: unique decoder function (d#164)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_base_script<'input> {
 table_scope: View<'input>,
@@ -4121,7 +4153,7 @@ Decoder_opentype_base_base_script_record(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#161)
+/// trait-ready: unique decoder function (d#163)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_base_base_script_record<'input> {
 base_script_tag: u32,
@@ -4156,7 +4188,7 @@ Decoder_opentype_layout_axis_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#160)
+/// trait-ready: unique decoder function (d#162)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_axis_table<'input> {
 table_scope: View<'input>,
@@ -4199,7 +4231,7 @@ Decoder_opentype_common_variation_region_list(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#154)
+/// trait-ready: unique decoder function (d#156)
 #[derive(Debug, Clone)]
 pub struct opentype_common_variation_region_list {
 axis_count: u16,
@@ -4227,16 +4259,16 @@ word_count: u16
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
 pub struct opentype_common_item_variation_data_delta_sets_Delta16Sets {
-delta_data_full_word: Vec<u16>,
-delta_data_half_word: Vec<u8>
+delta_data_full_word: Vec<i16>,
+delta_data_half_word: Vec<i8>
 }
 
 /// expected size: 48
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
 pub struct opentype_common_item_variation_data_delta_sets_Delta32Sets {
-delta_data_full_word: Vec<u32>,
-delta_data_half_word: Vec<u16>
+delta_data_full_word: Vec<i32>,
+delta_data_half_word: Vec<i16>
 }
 
 /// expected size: 32
@@ -4255,7 +4287,7 @@ Decoder_opentype_common_item_variation_data(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#155)
+/// trait-ready: unique decoder function (d#157)
 #[derive(Debug, Clone)]
 pub struct opentype_common_item_variation_data {
 item_count: u16,
@@ -4284,7 +4316,7 @@ Decoder_opentype_common_item_variation_store(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#153)
+/// trait-ready: unique decoder function (d#155)
 #[derive(Debug, Clone)]
 pub struct opentype_common_item_variation_store<'input> {
 table_scope: View<'input>,
@@ -4313,7 +4345,7 @@ Decoder_opentype_base_table(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#40)
+/// trait-ready: unique decoder function (d#42)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_base_table<'input> {
 table_scope: View<'input>,
@@ -4366,7 +4398,7 @@ Decoder_opentype_class_def(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#93)
+/// trait-ready: unique decoder function (d#95)
 #[derive(Debug, Clone)]
 pub struct opentype_class_def {
 class_format: u16,
@@ -4422,7 +4454,7 @@ Decoder_opentype_coverage_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#88)
+/// trait-ready: unique decoder function (d#90)
 #[derive(Debug, Clone)]
 pub struct opentype_coverage_table {
 coverage_format: u16,
@@ -4448,7 +4480,7 @@ Decoder_opentype_gdef_attach_point(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#159)
+/// trait-ready: unique decoder function (d#161)
 #[derive(Debug, Clone)]
 pub struct opentype_gdef_attach_point {
 point_count: u16,
@@ -4474,7 +4506,7 @@ Decoder_opentype_gdef_attach_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#150)
+/// trait-ready: unique decoder function (d#152)
 #[derive(Debug, Clone)]
 pub struct opentype_gdef_attach_list<'input> {
 list_scope: View<'input>,
@@ -4495,7 +4527,7 @@ _data: std::marker::PhantomData<Option<opentype_gdef_attach_list<'input>>>
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gdef_caret_value_data_Format1 {
-coordinate: u16
+coordinate: i16
 }
 
 /// expected size: 2
@@ -4516,11 +4548,11 @@ Decoder_opentype_gdef_caret_value_data_format3(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#158)
+/// trait-ready: unique decoder function (d#160)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gdef_caret_value_data_format3<'input> {
 table_scope: View<'input>,
-coordinate: u16,
+coordinate: i16,
 table: opentype_gdef_caret_value_data_format3_table
 }
 
@@ -4540,7 +4572,7 @@ Decoder_opentype_gdef_caret_value(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#157)
+/// trait-ready: unique decoder function (d#159)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gdef_caret_value<'input> {
 format: u16,
@@ -4566,7 +4598,7 @@ Decoder_opentype_gdef_lig_glyph(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#156)
+/// trait-ready: unique decoder function (d#158)
 #[derive(Debug, Clone)]
 pub struct opentype_gdef_lig_glyph<'input> {
 table_scope: View<'input>,
@@ -4593,7 +4625,7 @@ Decoder_opentype_gdef_lig_caret_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#151)
+/// trait-ready: unique decoder function (d#153)
 #[derive(Debug, Clone)]
 pub struct opentype_gdef_lig_caret_list<'input> {
 list_scope: View<'input>,
@@ -4629,7 +4661,7 @@ Decoder_opentype_gdef_mark_glyph_set(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#152)
+/// trait-ready: unique decoder function (d#154)
 #[derive(Debug, Clone)]
 pub struct opentype_gdef_mark_glyph_set<'input> {
 table_scope: View<'input>,
@@ -4677,7 +4709,7 @@ Decoder_opentype_gdef_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#41)
+/// trait-ready: unique decoder function (d#43)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gdef_table<'input> {
 table_scope: View<'input>,
@@ -4701,7 +4733,7 @@ Decoder_opentype_layout_langsys(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#110)
+/// trait-ready: unique decoder function (d#112)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_langsys {
 lookup_order_offset: u16,
@@ -4729,7 +4761,7 @@ Decoder_opentype_layout_lang_sys_record(p, script_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#111)
+/// trait-ready: unique decoder function (d#113)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_lang_sys_record {
 lang_sys_tag: u32,
@@ -4747,7 +4779,7 @@ Decoder_opentype_layout_script_table(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#109)
+/// trait-ready: unique decoder function (d#111)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_script_table<'input> {
 script_scope: View<'input>,
@@ -4775,7 +4807,7 @@ Decoder_opentype_layout_script_record(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#108)
+/// trait-ready: unique decoder function (d#110)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_script_record<'input> {
 script_tag: u32,
@@ -4793,7 +4825,7 @@ Decoder_opentype_layout_script_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#69)
+/// trait-ready: unique decoder function (d#71)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_script_list<'input> {
 table_scope: View<'input>,
@@ -4820,7 +4852,7 @@ Decoder_opentype_layout_feature_table(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#76)
+/// trait-ready: unique decoder function (d#78)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_feature_table<'input> {
 table_scope: View<'input>,
@@ -4848,7 +4880,7 @@ Decoder_opentype_layout_feature_record(p, list_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#107)
+/// trait-ready: unique decoder function (d#109)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_feature_record<'input> {
 feature_tag: u32,
@@ -4866,7 +4898,7 @@ Decoder_opentype_layout_feature_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#70)
+/// trait-ready: unique decoder function (d#72)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_feature_list<'input> {
 list_scope: View<'input>,
@@ -4905,7 +4937,7 @@ Decoder_opentype_layout_sequence_lookup(p)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#92)
+/// trait-ready: unique decoder function (d#94)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_sequence_lookup {
 sequence_index: u16,
@@ -4923,7 +4955,7 @@ Decoder_opentype_layout_chained_sequence_rule(p)
 }
 
 /// expected size: 104
-/// trait-ready: unique decoder function (d#95)
+/// trait-ready: unique decoder function (d#97)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_rule {
 backtrack_glyph_count: u16,
@@ -4955,7 +4987,7 @@ Decoder_opentype_layout_chained_sequence_rule_set(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#94)
+/// trait-ready: unique decoder function (d#96)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_rule_set<'input> {
 table_scope: View<'input>,
@@ -4982,7 +5014,7 @@ Decoder_opentype_layout_chained_sequence_context_format1(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#89)
+/// trait-ready: unique decoder function (d#91)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_context_format1<'input> {
 coverage: opentype_gdef_attach_list_coverage,
@@ -5001,7 +5033,7 @@ Decoder_opentype_layout_chained_sequence_context_format2(p, table_view)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#90)
+/// trait-ready: unique decoder function (d#92)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_context_format2<'input> {
 coverage: opentype_gdef_attach_list_coverage,
@@ -5023,7 +5055,7 @@ Decoder_opentype_layout_chained_sequence_context_format3(p, table_view)
 }
 
 /// expected size: 104
-/// trait-ready: unique decoder function (d#91)
+/// trait-ready: unique decoder function (d#93)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_context_format3 {
 backtrack_glyph_count: u16,
@@ -5052,7 +5084,7 @@ Decoder_opentype_layout_chained_sequence_context(p)
 }
 
 /// expected size: 144
-/// trait-ready: unique decoder function (d#86)
+/// trait-ready: unique decoder function (d#88)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_chained_sequence_context<'input> {
 table_scope: View<'input>,
@@ -5064,16 +5096,16 @@ subst: opentype_layout_chained_sequence_context_subst<'input>
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_anchor_table_table_Format1 {
-x_coordinate: u16,
-y_coordinate: u16
+x_coordinate: i16,
+y_coordinate: i16
 }
 
 /// expected size: 6
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_anchor_table_table_Format2 {
-x_coordinate: u16,
-y_coordinate: u16,
+x_coordinate: i16,
+y_coordinate: i16,
 anchor_point: u16
 }
 
@@ -5088,12 +5120,12 @@ Decoder_opentype_layout_anchor_table_format3(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#127)
+/// trait-ready: unique decoder function (d#129)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_anchor_table_format3<'input> {
 table_scope: View<'input>,
-x_coordinate: u16,
-y_coordinate: u16,
+x_coordinate: i16,
+y_coordinate: i16,
 x_device: opentype_gdef_caret_value_data_format3_table,
 y_device: opentype_gdef_caret_value_data_format3_table
 }
@@ -5114,7 +5146,7 @@ Decoder_opentype_layout_anchor_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#126)
+/// trait-ready: unique decoder function (d#128)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_anchor_table<'input> {
 anchor_format: u16,
@@ -5140,7 +5172,7 @@ Decoder_opentype_layout_entry_exit_record(p, table_view)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#135)
+/// trait-ready: unique decoder function (d#137)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_entry_exit_record<'input> {
 entry_anchor: opentype_layout_entry_exit_record_entry_anchor<'input>,
@@ -5158,7 +5190,7 @@ Decoder_opentype_layout_cursive_pos(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#119)
+/// trait-ready: unique decoder function (d#121)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_cursive_pos<'input> {
 pos_format: u16,
@@ -5179,7 +5211,7 @@ Decoder_opentype_layout_mark_record(p, array_view)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#129)
+/// trait-ready: unique decoder function (d#131)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_mark_record<'input> {
 mark_class: u16,
@@ -5197,7 +5229,7 @@ Decoder_opentype_layout_mark_array(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#123)
+/// trait-ready: unique decoder function (d#125)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_mark_array<'input> {
 array_scope: View<'input>,
@@ -5225,7 +5257,7 @@ Decoder_opentype_layout_base_array_base_record(p, mark_class_count, _array_view)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#134)
+/// trait-ready: unique decoder function (d#136)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_base_array_base_record<'input> {
 base_anchor_offsets: Vec<u16>,
@@ -5243,7 +5275,7 @@ Decoder_opentype_layout_base_array(p, mark_class_count)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#133)
+/// trait-ready: unique decoder function (d#135)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_base_array<'input> {
 array_scope: View<'input>,
@@ -5270,7 +5302,7 @@ Decoder_opentype_layout_mark_base_pos(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#120)
+/// trait-ready: unique decoder function (d#122)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_mark_base_pos<'input> {
 format: u16,
@@ -5294,7 +5326,7 @@ Decoder_opentype_layout_ligature_attach_component_record(p, mark_class_count, ta
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#132)
+/// trait-ready: unique decoder function (d#134)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_ligature_attach_component_record<'input> {
 record_scope: View<'input>,
@@ -5313,7 +5345,7 @@ Decoder_opentype_layout_ligature_attach(p, mark_class_count)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#131)
+/// trait-ready: unique decoder function (d#133)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_ligature_attach<'input> {
 component_count: u16,
@@ -5331,7 +5363,7 @@ Decoder_opentype_layout_ligature_array(p, mark_class_count)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#130)
+/// trait-ready: unique decoder function (d#132)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_ligature_array<'input> {
 array_scope: View<'input>,
@@ -5360,7 +5392,7 @@ Decoder_opentype_layout_mark_lig_pos(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#121)
+/// trait-ready: unique decoder function (d#123)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_mark_lig_pos<'input> {
 table_scope: View<'input>,
@@ -5384,7 +5416,7 @@ Decoder_opentype_layout_mark2_array_mark2_record(p, mark_class_count, _array_vie
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#125)
+/// trait-ready: unique decoder function (d#127)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_mark2_array_mark2_record<'input> {
 mark2_anchor_offsets: Vec<u16>,
@@ -5402,7 +5434,7 @@ Decoder_opentype_layout_mark2_array(p, mark_class_count)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#124)
+/// trait-ready: unique decoder function (d#126)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_mark2_array<'input> {
 array_scope: View<'input>,
@@ -5429,7 +5461,7 @@ Decoder_opentype_layout_mark_mark_pos(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#122)
+/// trait-ready: unique decoder function (d#124)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_mark_mark_pos<'input> {
 format: u16,
@@ -5452,7 +5484,7 @@ Decoder_opentype_layout_value_format_flags(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#138)
+/// trait-ready: unique decoder function (d#140)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_value_format_flags {
 y_advance_device: bool,
@@ -5466,13 +5498,13 @@ x_placement: bool
 }
 
 /// expected size: 32
-/// trait-unready: multiple (6) decoders exist (d#{140, 141, 144, 145, 148, 149})
+/// trait-unready: multiple (6) decoders exist (d#{142, 143, 146, 147, 150, 151})
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_value_record {
-x_placement: Option<u16>,
-y_placement: Option<u16>,
-x_advance: Option<u16>,
-y_advance: Option<u16>,
+x_placement: Option<i16>,
+y_placement: Option<i16>,
+x_advance: Option<i16>,
+y_advance: Option<i16>,
 x_placement_device: Option<opentype_gdef_caret_value_data_format3_table>,
 y_placement_device: Option<opentype_gdef_caret_value_data_format3_table>,
 x_advance_device: Option<opentype_gdef_caret_value_data_format3_table>,
@@ -5491,7 +5523,7 @@ Decoder_opentype_layout_pair_pos_pair_value_record(p, value_format1, value_forma
 }
 
 /// expected size: 66
-/// trait-ready: unique decoder function (d#143)
+/// trait-ready: unique decoder function (d#145)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_pair_pos_pair_value_record {
 second_glyph: u16,
@@ -5511,7 +5543,7 @@ Decoder_opentype_layout_pair_pos_pair_set(p, value_format1, value_format2)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#142)
+/// trait-ready: unique decoder function (d#144)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_pair_pos_pair_set<'input> {
 set_scope: View<'input>,
@@ -5538,7 +5570,7 @@ Decoder_opentype_layout_pair_pos_format1(p, table_view)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#136)
+/// trait-ready: unique decoder function (d#138)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_pair_pos_format1<'input> {
 table_scope: View<'input>,
@@ -5561,7 +5593,7 @@ Decoder_opentype_layout_pair_pos_class2_record(p, value_format1, value_format2, 
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#139)
+/// trait-ready: unique decoder function (d#141)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_pair_pos_class2_record {
 value_record1: Option<opentype_layout_value_record>,
@@ -5586,7 +5618,7 @@ Decoder_opentype_layout_pair_pos_format2(p, table_view)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#137)
+/// trait-ready: unique decoder function (d#139)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_pair_pos_format2<'input> {
 table_scope: View<'input>,
@@ -5616,7 +5648,7 @@ Decoder_opentype_layout_pair_pos(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#118)
+/// trait-ready: unique decoder function (d#120)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_pair_pos<'input> {
 pos_format: u16,
@@ -5634,7 +5666,7 @@ Decoder_opentype_layout_sequence_context_rule(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#100)
+/// trait-ready: unique decoder function (d#102)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context_rule {
 glyph_count: u16,
@@ -5662,7 +5694,7 @@ Decoder_opentype_layout_sequence_context_rule_set(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#99)
+/// trait-ready: unique decoder function (d#101)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context_rule_set<'input> {
 table_scope: View<'input>,
@@ -5689,7 +5721,7 @@ Decoder_opentype_layout_sequence_context_format1(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#96)
+/// trait-ready: unique decoder function (d#98)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context_format1<'input> {
 coverage: opentype_gdef_attach_list_coverage,
@@ -5708,7 +5740,7 @@ Decoder_opentype_layout_sequence_context_format2(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#97)
+/// trait-ready: unique decoder function (d#99)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context_format2<'input> {
 coverage: opentype_gdef_attach_list_coverage,
@@ -5728,7 +5760,7 @@ Decoder_opentype_layout_sequence_context_format3(p, table_view)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#98)
+/// trait-ready: unique decoder function (d#100)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context_format3 {
 glyph_count: u16,
@@ -5753,7 +5785,7 @@ Decoder_opentype_layout_sequence_context(p)
 }
 
 /// expected size: 96
-/// trait-ready: unique decoder function (d#85)
+/// trait-ready: unique decoder function (d#87)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_sequence_context<'input> {
 table_scope: View<'input>,
@@ -5772,7 +5804,7 @@ Decoder_opentype_layout_single_pos_format1(p, table_view)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#146)
+/// trait-ready: unique decoder function (d#148)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_single_pos_format1<'input> {
 table_scope: View<'input>,
@@ -5792,7 +5824,7 @@ Decoder_opentype_layout_single_pos_format2(p, table_view)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#147)
+/// trait-ready: unique decoder function (d#149)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_single_pos_format2<'input> {
 table_scope: View<'input>,
@@ -5818,7 +5850,7 @@ Decoder_opentype_layout_single_pos(p)
 }
 
 /// expected size: 88
-/// trait-ready: unique decoder function (d#117)
+/// trait-ready: unique decoder function (d#119)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_single_pos<'input> {
 pos_format: u16,
@@ -5836,7 +5868,7 @@ Decoder_opentype_layout_ground_pos(p, lookup_type)
 }
 
 /// expected size: 152
-/// trait-ready: unique decoder function (d#116)
+/// trait-ready: unique decoder function (d#118)
 #[derive(Debug, Clone)]
 pub enum opentype_layout_ground_pos<'input> { ChainedSequenceContext(opentype_layout_chained_sequence_context<'input>), CursivePos(opentype_layout_cursive_pos<'input>), MarkBasePos(opentype_layout_mark_base_pos<'input>), MarkLigPos(opentype_layout_mark_lig_pos<'input>), MarkMarkPos(opentype_layout_mark_mark_pos<'input>), PairPos(opentype_layout_pair_pos<'input>), SequenceContext(opentype_layout_sequence_context<'input>), SinglePos(opentype_layout_single_pos<'input>) }
 
@@ -5859,7 +5891,7 @@ Decoder_opentype_layout_pos_extension(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#115)
+/// trait-ready: unique decoder function (d#117)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_pos_extension<'input> {
 format: u16,
@@ -5879,7 +5911,7 @@ Decoder_opentype_gpos_lookup_subtable(p, lookup_type)
 }
 
 /// expected size: 160
-/// trait-ready: unique decoder function (d#114)
+/// trait-ready: unique decoder function (d#116)
 #[derive(Debug, Clone)]
 pub enum opentype_gpos_lookup_subtable<'input> { GroundPos(opentype_layout_ground_pos<'input>), PosExtension(opentype_layout_pos_extension<'input>) }
 
@@ -5902,7 +5934,7 @@ Decoder_opentype_gpos_lookup_table(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#113)
+/// trait-ready: unique decoder function (d#115)
 #[derive(Debug, Clone)]
 pub struct opentype_gpos_lookup_table<'input> {
 table_scope: View<'input>,
@@ -5932,7 +5964,7 @@ Decoder_opentype_gpos_lookup_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#112)
+/// trait-ready: unique decoder function (d#114)
 #[derive(Debug, Clone)]
 pub struct opentype_gpos_lookup_list<'input> {
 list_scope: View<'input>,
@@ -5987,7 +6019,7 @@ Decoder_opentype_layout_feature_table_substitution_record(p, _table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#75)
+/// trait-ready: unique decoder function (d#77)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_feature_table_substitution_record<'input> {
 feature_index: u16,
@@ -6006,7 +6038,7 @@ Decoder_opentype_layout_feature_table_substitution(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#74)
+/// trait-ready: unique decoder function (d#76)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_feature_table_substitution<'input> {
 table_scope: View<'input>,
@@ -6035,7 +6067,7 @@ Decoder_opentype_layout_feature_variation_record(p, table_view)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#73)
+/// trait-ready: unique decoder function (d#75)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_feature_variation_record<'input> {
 condition_set: opentype_layout_feature_variation_record_condition_set<'input>,
@@ -6053,7 +6085,7 @@ Decoder_opentype_layout_feature_variations(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#72)
+/// trait-ready: unique decoder function (d#74)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_feature_variations<'input> {
 table_scope: View<'input>,
@@ -6082,7 +6114,7 @@ Decoder_opentype_gpos_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#42)
+/// trait-ready: unique decoder function (d#44)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gpos_table<'input> {
 table_scope: View<'input>,
@@ -6105,7 +6137,7 @@ Decoder_opentype_gsub_alternate_subst_alternate_set(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#103)
+/// trait-ready: unique decoder function (d#105)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_alternate_subst_alternate_set {
 glyph_count: u16,
@@ -6131,7 +6163,7 @@ Decoder_opentype_gsub_alternate_subst(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#83)
+/// trait-ready: unique decoder function (d#85)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_alternate_subst<'input> {
 table_scope: View<'input>,
@@ -6152,7 +6184,7 @@ Decoder_opentype_gsub_ligature_subst_ligature_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#102)
+/// trait-ready: unique decoder function (d#104)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_ligature_subst_ligature_table {
 ligature_glyph: u16,
@@ -6179,7 +6211,7 @@ Decoder_opentype_gsub_ligature_subst_ligature_set(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#101)
+/// trait-ready: unique decoder function (d#103)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_ligature_subst_ligature_set<'input> {
 set_scope: View<'input>,
@@ -6206,7 +6238,7 @@ Decoder_opentype_layout_ligature_subst(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#84)
+/// trait-ready: unique decoder function (d#86)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_ligature_subst<'input> {
 table_scope: View<'input>,
@@ -6227,7 +6259,7 @@ Decoder_opentype_layout_multiple_subst_sequence_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#104)
+/// trait-ready: unique decoder function (d#106)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_multiple_subst_sequence_table {
 glyph_count: u16,
@@ -6259,7 +6291,7 @@ Decoder_opentype_layout_multiple_subst(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#82)
+/// trait-ready: unique decoder function (d#84)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_multiple_subst<'input> {
 table_scope: View<'input>,
@@ -6279,7 +6311,7 @@ Decoder_opentype_layout_reverse_chain_single_subst(p)
 }
 
 /// expected size: 112
-/// trait-ready: unique decoder function (d#87)
+/// trait-ready: unique decoder function (d#89)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_reverse_chain_single_subst<'input> {
 subst_format: u16,
@@ -6304,12 +6336,12 @@ Decoder_opentype_layout_single_subst_format1(p, table_view)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#105)
+/// trait-ready: unique decoder function (d#107)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_single_subst_format1<'input> {
 table_scope: View<'input>,
 coverage: opentype_gdef_attach_list_coverage,
-delta_glyph_id: u16
+delta_glyph_id: i16
 }
 
 impl<'a> CommonObject for opentype_layout_single_subst_format2<'a> {
@@ -6323,7 +6355,7 @@ Decoder_opentype_layout_single_subst_format2(p, table_view)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#106)
+/// trait-ready: unique decoder function (d#108)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_single_subst_format2<'input> {
 table_scope: View<'input>,
@@ -6348,7 +6380,7 @@ Decoder_opentype_layout_single_subst(p)
 }
 
 /// expected size: 72
-/// trait-ready: unique decoder function (d#81)
+/// trait-ready: unique decoder function (d#83)
 #[derive(Debug, Clone)]
 pub struct opentype_layout_single_subst<'input> {
 subst_format: u16,
@@ -6366,7 +6398,7 @@ Decoder_opentype_layout_ground_subst(p, lookup_type)
 }
 
 /// expected size: 152
-/// trait-ready: unique decoder function (d#80)
+/// trait-ready: unique decoder function (d#82)
 #[derive(Debug, Clone)]
 pub enum opentype_layout_ground_subst<'input> { AlternateSubst(opentype_gsub_alternate_subst<'input>), ChainedSequenceContext(opentype_layout_chained_sequence_context<'input>), LigatureSubst(opentype_layout_ligature_subst<'input>), MultipleSubst(opentype_layout_multiple_subst<'input>), ReverseChainSingleSubst(opentype_layout_reverse_chain_single_subst<'input>), SequenceContext(opentype_layout_sequence_context<'input>), SingleSubst(opentype_layout_single_subst<'input>) }
 
@@ -6389,7 +6421,7 @@ Decoder_opentype_layout_subst_extension(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#79)
+/// trait-ready: unique decoder function (d#81)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_layout_subst_extension<'input> {
 format: u16,
@@ -6409,7 +6441,7 @@ Decoder_opentype_gsub_lookup_subtable(p, lookup_type)
 }
 
 /// expected size: 160
-/// trait-ready: unique decoder function (d#78)
+/// trait-ready: unique decoder function (d#80)
 #[derive(Debug, Clone)]
 pub enum opentype_gsub_lookup_subtable<'input> { GroundSubst(opentype_layout_ground_subst<'input>), SubstExtension(opentype_layout_subst_extension<'input>) }
 
@@ -6432,7 +6464,7 @@ Decoder_opentype_gsub_lookup_table(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#77)
+/// trait-ready: unique decoder function (d#79)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_lookup_table<'input> {
 table_scope: View<'input>,
@@ -6462,7 +6494,7 @@ Decoder_opentype_gsub_lookup_list(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#71)
+/// trait-ready: unique decoder function (d#73)
 #[derive(Debug, Clone)]
 pub struct opentype_gsub_lookup_list<'input> {
 list_scope: View<'input>,
@@ -6489,7 +6521,7 @@ Decoder_opentype_gsub_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#43)
+/// trait-ready: unique decoder function (d#45)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_gsub_table<'input> {
 table_scope: View<'input>,
@@ -6519,7 +6551,7 @@ Decoder_opentype_fvar_variation_axis_record(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#66)
+/// trait-ready: unique decoder function (d#68)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_fvar_variation_axis_record {
 axis_tag: u32,
@@ -6541,7 +6573,7 @@ Decoder_opentype_fvar_user_tuple(p, axis_count)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#68)
+/// trait-ready: unique decoder function (d#70)
 #[derive(Debug, Clone)]
 pub struct opentype_fvar_user_tuple {
 coordinates: Vec<opentype_head_table_font_revision>
@@ -6559,7 +6591,7 @@ Decoder_opentype_fvar_instance_record(p, axis_count, instance_size)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#67)
+/// trait-ready: unique decoder function (d#69)
 #[derive(Debug, Clone)]
 pub struct opentype_fvar_instance_record {
 subfamily_nameid: u16,
@@ -6579,7 +6611,7 @@ Decoder_opentype_fvar_table(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#44)
+/// trait-ready: unique decoder function (d#46)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_fvar_table<'input> {
 table_scope: View<'input>,
@@ -6606,7 +6638,7 @@ Decoder_opentype_gvar_tuple_record(p, axis_count)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#59)
+/// trait-ready: unique decoder function (d#61)
 #[derive(Debug, Clone)]
 pub struct opentype_gvar_tuple_record {
 coordinates: Vec<opentype_gvar_tuple_record_coordinates>
@@ -6664,7 +6696,7 @@ Decoder_opentype_gvar_tuple_variation_header(p, axis_count)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#61)
+/// trait-ready: unique decoder function (d#63)
 #[derive(Debug, Clone)]
 pub struct opentype_gvar_tuple_variation_header {
 variation_data_size: u16,
@@ -6697,7 +6729,7 @@ Decoder_opentype_var_packed_point_numbers_runs(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#65)
+/// trait-ready: unique decoder function (d#67)
 #[derive(Debug, Clone)]
 pub struct opentype_var_packed_point_numbers_runs {
 control: opentype_var_packed_point_numbers_run_control,
@@ -6716,7 +6748,7 @@ delta_run_count: u8
 /// expected size: 32
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
-pub enum opentype_gvar_serialized_data_per_tuple_variation_data_x_and_y_coordinate_deltas_deltas { Delta0(u8), Delta16(Vec<u16>), Delta8(Vec<u8>) }
+pub enum opentype_gvar_serialized_data_per_tuple_variation_data_x_and_y_coordinate_deltas_deltas { Delta0(u8), Delta16(Vec<i16>), Delta8(Vec<i8>) }
 
 /// expected size: 40
 /// trait-orphaned: no decoder functions provided
@@ -6746,7 +6778,7 @@ Decoder_opentype_gvar_serialized_data(p, shared_point_numbers, tuple_var_headers
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#62)
+/// trait-ready: unique decoder function (d#64)
 #[derive(Debug, Clone)]
 pub struct opentype_gvar_serialized_data {
 shared_point_numbers: Option<(u16, Vec<opentype_var_packed_point_numbers_runs>)>,
@@ -6764,7 +6796,7 @@ Decoder_opentype_gvar_glyph_variation_data(p, axis_count)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#60)
+/// trait-ready: unique decoder function (d#62)
 #[derive(Debug, Clone)]
 pub struct opentype_gvar_glyph_variation_data<'input> {
 data_scope: View<'input>,
@@ -6785,7 +6817,7 @@ Decoder_opentype_gvar_table(p)
 }
 
 /// expected size: 80
-/// trait-ready: unique decoder function (d#45)
+/// trait-ready: unique decoder function (d#47)
 #[derive(Debug, Clone)]
 pub struct opentype_gvar_table<'input> {
 table_scope: View<'input>,
@@ -6818,7 +6850,7 @@ horizontal: bool
 pub struct opentype_kern_subtable_format0_kern_pairs {
 left: u16,
 right: u16,
-value: u16
+value: i16
 }
 
 impl CommonObject for opentype_kern_subtable_format0 {
@@ -6832,7 +6864,7 @@ Decoder_opentype_kern_subtable_format0(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#55)
+/// trait-ready: unique decoder function (d#57)
 #[derive(Debug, Clone)]
 pub struct opentype_kern_subtable_format0 {
 n_pairs: u16,
@@ -6853,7 +6885,7 @@ Decoder_opentype_kern_class_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#57)
+/// trait-ready: unique decoder function (d#59)
 #[derive(Debug, Clone)]
 pub struct opentype_kern_class_table {
 first_glyph: u16,
@@ -6881,12 +6913,12 @@ Decoder_opentype_kern_kerning_array(p, left_glyph_count, right_glyph_count)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#58)
+/// trait-ready: unique decoder function (d#60)
 #[derive(Debug, Clone)]
 pub struct opentype_kern_kerning_array {
 left_glyph_count: u16,
 right_glyph_count: u16,
-kerning_values: Vec<Vec<u16>>
+kerning_values: Vec<Vec<i16>>
 }
 
 /// expected size: 2
@@ -6908,7 +6940,7 @@ Decoder_opentype_kern_subtable_format2(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#56)
+/// trait-ready: unique decoder function (d#58)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_kern_subtable_format2<'input> {
 table_scope: View<'input>,
@@ -6934,7 +6966,7 @@ Decoder_opentype_kern_kern_subtable(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#54)
+/// trait-ready: unique decoder function (d#56)
 #[derive(Debug, Clone)]
 pub struct opentype_kern_kern_subtable<'input> {
 version: u16,
@@ -6954,7 +6986,7 @@ Decoder_opentype_kern_table(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#46)
+/// trait-ready: unique decoder function (d#48)
 #[derive(Debug, Clone)]
 pub struct opentype_kern_table<'input> {
 version: u16,
@@ -6982,7 +7014,7 @@ Decoder_opentype_stat_design_axes_array(p, design_axis_count)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#50)
+/// trait-ready: unique decoder function (d#52)
 #[derive(Debug, Clone)]
 pub struct opentype_stat_design_axes_array {
 design_axes: Vec<opentype_stat_design_axes_array_design_axes>
@@ -7071,7 +7103,7 @@ Decoder_opentype_stat_axis_value_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#52)
+/// trait-ready: unique decoder function (d#54)
 #[derive(Debug, Clone)]
 pub struct opentype_stat_axis_value_table {
 format: u16,
@@ -7097,7 +7129,7 @@ Decoder_opentype_stat_axis_value_array(p, axis_value_count)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#51)
+/// trait-ready: unique decoder function (d#53)
 #[derive(Debug, Clone)]
 pub struct opentype_stat_axis_value_array<'input> {
 array_scope: View<'input>,
@@ -7123,7 +7155,7 @@ Decoder_opentype_stat_table(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#47)
+/// trait-ready: unique decoder function (d#49)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_stat_table<'input> {
 table_scope: View<'input>,
@@ -7149,7 +7181,7 @@ Decoder_opentype_table_directory_table_links(p, tables, font_view)
 }
 
 /// expected size: 1200
-/// trait-ready: unique decoder function (d#28)
+/// trait-ready: unique decoder function (d#30)
 #[derive(Debug, Clone)]
 pub struct opentype_table_directory_table_links<'input> {
 cmap: opentype_cmap_table<'input>,
@@ -7160,7 +7192,7 @@ hmtx: opentype_hmtx_table,
 name: opentype_name_table<'input>,
 os2: opentype_os2_table,
 post: opentype_post_table<'input>,
-cvt: Option<Vec<u16>>,
+cvt: Option<Vec<i16>>,
 fpgm: Option<Vec<u8>>,
 loca: Option<opentype_loca_table>,
 glyf: Option<opentype_glyf_table<'input>>,
@@ -7189,7 +7221,7 @@ Decoder_opentype_table_directory(p, font_view)
 }
 
 /// expected size: 1240
-/// trait-ready: unique decoder function (d#25)
+/// trait-ready: unique decoder function (d#27)
 #[derive(Debug, Clone)]
 pub struct opentype_table_directory<'input> {
 sfnt_version: u32,
@@ -7244,7 +7276,7 @@ Decoder_opentype_ttc_header(p, font_view)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#26)
+/// trait-ready: unique decoder function (d#28)
 #[derive(Debug, Clone)]
 pub struct opentype_ttc_header<'input> {
 ttc_tag: u32,
@@ -7289,7 +7321,7 @@ Decoder_png_ihdr_data(p)
 }
 
 /// expected size: 16
-/// trait-ready: unique decoder function (d#282)
+/// trait-ready: unique decoder function (d#284)
 #[derive(Debug, Copy, Clone)]
 pub struct png_ihdr_data {
 width: u32,
@@ -7312,7 +7344,7 @@ Decoder_png_ihdr(p)
 }
 
 /// expected size: 28
-/// trait-ready: unique decoder function (d#235)
+/// trait-ready: unique decoder function (d#237)
 #[derive(Debug, Copy, Clone)]
 pub struct png_ihdr {
 length: u32,
@@ -7355,7 +7387,7 @@ Decoder_png_bkgd(p, ihdr)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#262)
+/// trait-ready: unique decoder function (d#264)
 #[derive(Debug, Copy, Clone)]
 pub enum png_bkgd { color_type_0(png_trns_color_type_0), color_type_2(png_trns_color_type_2), color_type_3(png_trns_color_type_3), color_type_4(png_trns_color_type_0), color_type_6(png_trns_color_type_2) }
 
@@ -7370,7 +7402,7 @@ Decoder_png_chrm(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#254)
+/// trait-ready: unique decoder function (d#256)
 #[derive(Debug, Copy, Clone)]
 pub struct png_chrm {
 whitepoint_x: u32,
@@ -7394,7 +7426,7 @@ Decoder_png_gama(p)
 }
 
 /// expected size: 4
-/// trait-ready: unique decoder function (d#255)
+/// trait-ready: unique decoder function (d#257)
 #[derive(Debug, Copy, Clone)]
 pub struct png_gama {
 gamma: u32
@@ -7411,7 +7443,7 @@ Decoder_png_hist(p)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#263)
+/// trait-ready: unique decoder function (d#265)
 #[derive(Debug, Clone)]
 pub struct png_hist {
 histogram: Vec<u16>
@@ -7435,7 +7467,7 @@ fcheck: u8
 }
 
 /// expected size: 96
-/// trait-unready: multiple (4) decoders exist (d#{238, 269, 275, 280})
+/// trait-unready: multiple (4) decoders exist (d#{240, 271, 277, 282})
 #[derive(Debug, Clone)]
 pub struct zlib_main {
 compression_method_flags: zlib_main_compression_method_flags,
@@ -7456,7 +7488,7 @@ Decoder_png_iccp(p)
 }
 
 /// expected size: 128
-/// trait-ready: unique decoder function (d#256)
+/// trait-ready: unique decoder function (d#258)
 #[derive(Debug, Clone)]
 pub struct png_iccp {
 profile_name: Vec<u8>,
@@ -7485,7 +7517,7 @@ Decoder_png_itxt(p)
 }
 
 /// expected size: 120
-/// trait-ready: unique decoder function (d#259)
+/// trait-ready: unique decoder function (d#261)
 #[derive(Debug, Clone)]
 pub struct png_itxt {
 keyword: Vec<u8>,
@@ -7507,7 +7539,7 @@ Decoder_png_phys(p)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#264)
+/// trait-ready: unique decoder function (d#266)
 #[derive(Debug, Copy, Clone)]
 pub struct png_phys {
 pixels_per_unit_x: u32,
@@ -7560,7 +7592,7 @@ Decoder_png_sbit(p, ihdr)
 }
 
 /// expected size: 5
-/// trait-ready: unique decoder function (d#257)
+/// trait-ready: unique decoder function (d#259)
 #[derive(Debug, Copy, Clone)]
 pub enum png_sbit { color_type_0(png_sbit_color_type_0), color_type_2(png_sbit_color_type_2), color_type_3(png_sbit_color_type_2), color_type_4(png_sbit_color_type_4), color_type_6(png_sbit_color_type_6) }
 
@@ -7602,7 +7634,7 @@ Decoder_png_splt(p)
 }
 
 /// expected size: 64
-/// trait-ready: unique decoder function (d#265)
+/// trait-ready: unique decoder function (d#267)
 #[derive(Debug, Clone)]
 pub struct png_splt {
 palette_name: Vec<u8>,
@@ -7621,7 +7653,7 @@ Decoder_png_srgb(p)
 }
 
 /// expected size: 1
-/// trait-ready: unique decoder function (d#258)
+/// trait-ready: unique decoder function (d#260)
 #[derive(Debug, Copy, Clone)]
 pub struct png_srgb {
 rendering_intent: u8
@@ -7638,7 +7670,7 @@ Decoder_png_text(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#260)
+/// trait-ready: unique decoder function (d#262)
 #[derive(Debug, Clone)]
 pub struct png_text {
 keyword: Vec<u8>,
@@ -7656,7 +7688,7 @@ Decoder_png_time(p)
 }
 
 /// expected size: 8
-/// trait-ready: unique decoder function (d#266)
+/// trait-ready: unique decoder function (d#268)
 #[derive(Debug, Copy, Clone)]
 pub struct png_time {
 year: u16,
@@ -7678,7 +7710,7 @@ Decoder_png_trns(p, ihdr)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#253)
+/// trait-ready: unique decoder function (d#255)
 #[derive(Debug, Clone)]
 pub enum png_trns { color_type_0(png_trns_color_type_0), color_type_2(png_trns_color_type_2), color_type_3(Vec<png_trns_color_type_3>) }
 
@@ -7693,7 +7725,7 @@ Decoder_png_ztxt(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#261)
+/// trait-ready: unique decoder function (d#263)
 #[derive(Debug, Clone)]
 pub struct png_ztxt {
 keyword: Vec<u8>,
@@ -7717,7 +7749,7 @@ Decoder_png_chunk(p, ihdr)
 }
 
 /// expected size: 168
-/// trait-ready: unique decoder function (d#236)
+/// trait-ready: unique decoder function (d#238)
 #[derive(Debug, Clone)]
 pub struct png_chunk {
 length: u32,
@@ -7737,7 +7769,7 @@ Decoder_png_iend(p)
 }
 
 /// expected size: 12
-/// trait-ready: unique decoder function (d#239)
+/// trait-ready: unique decoder function (d#241)
 #[derive(Debug, Copy, Clone)]
 pub struct png_iend {
 length: u32,
@@ -7778,7 +7810,7 @@ Decoder_riff_chunk(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#234)
+/// trait-ready: unique decoder function (d#236)
 #[derive(Debug, Clone)]
 pub struct riff_chunk {
 tag: (u8, u8, u8, u8),
@@ -7798,7 +7830,7 @@ Decoder_riff_subchunks(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#232)
+/// trait-ready: unique decoder function (d#234)
 #[derive(Debug, Clone)]
 pub struct riff_subchunks {
 tag: (u8, u8, u8, u8),
@@ -7836,7 +7868,7 @@ Decoder_rle_new_style(p)
 }
 
 /// expected size: 24
-/// trait-ready: unique decoder function (d#22)
+/// trait-ready: unique decoder function (d#23)
 #[derive(Debug, Clone)]
 pub struct rle_new_style {
 data: Vec<u8>
@@ -7853,7 +7885,7 @@ Decoder_rle_old_style_run(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#24)
+/// trait-ready: unique decoder function (d#25)
 #[derive(Debug, Clone)]
 pub struct rle_old_style_run {
 len: u8,
@@ -7872,7 +7904,7 @@ Decoder_rle_old_style(p)
 }
 
 /// expected size: 48
-/// trait-ready: unique decoder function (d#21)
+/// trait-ready: unique decoder function (d#22)
 #[derive(Debug, Clone)]
 pub struct rle_old_style {
 runs: Vec<rle_old_style_run>,
@@ -7890,12 +7922,12 @@ Decoder_rle_main(p)
 }
 
 /// expected size: 56
-/// trait-ready: unique decoder function (d#15)
+/// trait-ready: unique decoder function (d#16)
 #[derive(Debug, Clone)]
 pub enum rle_main { new_style(rle_new_style), old_style(rle_old_style) }
 
 /// expected size: 24
-/// trait-unready: multiple (3) decoders exist (d#{224, 226, 227})
+/// trait-unready: multiple (3) decoders exist (d#{226, 228, 229})
 #[derive(Debug, Clone)]
 pub struct tar_ascii_string_opt0_nonempty {
 string: Vec<u8>
@@ -7912,7 +7944,7 @@ Decoder_tar_header(p)
 }
 
 /// expected size: 328
-/// trait-ready: unique decoder function (d#223)
+/// trait-ready: unique decoder function (d#225)
 #[derive(Debug, Clone)]
 pub struct tar_header {
 name: tar_ascii_string_opt0_nonempty,
@@ -7945,7 +7977,7 @@ Decoder_tar_header_with_data(p)
 }
 
 /// expected size: 352
-/// trait-ready: unique decoder function (d#222)
+/// trait-ready: unique decoder function (d#224)
 #[derive(Debug, Clone)]
 pub struct tar_header_with_data {
 header: tar_header,
@@ -7953,7 +7985,7 @@ file: Vec<u8>
 }
 
 /// expected size: 24
-/// trait-unready: multiple (2) decoders exist (d#{12, 426})
+/// trait-unready: multiple (2) decoders exist (d#{12, 428})
 #[derive(Debug, Clone)]
 pub struct tar_main {
 contents: Vec<tar_header_with_data>
@@ -7979,10 +8011,10 @@ waldo: &'input [u8]
 }
 
 /// expected size: 1264
-/// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] }, Layout { size: 104, align: 8 (1 << 3) })
+/// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] }, Layout { size: 104, align: 8 (1 << 3) })
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
-pub enum main_data<'input> { elf(elf_main), gif(gif_main), gzip(Vec<gzip_main>), jpeg(jpeg_main), mpeg4(mpeg4_main), opentype(opentype_main<'input>), peano(Vec<u32>), png(png_main), riff(riff_main), rle(rle_main), tar(tar_main), text(Vec<char>), tgz(Vec<tar_main>), tiff(tiff_main), waldo(waldo_main<'input>) }
+pub enum main_data<'input> { elf(elf_main), gif(gif_main), gzip(Vec<gzip_main>), jpeg(jpeg_main), mpeg4(mpeg4_main), numbers(numbers_main), opentype(opentype_main<'input>), peano(Vec<u32>), png(png_main), riff(riff_main), rle(rle_main), tar(tar_main), text(Vec<char>), tgz(Vec<tar_main>), tiff(tiff_main), waldo(waldo_main<'input>) }
 
 /// expected size: 4
 /// trait-orphaned: no decoder functions provided
@@ -8002,7 +8034,7 @@ Decoder_png_idat(p)
 }
 
 /// expected size: 40
-/// trait-ready: unique decoder function (d#237)
+/// trait-ready: unique decoder function (d#239)
 #[derive(Debug, Clone)]
 pub struct png_idat {
 length: u32,
@@ -8045,7 +8077,7 @@ Decoder_opentype_glyph_description_simple_flags_raw(p)
 }
 
 /// expected size: 7
-/// trait-ready: unique decoder function (d#172)
+/// trait-ready: unique decoder function (d#174)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_glyph_description_simple_flags_raw {
 overlap_simple: bool,
@@ -8076,7 +8108,7 @@ Decoder_rle_new_style_run(p)
 }
 
 /// expected size: 32
-/// trait-ready: unique decoder function (d#23)
+/// trait-ready: unique decoder function (d#24)
 #[derive(Debug, Clone)]
 pub struct rle_new_style_run {
 _len: u8,
@@ -8085,7 +8117,7 @@ buf: Vec<u8>
 }
 
 /// expected size: 1264
-/// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [InDef(InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] })] }, Layout { size: 104, align: 8 (1 << 3) })
+/// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [InDef(InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] })] }, Layout { size: 104, align: 8 (1 << 3) })
 /// trait-unready: multiple (2) decoders exist (d#{0, 1})
 #[derive(Debug, Clone)]
 pub struct main<'input> {
@@ -8101,7 +8133,7 @@ expand_vertical: u8
 }
 
 /// expected size: 2
-/// trait-unready: multiple (2) decoders exist (d#{456, 461})
+/// trait-unready: multiple (2) decoders exist (d#{458, 463})
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_exp_data {
 expand_horizontal_vertical: jpeg_exp_data_expand_horizontal_vertical
@@ -8118,7 +8150,7 @@ Decoder_jpeg_exp(p)
 }
 
 /// expected size: 6
-/// trait-ready: unique decoder function (d#460)
+/// trait-ready: unique decoder function (d#462)
 #[derive(Debug, Copy, Clone)]
 pub struct jpeg_exp {
 marker: jpeg_soi,
@@ -8305,6 +8337,19 @@ _input.next_alt(false)?;
 }
 };
 let res = (|| {
+let inner = (Decoder_numbers_main(_input))?;
+PResult::Ok(main_data::numbers(inner))
+})();
+match res {
+Ok(inner) => {
+return PResult::Ok(inner);
+},
+
+Err(_e) => {
+_input.next_alt(false)?;
+}
+};
+let res = (|| {
 let inner = (Decoder_rle_main(_input))?;
 PResult::Ok(main_data::rle(inner))
 })();
@@ -8318,7 +8363,7 @@ _input.next_alt(true)?;
 }
 };
 let res = (|| {
-let inner = (Decoder16(_input))?;
+let inner = (Decoder17(_input))?;
 PResult::Ok(main_data::text(inner))
 })();
 match res {
@@ -8428,7 +8473,7 @@ return Err(ParseError::InsufficientRepeats);
 break
 }
 } else {
-let next_elem = (Decoder450(_input))?;
+let next_elem = (Decoder452(_input))?;
 accum.push(next_elem)
 }
 };
@@ -8481,13 +8526,13 @@ PResult::Ok(gif_main { header, logical_screen, blocks, trailer })
 
 /// d#5
 fn Decoder5(_input: &mut Parser<'_>) -> Result<Vec<tar_main>, ParseError> {
-let gzip_raw = (Decoder425(_input))?;
+let gzip_raw = (Decoder427(_input))?;
 let mut accum = Vec::new();
 for item in gzip_raw.clone() {
 let next_elem = {
 let mut buf_parser = Parser::new(slice_all(&item.data.inflate));
 let buf_input = &mut buf_parser;
-(Decoder426(buf_input))?
+(Decoder428(buf_input))?
 };
 accum.push(next_elem)
 };
@@ -8526,7 +8571,7 @@ Some((Decoder_gzip_fextra(_input))?)
 None
 };
 let fname = if header.file_flags.fname {
-Some((Decoder419(_input))?)
+Some((Decoder421(_input))?)
 } else {
 None
 };
@@ -8559,7 +8604,7 @@ PResult::Ok(accum)
 fn Decoder_jpeg_main(_input: &mut Parser<'_>) -> Result<jpeg_main, ParseError> {
 let soi = (Decoder_jpeg_soi(_input))?;
 let frame = (Decoder_jpeg_frame(_input))?;
-let eoi = (Decoder341(_input))?;
+let eoi = (Decoder343(_input))?;
 PResult::Ok(jpeg_main { soi, frame, eoi })
 }
 
@@ -9107,7 +9152,7 @@ x64
 }
 };
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
-let ret = (Decoder194(_input, header.ident.data == 2u8, header.ident.class, header.phnum))?;
+let ret = (Decoder196(_input, header.ident.data == 2u8, header.ident.class, header.phnum))?;
 _input.close_peek_context()?;
 Some(ret)
 } else {
@@ -9124,7 +9169,7 @@ x64
 }
 };
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
-let ret = (Decoder195(_input, header.ident.data == 2u8, header.ident.class, header.shnum))?;
+let ret = (Decoder197(_input, header.ident.data == 2u8, header.ident.class, header.shnum))?;
 _input.close_peek_context()?;
 Some(ret)
 } else {
@@ -9145,7 +9190,7 @@ x64
 }
 };
 let _is_advance = _input.advance_or_seek(tgt_offset)?;
-let ret = (Decoder196(_input, shdr.r#type, match shdr.size {
+let ret = (Decoder198(_input, shdr.r#type, match shdr.size {
 elf_types_elf_full::Full32(x32) => {
 x32 as u64
 },
@@ -9213,6 +9258,102 @@ PResult::Ok(opentype_main { magic, directory })
 }
 
 /// d#15
+fn Decoder_numbers_main(_input: &mut Parser<'_>) -> Result<numbers_main, ParseError> {
+{
+let arg0 = {
+let b = _input.read_byte()?;
+if b == 78 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(10036638040555853769u64));
+}
+};
+let arg1 = {
+let b = _input.read_byte()?;
+if b == 85 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(13230337088401352826u64));
+}
+};
+let arg2 = {
+let b = _input.read_byte()?;
+if b == 77 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(11460567998186064482u64));
+}
+};
+let arg3 = {
+let b = _input.read_byte()?;
+if b == 83 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(6223008304848233301u64));
+}
+};
+(arg0, arg1, arg2, arg3)
+};
+let values = {
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+{
+let ret = match _input.read_byte()? {
+0u8 => {
+0
+},
+
+1u8 => {
+0
+},
+
+2u8 => {
+0
+},
+
+3u8 => {
+0
+},
+
+4u8 => {
+0
+},
+
+5u8 => {
+0
+},
+
+6u8 => {
+0
+},
+
+7u8 => {
+0
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14550754927305275517u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = (Decoder_numbers_num_value(_input))?;
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+PResult::Ok(numbers_main { values })
+}
+
+/// d#16
 fn Decoder_rle_main(_input: &mut Parser<'_>) -> Result<rle_main, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -9227,7 +9368,7 @@ let ret = match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11460567998186064482u64));
+return Err(ParseError::ExcludedBranch(2391834656526534993u64));
 }
 };
 _input.close_peek_context()?;
@@ -9241,7 +9382,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10036638040555853769u64));
+return Err(ParseError::ExcludedBranch(10197098993763395417u64));
 }
 };
 let inner = (Decoder_rle_old_style(_input))?;
@@ -9254,7 +9395,7 @@ let b = _input.read_byte()?;
 if b == 1 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13230337088401352826u64));
+return Err(ParseError::ExcludedBranch(15631554783732883240u64));
 }
 };
 let inner = (Decoder_rle_new_style(_input))?;
@@ -9262,18 +9403,18 @@ rle_main::new_style(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6223008304848233301u64));
+return Err(ParseError::ExcludedBranch(9422510723961972169u64));
 }
 })
 }
 
-/// d#16
-fn Decoder16(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
-Decoder17(_input)
-}
-
 /// d#17
 fn Decoder17(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+Decoder18(_input)
+}
+
+/// d#18
+fn Decoder18(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -9321,7 +9462,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14550754927305275517u64));
+return Err(ParseError::ExcludedBranch(10940017698627680568u64));
 }
 };
 _input.close_peek_context()?;
@@ -9329,7 +9470,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder18(_input))?;
+let next_elem = (Decoder19(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -9338,8 +9479,8 @@ break
 PResult::Ok(accum)
 }
 
-/// d#18
-fn Decoder18(_input: &mut Parser<'_>) -> Result<char, ParseError> {
+/// d#19
+fn Decoder19(_input: &mut Parser<'_>) -> Result<char, ParseError> {
 let tree_index = {
 _input.open_peek_context();
 {
@@ -9385,7 +9526,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15631554783732883240u64));
+return Err(ParseError::ExcludedBranch(9665974566873665536u64));
 }
 };
 _input.close_peek_context()?;
@@ -9399,24 +9540,24 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10197098993763395417u64));
+return Err(ParseError::ExcludedBranch(179268011689651936u64));
 }
 };
 (char::from_u32(0u32)).unwrap()
 },
 
 1 => {
-(Decoder19(_input))?
+(Decoder20(_input))?
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2391834656526534993u64));
+return Err(ParseError::ExcludedBranch(374064178837027275u64));
 }
 })
 }
 
-/// d#19
-fn Decoder19(_input: &mut Parser<'_>) -> Result<char, ParseError> {
+/// d#20
+fn Decoder20(_input: &mut Parser<'_>) -> Result<char, ParseError> {
 let codepoint = {
 let tree_index = {
 _input.open_peek_context();
@@ -9459,7 +9600,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3852079030227774582u64));
+return Err(ParseError::ExcludedBranch(18164850183020044607u64));
 }
 };
 _input.close_peek_context()?;
@@ -9473,7 +9614,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744073709551614u64, 18446744073709551615u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9422510723961972169u64));
+return Err(ParseError::ExcludedBranch(658824046370133753u64));
 }
 };
 byte as u32
@@ -9487,12 +9628,12 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 0u64, 4294967292u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10940017698627680568u64));
+return Err(ParseError::ExcludedBranch(3725673472712527969u64));
 }
 };
 raw & 31u8
 };
-let arg1 = (Decoder20(_input))?;
+let arg1 = (Decoder21(_input))?;
 (arg0, arg1)
 };
 {
@@ -9524,7 +9665,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 211106232532992u64])).contains(b
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15741082764016749161u64));
+return Err(ParseError::ExcludedBranch(15080388466336998873u64));
 }
 };
 _input.close_peek_context()?;
@@ -9539,7 +9680,7 @@ let b = _input.read_byte()?;
 if b == 224 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(179268011689651936u64));
+return Err(ParseError::ExcludedBranch(12728843535195535635u64));
 }
 };
 raw & 15u8
@@ -9550,12 +9691,12 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 18446744069414584320u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9665974566873665536u64));
+return Err(ParseError::ExcludedBranch(15741082764016749161u64));
 }
 };
 raw & 63u8
 };
-let arg2 = (Decoder20(_input))?;
+let arg2 = (Decoder21(_input))?;
 (arg0, arg1, arg2)
 },
 
@@ -9566,13 +9707,13 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 0u64, 35175782154240u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(374064178837027275u64));
+return Err(ParseError::ExcludedBranch(9967703502401950260u64));
 }
 };
 raw & 15u8
 };
-let arg1 = (Decoder20(_input))?;
-let arg2 = (Decoder20(_input))?;
+let arg1 = (Decoder21(_input))?;
+let arg2 = (Decoder21(_input))?;
 (arg0, arg1, arg2)
 },
 
@@ -9583,7 +9724,7 @@ let b = _input.read_byte()?;
 if b == 237 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(658824046370133753u64));
+return Err(ParseError::ExcludedBranch(8376883036401934317u64));
 }
 };
 raw & 15u8
@@ -9594,12 +9735,12 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 4294967295u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3725673472712527969u64));
+return Err(ParseError::ExcludedBranch(9069368457806005425u64));
 }
 };
 raw & 63u8
 };
-let arg2 = (Decoder20(_input))?;
+let arg2 = (Decoder21(_input))?;
 (arg0, arg1, arg2)
 },
 
@@ -9610,18 +9751,18 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 0u64, 211106232532992u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12728843535195535635u64));
+return Err(ParseError::ExcludedBranch(3179861450314844647u64));
 }
 };
 raw & 15u8
 };
-let arg1 = (Decoder20(_input))?;
-let arg2 = (Decoder20(_input))?;
+let arg1 = (Decoder21(_input))?;
+let arg2 = (Decoder21(_input))?;
 (arg0, arg1, arg2)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9967703502401950260u64));
+return Err(ParseError::ExcludedBranch(6070260202873699214u64));
 }
 }
 };
@@ -9650,7 +9791,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8986322043713516692u64));
+return Err(ParseError::ExcludedBranch(8772793160380380086u64));
 }
 };
 _input.close_peek_context()?;
@@ -9665,7 +9806,7 @@ let b = _input.read_byte()?;
 if b == 240 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8376883036401934317u64));
+return Err(ParseError::ExcludedBranch(8986322043713516692u64));
 }
 };
 raw & 7u8
@@ -9676,13 +9817,13 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 18446744073709486080u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9069368457806005425u64));
+return Err(ParseError::ExcludedBranch(11786939113783016634u64));
 }
 };
 raw & 63u8
 };
-let arg2 = (Decoder20(_input))?;
-let arg3 = (Decoder20(_input))?;
+let arg2 = (Decoder21(_input))?;
+let arg3 = (Decoder21(_input))?;
 (arg0, arg1, arg2, arg3)
 },
 
@@ -9693,14 +9834,14 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3179861450314844647u64));
+return Err(ParseError::ExcludedBranch(3852079030227774582u64));
 }
 };
 raw & 7u8
 };
-let arg1 = (Decoder20(_input))?;
-let arg2 = (Decoder20(_input))?;
-let arg3 = (Decoder20(_input))?;
+let arg1 = (Decoder21(_input))?;
+let arg2 = (Decoder21(_input))?;
+let arg3 = (Decoder21(_input))?;
 (arg0, arg1, arg2, arg3)
 },
 
@@ -9711,7 +9852,7 @@ let b = _input.read_byte()?;
 if b == 244 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15080388466336998873u64));
+return Err(ParseError::ExcludedBranch(5176232487486782188u64));
 }
 };
 raw & 7u8
@@ -9722,18 +9863,18 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 65535u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6070260202873699214u64));
+return Err(ParseError::ExcludedBranch(9220862562374507822u64));
 }
 };
 raw & 63u8
 };
-let arg2 = (Decoder20(_input))?;
-let arg3 = (Decoder20(_input))?;
+let arg2 = (Decoder21(_input))?;
+let arg3 = (Decoder21(_input))?;
 (arg0, arg1, arg2, arg3)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11786939113783016634u64));
+return Err(ParseError::ExcludedBranch(2605623462625042002u64));
 }
 }
 };
@@ -9744,27 +9885,27 @@ let (x3, x2, x1, x0) = tuple_var;
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5176232487486782188u64));
+return Err(ParseError::ExcludedBranch(10688770705819276010u64));
 }
 }
 };
 PResult::Ok((char::from_u32(codepoint)).unwrap())
 }
 
-/// d#20
-fn Decoder20(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+/// d#21
+fn Decoder21(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
 let raw = {
 let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 18446744073709551615u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9220862562374507822u64));
+return Err(ParseError::ExcludedBranch(10416240583538343445u64));
 }
 };
 PResult::Ok(raw & 63u8)
 }
 
-/// d#21
+/// d#22
 fn Decoder_rle_old_style(_input: &mut Parser<'_>) -> Result<rle_old_style, ParseError> {
 let runs = {
 let mut accum = Vec::new();
@@ -9791,7 +9932,7 @@ let data = (try_flat_map_vec(runs.iter().cloned(), |run: rle_old_style_run| PRes
 PResult::Ok(rle_old_style { runs, data })
 }
 
-/// d#22
+/// d#23
 fn Decoder_rle_new_style(_input: &mut Parser<'_>) -> Result<rle_new_style, ParseError> {
 let _runs = {
 let mut accum = Vec::new();
@@ -9818,7 +9959,7 @@ let data = (try_flat_map_vec(_runs.iter().cloned(), |run: rle_new_style_run| PRe
 PResult::Ok(rle_new_style { data })
 }
 
-/// d#23
+/// d#24
 fn Decoder_rle_new_style_run(_input: &mut Parser<'_>) -> Result<rle_new_style_run, ParseError> {
 let _len = _input.read_byte()?;
 let _char = _input.read_byte()?;
@@ -9833,7 +9974,7 @@ accum
 PResult::Ok(rle_new_style_run { _len, _char, buf })
 }
 
-/// d#24
+/// d#25
 fn Decoder_rle_old_style_run(_input: &mut Parser<'_>) -> Result<rle_old_style_run, ParseError> {
 let len = _input.read_byte()?;
 let char = _input.read_byte()?;
@@ -9848,7 +9989,196 @@ accum
 PResult::Ok(rle_old_style_run { len, char, buf })
 }
 
-/// d#25
+/// d#26
+fn Decoder_numbers_num_value(_input: &mut Parser<'_>) -> Result<numbers_num_value, ParseError> {
+let tree_index = {
+_input.open_peek_context();
+{
+let ret = match _input.read_byte()? {
+0u8 => {
+0
+},
+
+1u8 => {
+1
+},
+
+2u8 => {
+2
+},
+
+3u8 => {
+3
+},
+
+4u8 => {
+4
+},
+
+5u8 => {
+5
+},
+
+6u8 => {
+6
+},
+
+7u8 => {
+7
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11936787736236307191u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+PResult::Ok(match tree_index {
+0 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(1457499133218925748u64));
+}
+};
+_input.read_byte()?
+};
+numbers_num_value::U8Value(inner)
+},
+
+1 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 1 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(14215639860155940137u64));
+}
+};
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+numbers_num_value::U16BEValue(inner)
+},
+
+2 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 2 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(5584166819955891466u64));
+}
+};
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32be(x)
+};
+numbers_num_value::U32BEValue(inner)
+},
+
+3 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 3 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(11133239979815295357u64));
+}
+};
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u64be(x)
+};
+numbers_num_value::U64BEValue(inner)
+},
+
+4 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 4 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(1275286460638129217u64));
+}
+};
+let raw = _input.read_byte()?;
+raw as i8
+};
+numbers_num_value::I8Value(inner)
+},
+
+5 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 5 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(386759067598651566u64));
+}
+};
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+raw as i16
+};
+numbers_num_value::I16BEValue(inner)
+},
+
+6 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 6 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(13527164188224560282u64));
+}
+};
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32be(x)
+};
+raw as i32
+};
+numbers_num_value::I32BEValue(inner)
+},
+
+7 => {
+let inner = {
+{
+let b = _input.read_byte()?;
+if b == 7 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(240888096670347429u64));
+}
+};
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u64be(x)
+};
+raw as i64
+};
+numbers_num_value::I64BEValue(inner)
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5215619712890029856u64));
+}
+})
+}
+
+/// d#27
 fn Decoder_opentype_table_directory<'input>(_input: &mut Parser<'input>, font_view: View<'input>) -> Result<opentype_table_directory<'input>, ParseError> {
 let sfnt_version = {
 let inner = {
@@ -9862,7 +10192,7 @@ matches!(version, 65536u32 | 1330926671u32 | 1953658213u32)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8772793160380380086u64));
+return Err(ParseError::FalsifiedWhere(3167775832820164678u64));
 }
 };
 let num_tables = {
@@ -9893,7 +10223,7 @@ let table_links = (Decoder_opentype_table_directory_table_links(_input, &table_r
 PResult::Ok(opentype_table_directory { sfnt_version, num_tables, search_range, entry_selector, range_shift, table_records, table_links })
 }
 
-/// d#26
+/// d#28
 fn Decoder_opentype_ttc_header<'input>(_input: &mut Parser<'input>, font_view: View<'input>) -> Result<opentype_ttc_header<'input>, ParseError> {
 let ttc_tag = {
 let inner = {
@@ -9907,7 +10237,7 @@ tag == 1953784678u32
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2605623462625042002u64));
+return Err(ParseError::FalsifiedWhere(7215050775822222282u64));
 }
 };
 let major_version = {
@@ -10004,9 +10334,9 @@ _input.skip_remainder();
 PResult::Ok(opentype_ttc_header { ttc_tag, major_version, minor_version, header })
 }
 
-/// d#27
+/// d#29
 fn Decoder_opentype_table_record(_input: &mut Parser<'_>) -> Result<opentype_table_record, ParseError> {
-let table_id = (Decoder53(_input))?;
+let table_id = (Decoder55(_input))?;
 let checksum = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
@@ -10022,7 +10352,7 @@ u32be(x)
 PResult::Ok(opentype_table_record { table_id, checksum, offset, length })
 }
 
-/// d#28
+/// d#30
 fn Decoder_opentype_table_directory_table_links<'input>(_input: &mut Parser<'input>, tables: &[opentype_table_record], font_view: View<'input>) -> Result<opentype_table_directory_table_links<'input>, ParseError> {
 let cmap = match (find_by_key_unsorted(|elem: &opentype_table_record| elem.table_id, 1668112752u32, tables)).copied() {
 Some(ref matching_table) => {
@@ -10165,8 +10495,11 @@ ret
 };
 if matching_ix == 0 {
 let next_elem = {
+let raw = {
 let x = (view_input.read_byte()?, view_input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 } else {
@@ -10432,7 +10765,7 @@ let mut view_parser = Parser::from(font_view.offset(table.offset as usize)?);
 let view_input = &mut view_parser;
 let sz = table.length as usize;
 view_input.start_slice(sz)?;
-let ret = (Decoder48(view_input))?;
+let ret = (Decoder50(view_input))?;
 view_input.end_slice()?;
 Some(ret)
 },
@@ -10447,13 +10780,13 @@ let mut view_parser = Parser::from(font_view.offset(table.offset as usize)?);
 let view_input = &mut view_parser;
 let sz = table.length as usize;
 view_input.start_slice(sz)?;
-let ret = (Decoder49(view_input, match vhea {
+let ret = (Decoder51(view_input, match vhea {
 Some(ref x) => {
 x
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(18164850183020044607u64));
+return Err(ParseError::ExcludedBranch(3743786174148899814u64));
 }
 }.number_of_long_metrics, maxp.num_glyphs))?;
 view_input.end_slice()?;
@@ -10468,7 +10801,7 @@ _input.skip_remainder();
 PResult::Ok(opentype_table_directory_table_links { cmap, head, hhea, maxp, hmtx, name, os2, post, cvt, fpgm, loca, glyf, prep, gasp, base, gdef, gpos, gsub, fvar, gvar, kern, stat, vhea, vmtx })
 }
 
-/// d#29
+/// d#31
 fn Decoder_opentype_cmap_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_cmap_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -10491,7 +10824,7 @@ accum
 PResult::Ok(opentype_cmap_table { table_scope, version, num_tables, encoding_records })
 }
 
-/// d#30
+/// d#32
 fn Decoder_opentype_head_table(_input: &mut Parser<'_>) -> Result<opentype_head_table, ParseError> {
 let major_version = {
 let inner = {
@@ -10505,7 +10838,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10688770705819276010u64));
+return Err(ParseError::FalsifiedWhere(12652804269632162478u64));
 }
 };
 let minor_version = {
@@ -10520,7 +10853,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10416240583538343445u64));
+return Err(ParseError::FalsifiedWhere(18134882366868794706u64));
 }
 };
 let font_revision = {
@@ -10540,7 +10873,7 @@ let b = _input.read_byte()?;
 if b == 95 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1457499133218925748u64));
+return Err(ParseError::ExcludedBranch(7155653122005708978u64));
 }
 };
 let arg1 = {
@@ -10548,7 +10881,7 @@ let b = _input.read_byte()?;
 if b == 15 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14215639860155940137u64));
+return Err(ParseError::ExcludedBranch(17920584887603040596u64));
 }
 };
 let arg2 = {
@@ -10556,7 +10889,7 @@ let b = _input.read_byte()?;
 if b == 60 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5584166819955891466u64));
+return Err(ParseError::ExcludedBranch(5673845796627816005u64));
 }
 };
 let arg3 = {
@@ -10564,7 +10897,7 @@ let b = _input.read_byte()?;
 if b == 245 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11133239979815295357u64));
+return Err(ParseError::ExcludedBranch(14591018267292443527u64));
 }
 };
 (arg0, arg1, arg2, arg3)
@@ -10585,27 +10918,39 @@ matches!(x, 16u16..=16384u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1275286460638129217u64));
+return Err(ParseError::FalsifiedWhere(4762692522317026931u64));
 }
 };
-let created = (Decoder179(_input))?;
-let modified = (Decoder179(_input))?;
+let created = (Decoder181(_input))?;
+let modified = (Decoder181(_input))?;
 let glyph_extents = {
 let x_min = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_min = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let x_max = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let y_max = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_head_table_glyph_extents { x_min, y_min, x_max, y_max }
 };
@@ -10643,7 +10988,7 @@ x <= 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(386759067598651566u64));
+return Err(ParseError::FalsifiedWhere(9630069758457681762u64));
 }
 };
 let glyph_data_format = {
@@ -10658,13 +11003,13 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13527164188224560282u64));
+return Err(ParseError::FalsifiedWhere(908377722732597655u64));
 }
 };
 PResult::Ok(opentype_head_table { major_version, minor_version, font_revision, checksum_adjustment, magic_number, flags, units_per_em, created, modified, glyph_extents, mac_style, lowest_rec_ppem, font_direction_hint, index_to_loc_format, glyph_data_format })
 }
 
-/// d#31
+/// d#33
 fn Decoder_opentype_hhea_table(_input: &mut Parser<'_>) -> Result<opentype_hhea_table, ParseError> {
 let major_version = {
 let inner = {
@@ -10678,7 +11023,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(240888096670347429u64));
+return Err(ParseError::FalsifiedWhere(3203034260088513018u64));
 }
 };
 let minor_version = {
@@ -10693,51 +11038,78 @@ matches!(x, 0u16 | 4096u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11936787736236307191u64));
+return Err(ParseError::FalsifiedWhere(14677505873656710393u64));
 }
 };
 let ascent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let descent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let line_gap = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let advance_width_max = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let min_left_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let min_right_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let x_max_extent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let caret_slope = {
 let rise = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let run = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_hhea_table_caret_slope { rise, run }
 };
 let caret_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 {
 let arg0 = {
@@ -10752,7 +11124,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5215619712890029856u64));
+return Err(ParseError::FalsifiedWhere(10102114574336663273u64));
 }
 };
 let arg1 = {
@@ -10767,7 +11139,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3167775832820164678u64));
+return Err(ParseError::FalsifiedWhere(4386762582485017400u64));
 }
 };
 let arg2 = {
@@ -10782,7 +11154,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7215050775822222282u64));
+return Err(ParseError::FalsifiedWhere(8893850231119365992u64));
 }
 };
 let arg3 = {
@@ -10797,7 +11169,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3743786174148899814u64));
+return Err(ParseError::FalsifiedWhere(7659860344311718435u64));
 }
 };
 (arg0, arg1, arg2, arg3)
@@ -10814,7 +11186,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12652804269632162478u64));
+return Err(ParseError::FalsifiedWhere(11052099086134529863u64));
 }
 };
 let number_of_long_metrics = {
@@ -10824,7 +11196,7 @@ u16be(x)
 PResult::Ok(opentype_hhea_table { major_version, minor_version, ascent, descent, line_gap, advance_width_max, min_left_side_bearing, min_right_side_bearing, x_max_extent, caret_slope, caret_offset, metric_data_format, number_of_long_metrics })
 }
 
-/// d#32
+/// d#34
 fn Decoder_opentype_maxp_table(_input: &mut Parser<'_>) -> Result<opentype_maxp_table, ParseError> {
 let version = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -10852,7 +11224,7 @@ opentype_maxp_table_data::MaxpUnknown(inner)
 PResult::Ok(opentype_maxp_table { version, num_glyphs, data })
 }
 
-/// d#33
+/// d#35
 fn Decoder_opentype_hmtx_table(_input: &mut Parser<'_>, num_long_metrics: u16, num_glyphs: u16) -> Result<opentype_hmtx_table, ParseError> {
 let long_metrics = {
 let mut accum = Vec::new();
@@ -10863,8 +11235,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let left_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_hmtx_table_long_metrics { advance_width, left_side_bearing }
 };
@@ -10876,8 +11251,11 @@ let left_side_bearings = {
 let mut accum = Vec::new();
 for _ in 0..try_sub!(num_glyphs, num_long_metrics, 2206609067086327257u64) {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -10886,7 +11264,7 @@ accum
 PResult::Ok(opentype_hmtx_table { long_metrics, left_side_bearings })
 }
 
-/// d#34
+/// d#36
 fn Decoder_opentype_name_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_name_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -10928,15 +11306,18 @@ opentype_name_table_data::NameVersionUnknown(inner)
 PResult::Ok(opentype_name_table { table_scope, version, name_count, storage_offset, name_records, data })
 }
 
-/// d#35
+/// d#37
 fn Decoder_opentype_os2_table(_input: &mut Parser<'_>, table_length: u32) -> Result<opentype_os2_table, ParseError> {
 let version = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let x_avg_char_width = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let us_weight_class = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -10951,48 +11332,81 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let y_subscript_x_size = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_subscript_y_size = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_subscript_x_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_subscript_y_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_superscript_x_size = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_superscript_y_size = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_superscript_x_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_superscript_y_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_strikeout_size = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_strikeout_position = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let s_family_class = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let panose = {
 let mut accum = Vec::new();
@@ -11018,7 +11432,7 @@ let ul_unicode_range4 = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let ach_vend_id = (Decoder53(_input))?;
+let ach_vend_id = (Decoder55(_input))?;
 let fs_selection = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
@@ -11033,16 +11447,25 @@ u16be(x)
 };
 let data = if (version > 0u16) || (table_length >= 78u32) {
 let s_typo_ascender = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let s_typo_descender = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let s_typo_line_gap = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let us_win_ascent = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -11063,12 +11486,18 @@ u32be(x)
 };
 let extra_fields_v2 = if matches!(version, 2u16..) {
 let sx_height = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let s_cap_height = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let us_default_char = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -11110,7 +11539,7 @@ None
 PResult::Ok(opentype_os2_table { version, x_avg_char_width, us_weight_class, us_width_class, fs_type, y_subscript_x_size, y_subscript_y_size, y_subscript_x_offset, y_subscript_y_offset, y_superscript_x_size, y_superscript_y_size, y_superscript_x_offset, y_superscript_y_offset, y_strikeout_size, y_strikeout_position, s_family_class, panose, ul_unicode_range1, ul_unicode_range2, ul_unicode_range3, ul_unicode_range4, ach_vend_id, fs_selection, us_first_char_index, us_last_char_index, data })
 }
 
-/// d#36
+/// d#38
 fn Decoder_opentype_post_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_post_table<'input>, ParseError> {
 let version = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -11124,12 +11553,18 @@ u32be(x)
 opentype_head_table_font_revision::Fixed32(inner)
 };
 let underline_position = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let underline_thickness = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let is_fixed_pitch = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -11170,7 +11605,10 @@ u16be(x)
 let offset = {
 let mut accum = Vec::new();
 for _ in 0..num_glyphs {
-let next_elem = _input.read_byte()?;
+let next_elem = {
+let raw = _input.read_byte()?;
+raw as i8
+};
 accum.push(next_elem)
 };
 accum
@@ -11192,7 +11630,7 @@ opentype_post_table_names::VersionUnknown(inner)
 PResult::Ok(opentype_post_table { version, italic_angle, underline_position, underline_thickness, is_fixed_pitch, min_mem_type42, max_mem_type42, min_mem_type1, max_mem_type1, names })
 }
 
-/// d#37
+/// d#39
 fn Decoder_opentype_loca_table(_input: &mut Parser<'_>, num_glyphs: u16, index_to_loc_format: u16) -> Result<opentype_loca_table, ParseError> {
 let offsets = match index_to_loc_format {
 0u16 => {
@@ -11232,7 +11670,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(opentype_loca_table { offsets })
 }
 
-/// d#38
+/// d#40
 fn Decoder_opentype_glyf_table<'input>(_input: &mut Parser<'input>, offsets: opentype_loca_table_offsets) -> Result<opentype_glyf_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11292,7 +11730,7 @@ accum
 PResult::Ok(opentype_glyf_table { table_scope, glyphs })
 }
 
-/// d#39
+/// d#41
 fn Decoder_opentype_gasp_table(_input: &mut Parser<'_>) -> Result<opentype_gasp_table, ParseError> {
 let version = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -11340,7 +11778,7 @@ opentype_gasp_table_gasp_ranges_range_gasp_behavior::Version1(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(18134882366868794706u64));
+return Err(ParseError::FailToken(1079884235207081886u64));
 }
 };
 opentype_gasp_table_gasp_ranges { range_max_ppem, range_gasp_behavior }
@@ -11352,7 +11790,7 @@ accum
 PResult::Ok(opentype_gasp_table { version, num_ranges, gasp_ranges })
 }
 
-/// d#40
+/// d#42
 fn Decoder_opentype_base_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_base_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11368,7 +11806,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7155653122005708978u64));
+return Err(ParseError::FalsifiedWhere(980800817911480223u64));
 }
 };
 let minor_version = {
@@ -11383,7 +11821,7 @@ x <= 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17920584887603040596u64));
+return Err(ParseError::FalsifiedWhere(9042484249406774160u64));
 }
 };
 let horiz_axis_offset = {
@@ -11415,7 +11853,7 @@ None
 PResult::Ok(opentype_base_table { table_scope, major_version, minor_version, horiz_axis_offset, vert_axis_offset, item_var_store_offset })
 }
 
-/// d#41
+/// d#43
 fn Decoder_opentype_gdef_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11431,7 +11869,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5673845796627816005u64));
+return Err(ParseError::FalsifiedWhere(7801539417877429212u64));
 }
 };
 let minor_version = {
@@ -11476,7 +11914,7 @@ opentype_gdef_table_data::Version1_0
 },
 
 1u16 => {
-return Err(ParseError::FailToken(14591018267292443527u64));
+return Err(ParseError::FailToken(14931240509007516758u64));
 },
 
 2u16 => {
@@ -11543,7 +11981,7 @@ opentype_gdef_table_data::Version1_3(inner)
 PResult::Ok(opentype_gdef_table { table_scope, major_version, minor_version, glyph_class_def, attach_list, lig_caret_list, mark_attach_class_def, data })
 }
 
-/// d#42
+/// d#44
 fn Decoder_opentype_gpos_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gpos_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11559,7 +11997,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4762692522317026931u64));
+return Err(ParseError::FalsifiedWhere(11328034188734904930u64));
 }
 };
 let minor_version = {
@@ -11603,7 +12041,7 @@ None
 PResult::Ok(opentype_gpos_table { table_scope, major_version, minor_version, script_list, feature_list, lookup_list, feature_variations_offset })
 }
 
-/// d#43
+/// d#45
 fn Decoder_opentype_gsub_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gsub_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11619,7 +12057,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9630069758457681762u64));
+return Err(ParseError::FalsifiedWhere(1338347005175300217u64));
 }
 };
 let minor_version = {
@@ -11663,7 +12101,7 @@ None
 PResult::Ok(opentype_gsub_table { table_scope, major_version, minor_version, script_list, feature_list, lookup_list, feature_variations_offset })
 }
 
-/// d#44
+/// d#46
 fn Decoder_opentype_fvar_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_fvar_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11679,7 +12117,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(908377722732597655u64));
+return Err(ParseError::FalsifiedWhere(15432825464810477099u64));
 }
 };
 let minor_version = {
@@ -11694,7 +12132,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3203034260088513018u64));
+return Err(ParseError::FalsifiedWhere(8987822076696059625u64));
 }
 };
 let offset_axes = {
@@ -11709,7 +12147,7 @@ raw > 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14677505873656710393u64));
+return Err(ParseError::FalsifiedWhere(10078755145706786000u64));
 }
 };
 {
@@ -11724,7 +12162,7 @@ x == 2u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10102114574336663273u64));
+return Err(ParseError::FalsifiedWhere(1977899765720151190u64));
 }
 };
 let axis_count = {
@@ -11743,7 +12181,7 @@ x == 20u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4386762582485017400u64));
+return Err(ParseError::FalsifiedWhere(7343323033370781545u64));
 }
 };
 let instance_count = {
@@ -11761,7 +12199,7 @@ let _instances = std::marker::PhantomData;
 PResult::Ok(opentype_fvar_table { table_scope, major_version, minor_version, offset_axes, axis_count, axis_size, instance_count, instance_size, _axes, offset_instances, _instances })
 }
 
-/// d#45
+/// d#47
 fn Decoder_opentype_gvar_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gvar_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11777,7 +12215,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8893850231119365992u64));
+return Err(ParseError::FalsifiedWhere(12890902517277365935u64));
 }
 };
 let minor_version = {
@@ -11792,7 +12230,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7659860344311718435u64));
+return Err(ParseError::FalsifiedWhere(13049534979177835905u64));
 }
 };
 let axis_count = {
@@ -11862,7 +12300,7 @@ let _glyph_variation_data_array = std::marker::PhantomData;
 PResult::Ok(opentype_gvar_table { table_scope, major_version, minor_version, axis_count, shared_tuple_count, shared_tuples, glyph_count, flags, glyph_variation_data_array_offset, glyph_variation_data_offsets, _glyph_variation_data_array })
 }
 
-/// d#46
+/// d#48
 fn Decoder_opentype_kern_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_kern_table<'input>, ParseError> {
 let version = {
 let inner = {
@@ -11876,7 +12314,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11052099086134529863u64));
+return Err(ParseError::FalsifiedWhere(9011855507994367971u64));
 }
 };
 let n_tables = {
@@ -11894,7 +12332,7 @@ accum
 PResult::Ok(opentype_kern_table { version, n_tables, subtables })
 }
 
-/// d#47
+/// d#49
 fn Decoder_opentype_stat_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_stat_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -11910,7 +12348,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1079884235207081886u64));
+return Err(ParseError::FalsifiedWhere(14796083725261108356u64));
 }
 };
 let minor_version = {
@@ -11925,7 +12363,7 @@ matches!(x, 1u16 | 2u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(980800817911480223u64));
+return Err(ParseError::FalsifiedWhere(2879885114680241844u64));
 }
 };
 let design_axis_size = {
@@ -11963,8 +12401,8 @@ u16be(x)
 PResult::Ok(opentype_stat_table { table_scope, major_version, minor_version, design_axis_size, design_axis_count, design_axes, axis_value_count, axis_value_offsets, elided_fallback_name_id })
 }
 
-/// d#48
-fn Decoder48(_input: &mut Parser<'_>) -> Result<opentype_hhea_table, ParseError> {
+/// d#50
+fn Decoder50(_input: &mut Parser<'_>) -> Result<opentype_hhea_table, ParseError> {
 let major_version = {
 let inner = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -11977,7 +12415,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9042484249406774160u64));
+return Err(ParseError::FalsifiedWhere(14009314771729697611u64));
 }
 };
 let minor_version = {
@@ -11992,51 +12430,78 @@ matches!(x, 0u16 | 4096u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7801539417877429212u64));
+return Err(ParseError::FalsifiedWhere(10973085168168570837u64));
 }
 };
 let ascent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let descent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let line_gap = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let advance_width_max = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let min_left_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let min_right_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let x_max_extent = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let caret_slope = {
 let rise = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let run = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_hhea_table_caret_slope { rise, run }
 };
 let caret_offset = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 {
 let arg0 = {
@@ -12051,7 +12516,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14931240509007516758u64));
+return Err(ParseError::FalsifiedWhere(10603707580403307601u64));
 }
 };
 let arg1 = {
@@ -12066,7 +12531,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11328034188734904930u64));
+return Err(ParseError::FalsifiedWhere(18065118697073160549u64));
 }
 };
 let arg2 = {
@@ -12081,7 +12546,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1338347005175300217u64));
+return Err(ParseError::FalsifiedWhere(10686389193617118447u64));
 }
 };
 let arg3 = {
@@ -12096,7 +12561,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15432825464810477099u64));
+return Err(ParseError::FalsifiedWhere(16128388243093908143u64));
 }
 };
 (arg0, arg1, arg2, arg3)
@@ -12113,7 +12578,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8987822076696059625u64));
+return Err(ParseError::FalsifiedWhere(2818918064991511645u64));
 }
 };
 let number_of_long_metrics = {
@@ -12123,8 +12588,8 @@ u16be(x)
 PResult::Ok(opentype_hhea_table { major_version, minor_version, ascent, descent, line_gap, advance_width_max, min_left_side_bearing, min_right_side_bearing, x_max_extent, caret_slope, caret_offset, metric_data_format, number_of_long_metrics })
 }
 
-/// d#49
-fn Decoder49(_input: &mut Parser<'_>, num_long_metrics: u16, num_glyphs: u16) -> Result<opentype_hmtx_table, ParseError> {
+/// d#51
+fn Decoder51(_input: &mut Parser<'_>, num_long_metrics: u16, num_glyphs: u16) -> Result<opentype_hmtx_table, ParseError> {
 let long_metrics = {
 let mut accum = Vec::new();
 for _ in 0..num_long_metrics {
@@ -12134,8 +12599,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let left_side_bearing = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_hmtx_table_long_metrics { advance_width, left_side_bearing }
 };
@@ -12147,8 +12615,11 @@ let left_side_bearings = {
 let mut accum = Vec::new();
 for _ in 0..try_sub!(num_glyphs, num_long_metrics, 11876854719037224982u64) {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -12157,13 +12628,13 @@ accum
 PResult::Ok(opentype_hmtx_table { long_metrics, left_side_bearings })
 }
 
-/// d#50
+/// d#52
 fn Decoder_opentype_stat_design_axes_array(_input: &mut Parser<'_>, design_axis_count: u16) -> Result<opentype_stat_design_axes_array, ParseError> {
 let design_axes = {
 let mut accum = Vec::new();
 for _ in 0..design_axis_count {
 let next_elem = {
-let axis_tag = (Decoder53(_input))?;
+let axis_tag = (Decoder55(_input))?;
 let axis_name_id = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
@@ -12181,7 +12652,7 @@ accum
 PResult::Ok(opentype_stat_design_axes_array { design_axes })
 }
 
-/// d#51
+/// d#53
 fn Decoder_opentype_stat_axis_value_array<'input>(_input: &mut Parser<'input>, axis_value_count: u16) -> Result<opentype_stat_axis_value_array<'input>, ParseError> {
 let array_view = _input.view();
 let array_scope = array_view;
@@ -12203,7 +12674,7 @@ accum
 PResult::Ok(opentype_stat_axis_value_array { array_scope, axis_values })
 }
 
-/// d#52
+/// d#54
 fn Decoder_opentype_stat_axis_value_table(_input: &mut Parser<'_>) -> Result<opentype_stat_axis_value_table, ParseError> {
 let format = {
 let inner = {
@@ -12217,7 +12688,7 @@ matches!(x, 1u16..=4u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10078755145706786000u64));
+return Err(ParseError::FalsifiedWhere(14082539304789607227u64));
 }
 };
 let data = match format {
@@ -12387,13 +12858,13 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(opentype_stat_axis_value_table { format, data })
 }
 
-/// d#53
-fn Decoder53(_input: &mut Parser<'_>) -> Result<u32, ParseError> {
+/// d#55
+fn Decoder55(_input: &mut Parser<'_>) -> Result<u32, ParseError> {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 PResult::Ok(u32be(x))
 }
 
-/// d#54
+/// d#56
 fn Decoder_opentype_kern_kern_subtable<'input>(_input: &mut Parser<'input>) -> Result<opentype_kern_kern_subtable<'input>, ParseError> {
 let version = {
 let inner = {
@@ -12407,7 +12878,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1977899765720151190u64));
+return Err(ParseError::FalsifiedWhere(11072034178440885507u64));
 }
 };
 let length = {
@@ -12438,13 +12909,13 @@ opentype_kern_kern_subtable_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(7343323033370781545u64));
+return Err(ParseError::FailToken(4608405370414018463u64));
 }
 };
 PResult::Ok(opentype_kern_kern_subtable { version, length, coverage, data })
 }
 
-/// d#55
+/// d#57
 fn Decoder_opentype_kern_subtable_format0(_input: &mut Parser<'_>) -> Result<opentype_kern_subtable_format0, ParseError> {
 let n_pairs = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -12475,8 +12946,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let value = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_kern_subtable_format0_kern_pairs { left, right, value }
 };
@@ -12487,7 +12961,7 @@ accum
 PResult::Ok(opentype_kern_subtable_format0 { n_pairs, search_range, entry_selector, range_shift, kern_pairs })
 }
 
-/// d#56
+/// d#58
 fn Decoder_opentype_kern_subtable_format2<'input>(_input: &mut Parser<'input>) -> Result<opentype_kern_subtable_format2<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -12522,7 +12996,7 @@ opentype_kern_subtable_format2_kerning_array_offset { offset, _data }
 PResult::Ok(opentype_kern_subtable_format2 { table_scope, row_width, left_class_offset, right_class_offset, kerning_array_offset })
 }
 
-/// d#57
+/// d#59
 fn Decoder_opentype_kern_class_table(_input: &mut Parser<'_>) -> Result<opentype_kern_class_table, ParseError> {
 let first_glyph = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -12546,7 +13020,7 @@ accum
 PResult::Ok(opentype_kern_class_table { first_glyph, n_glyphs, class_values })
 }
 
-/// d#58
+/// d#60
 fn Decoder_opentype_kern_kerning_array(_input: &mut Parser<'_>, left_glyph_count: u16, right_glyph_count: u16) -> Result<opentype_kern_kerning_array, ParseError> {
 let left_glyph_count = left_glyph_count;
 let right_glyph_count = right_glyph_count;
@@ -12557,8 +13031,11 @@ let next_elem = {
 let mut accum = Vec::new();
 for _ in 0..right_glyph_count {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -12571,7 +13048,7 @@ accum
 PResult::Ok(opentype_kern_kerning_array { left_glyph_count, right_glyph_count, kerning_values })
 }
 
-/// d#59
+/// d#61
 fn Decoder_opentype_gvar_tuple_record(_input: &mut Parser<'_>, axis_count: u16) -> Result<opentype_gvar_tuple_record, ParseError> {
 let coordinates = {
 let mut accum = Vec::new();
@@ -12590,7 +13067,7 @@ accum
 PResult::Ok(opentype_gvar_tuple_record { coordinates })
 }
 
-/// d#60
+/// d#62
 fn Decoder_opentype_gvar_glyph_variation_data<'input>(_input: &mut Parser<'input>, axis_count: u16) -> Result<opentype_gvar_glyph_variation_data<'input>, ParseError> {
 let data_view = _input.view();
 let data_scope = data_view;
@@ -12615,7 +13092,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12890902517277365935u64));
+return Err(ParseError::FalsifiedWhere(4418518334087228745u64));
 }
 };
 let tuple_variation_headers = {
@@ -12630,7 +13107,7 @@ let _data = std::marker::PhantomData;
 PResult::Ok(opentype_gvar_glyph_variation_data { data_scope, tuple_variation_count, data_offset, tuple_variation_headers, _data })
 }
 
-/// d#61
+/// d#63
 fn Decoder_opentype_gvar_tuple_variation_header(_input: &mut Parser<'_>, axis_count: u16) -> Result<opentype_gvar_tuple_variation_header, ParseError> {
 let variation_data_size = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -12662,10 +13139,10 @@ None
 PResult::Ok(opentype_gvar_tuple_variation_header { variation_data_size, tuple_index, peak_tuple, intermediate_tuples })
 }
 
-/// d#62
+/// d#64
 fn Decoder_opentype_gvar_serialized_data(_input: &mut Parser<'_>, shared_point_numbers: bool, tuple_var_headers: &[opentype_gvar_tuple_variation_header]) -> Result<opentype_gvar_serialized_data, ParseError> {
 let shared_point_numbers = if shared_point_numbers {
-Some((Decoder63(_input))?)
+Some((Decoder65(_input))?)
 } else {
 None
 };
@@ -12677,7 +13154,7 @@ let sz = header.variation_data_size as usize;
 _input.start_slice(sz)?;
 let ret = ((|| {
 let private_point_numbers = if header.tuple_index.private_point_numbers {
-Some((Decoder63(_input))?)
+Some((Decoder65(_input))?)
 } else {
 None
 };
@@ -12735,8 +13212,11 @@ let inner = {
 let mut accum = Vec::new();
 for _ in 0..run_length {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -12749,7 +13229,10 @@ false => {
 let inner = {
 let mut accum = Vec::new();
 for _ in 0..run_length {
-let next_elem = _input.read_byte()?;
+let next_elem = {
+let raw = _input.read_byte()?;
+raw as i8
+};
 accum.push(next_elem)
 };
 accum
@@ -12783,8 +13266,8 @@ accum
 PResult::Ok(opentype_gvar_serialized_data { shared_point_numbers, per_tuple_variation_data })
 }
 
-/// d#63
-fn Decoder63(_input: &mut Parser<'_>) -> Result<(u16, Vec<opentype_var_packed_point_numbers_runs>), ParseError> {
+/// d#65
+fn Decoder65(_input: &mut Parser<'_>) -> Result<(u16, Vec<opentype_var_packed_point_numbers_runs>), ParseError> {
 let tree_index = {
 _input.open_peek_context();
 {
@@ -12802,7 +13285,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 18446744073709551615u64, 1844674407370
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2879885114680241844u64));
+return Err(ParseError::ExcludedBranch(15557503981608772456u64));
 }
 };
 _input.close_peek_context()?;
@@ -12816,7 +13299,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13049534979177835905u64));
+return Err(ParseError::ExcludedBranch(7086880279337729577u64));
 }
 };
 (0u16, [].to_vec())
@@ -12828,10 +13311,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744073709551614u64, 18446744073709551615u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9011855507994367971u64));
+return Err(ParseError::ExcludedBranch(7511456693437940214u64));
 }
 };
-(Decoder64(_input, point_count as u16))?
+(Decoder66(_input, point_count as u16))?
 },
 
 2 => {
@@ -12840,21 +13323,21 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 0u64, 18446744073709551615u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14796083725261108356u64));
+return Err(ParseError::ExcludedBranch(973408085875818710u64));
 }
 };
 let lo = _input.read_byte()?;
-(Decoder64(_input, ((hi as u16) & 127u16) << 8u16 | (lo as u16)))?
+(Decoder66(_input, ((hi as u16) & 127u16) << 8u16 | (lo as u16)))?
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14009314771729697611u64));
+return Err(ParseError::ExcludedBranch(2154669163482751322u64));
 }
 })
 }
 
-/// d#64
-fn Decoder64(_input: &mut Parser<'_>, point_count: u16) -> Result<(u16, Vec<opentype_var_packed_point_numbers_runs>), ParseError> {
+/// d#66
+fn Decoder66(_input: &mut Parser<'_>, point_count: u16) -> Result<(u16, Vec<opentype_var_packed_point_numbers_runs>), ParseError> {
 let mut seq: Vec<opentype_var_packed_point_numbers_runs> = Vec::new();
 let mut acc = 0u16;
 loop {
@@ -12879,7 +13362,7 @@ seq.push(elem)
 PResult::Ok((acc, seq))
 }
 
-/// d#65
+/// d#67
 fn Decoder_opentype_var_packed_point_numbers_runs(_input: &mut Parser<'_>) -> Result<opentype_var_packed_point_numbers_runs, ParseError> {
 let control = {
 let _packed_bits = _input.read_byte()?;
@@ -12921,9 +13404,9 @@ opentype_var_packed_point_numbers_run_points::Points8(inner)
 PResult::Ok(opentype_var_packed_point_numbers_runs { control, points })
 }
 
-/// d#66
+/// d#68
 fn Decoder_opentype_fvar_variation_axis_record(_input: &mut Parser<'_>) -> Result<opentype_fvar_variation_axis_record, ParseError> {
-let axis_tag = (Decoder53(_input))?;
+let axis_tag = (Decoder55(_input))?;
 let min_value = {
 let inner = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -12960,7 +13443,7 @@ u16be(x)
 PResult::Ok(opentype_fvar_variation_axis_record { axis_tag, min_value, default_value, max_value, flags, axis_name_id })
 }
 
-/// d#67
+/// d#69
 fn Decoder_opentype_fvar_instance_record(_input: &mut Parser<'_>, axis_count: u16, instance_size: u16) -> Result<opentype_fvar_instance_record, ParseError> {
 let subfamily_nameid = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -12978,7 +13461,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10973085168168570837u64));
+return Err(ParseError::FalsifiedWhere(10263667190582992611u64));
 }
 };
 let coordinates = (Decoder_opentype_fvar_user_tuple(_input, axis_count))?;
@@ -12991,7 +13474,7 @@ None
 PResult::Ok(opentype_fvar_instance_record { subfamily_nameid, flags, coordinates, postscript_nameid })
 }
 
-/// d#68
+/// d#70
 fn Decoder_opentype_fvar_user_tuple(_input: &mut Parser<'_>, axis_count: u16) -> Result<opentype_fvar_user_tuple, ParseError> {
 let coordinates = {
 let mut accum = Vec::new();
@@ -13010,7 +13493,7 @@ accum
 PResult::Ok(opentype_fvar_user_tuple { coordinates })
 }
 
-/// d#69
+/// d#71
 fn Decoder_opentype_layout_script_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_script_list<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13029,7 +13512,7 @@ accum
 PResult::Ok(opentype_layout_script_list { table_scope, script_count, script_records })
 }
 
-/// d#70
+/// d#72
 fn Decoder_opentype_layout_feature_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_feature_list<'input>, ParseError> {
 let list_view = _input.view();
 let list_scope = list_view;
@@ -13048,7 +13531,7 @@ accum
 PResult::Ok(opentype_layout_feature_list { list_scope, feature_count, feature_records })
 }
 
-/// d#71
+/// d#73
 fn Decoder_opentype_gsub_lookup_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_gsub_lookup_list<'input>, ParseError> {
 let list_view = _input.view();
 let list_scope = list_view;
@@ -13074,7 +13557,7 @@ accum
 PResult::Ok(opentype_gsub_lookup_list { list_scope, lookup_count, lookups })
 }
 
-/// d#72
+/// d#74
 fn Decoder_opentype_layout_feature_variations<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_feature_variations<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13090,7 +13573,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10603707580403307601u64));
+return Err(ParseError::FalsifiedWhere(5482396765248532989u64));
 }
 };
 let minor_version = {
@@ -13105,7 +13588,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18065118697073160549u64));
+return Err(ParseError::FalsifiedWhere(12275201028130973875u64));
 }
 };
 let feature_variation_record_count = {
@@ -13123,7 +13606,7 @@ accum
 PResult::Ok(opentype_layout_feature_variations { table_scope, major_version, minor_version, feature_variation_record_count, feature_variation_records })
 }
 
-/// d#73
+/// d#75
 fn Decoder_opentype_layout_feature_variation_record<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_feature_variation_record<'input>, ParseError> {
 let condition_set = {
 let offset = {
@@ -13144,7 +13627,7 @@ opentype_layout_feature_variation_record_feature_table_substitution { offset, _d
 PResult::Ok(opentype_layout_feature_variation_record { condition_set, feature_table_substitution })
 }
 
-/// d#74
+/// d#76
 fn Decoder_opentype_layout_feature_table_substitution<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_feature_table_substitution<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13160,7 +13643,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10686389193617118447u64));
+return Err(ParseError::FalsifiedWhere(16097120758067046920u64));
 }
 };
 let minor_version = {
@@ -13175,7 +13658,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16128388243093908143u64));
+return Err(ParseError::FalsifiedWhere(9331632426086095927u64));
 }
 };
 let substitution_count = {
@@ -13193,7 +13676,7 @@ accum
 PResult::Ok(opentype_layout_feature_table_substitution { table_scope, major_version, minor_version, substitution_count, substitutions })
 }
 
-/// d#75
+/// d#77
 fn Decoder_opentype_layout_feature_table_substitution_record<'input>(_input: &mut Parser<'input>, _table_view: View<'input>) -> Result<opentype_layout_feature_table_substitution_record<'input>, ParseError> {
 let feature_index = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -13207,7 +13690,7 @@ let alternate_feature = std::marker::PhantomData;
 PResult::Ok(opentype_layout_feature_table_substitution_record { feature_index, alternate_feature_offset, alternate_feature })
 }
 
-/// d#76
+/// d#78
 fn Decoder_opentype_layout_feature_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_feature_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13233,7 +13716,7 @@ accum
 PResult::Ok(opentype_layout_feature_table { table_scope, feature_params, lookup_index_count, lookup_list_indices })
 }
 
-/// d#77
+/// d#79
 fn Decoder_opentype_gsub_lookup_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gsub_lookup_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13286,7 +13769,7 @@ None
 PResult::Ok(opentype_gsub_lookup_table { table_scope, lookup_type, lookup_flag, sub_table_count, subtables, mark_filtering_set })
 }
 
-/// d#78
+/// d#80
 fn Decoder_opentype_gsub_lookup_subtable<'input>(_input: &mut Parser<'input>, lookup_type: u16) -> Result<opentype_gsub_lookup_subtable<'input>, ParseError> {
 PResult::Ok(match lookup_type {
 7u16 => {
@@ -13301,7 +13784,7 @@ opentype_gsub_lookup_subtable::GroundSubst(inner)
 })
 }
 
-/// d#79
+/// d#81
 fn Decoder_opentype_layout_subst_extension<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_subst_extension<'input>, ParseError> {
 let table_view = _input.view();
 let format = {
@@ -13316,7 +13799,7 @@ format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2818918064991511645u64));
+return Err(ParseError::FalsifiedWhere(14959848987246965519u64));
 }
 };
 let table_scope = table_view;
@@ -13332,7 +13815,7 @@ matches!(x, 1u16..=6u16 | 8)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14082539304789607227u64));
+return Err(ParseError::FalsifiedWhere(9092905213558799443u64));
 }
 };
 let extension_offset = {
@@ -13346,7 +13829,7 @@ opentype_layout_subst_extension_extension_offset { offset, _data }
 PResult::Ok(opentype_layout_subst_extension { format, table_scope, extension_lookup_type, extension_offset })
 }
 
-/// d#80
+/// d#82
 fn Decoder_opentype_layout_ground_subst<'input>(_input: &mut Parser<'input>, lookup_type: u16) -> Result<opentype_layout_ground_subst<'input>, ParseError> {
 PResult::Ok(match lookup_type {
 1u16 => {
@@ -13385,16 +13868,16 @@ opentype_layout_ground_subst::ReverseChainSingleSubst(inner)
 },
 
 7u16 => {
-return Err(ParseError::FailToken(11072034178440885507u64));
+return Err(ParseError::FailToken(17544092807091201u64));
 },
 
 _ => {
-return Err(ParseError::FailToken(4608405370414018463u64));
+return Err(ParseError::FailToken(10502127387712395480u64));
 }
 })
 }
 
-/// d#81
+/// d#83
 fn Decoder_opentype_layout_single_subst<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_single_subst<'input>, ParseError> {
 let table_view = _input.view();
 let subst_format = {
@@ -13413,13 +13896,13 @@ opentype_layout_single_subst_subst::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(4418518334087228745u64));
+return Err(ParseError::FailToken(14454034443522724586u64));
 }
 };
 PResult::Ok(opentype_layout_single_subst { subst_format, subst })
 }
 
-/// d#82
+/// d#84
 fn Decoder_opentype_layout_multiple_subst<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_multiple_subst<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13466,7 +13949,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(opentype_layout_multiple_subst { table_scope, subst_format, coverage, subst })
 }
 
-/// d#83
+/// d#85
 fn Decoder_opentype_gsub_alternate_subst<'input>(_input: &mut Parser<'input>) -> Result<opentype_gsub_alternate_subst<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13482,7 +13965,7 @@ subst_format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7086880279337729577u64));
+return Err(ParseError::FalsifiedWhere(5322124757500927073u64));
 }
 };
 let coverage = {
@@ -13515,7 +13998,7 @@ accum
 PResult::Ok(opentype_gsub_alternate_subst { table_scope, subst_format, coverage, alternate_set_count, alternate_sets })
 }
 
-/// d#84
+/// d#86
 fn Decoder_opentype_layout_ligature_subst<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_ligature_subst<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13531,7 +14014,7 @@ subst_format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7511456693437940214u64));
+return Err(ParseError::FalsifiedWhere(17869550927478639832u64));
 }
 };
 let coverage = {
@@ -13564,7 +14047,7 @@ accum
 PResult::Ok(opentype_layout_ligature_subst { table_scope, subst_format, coverage, ligature_set_count, ligature_sets })
 }
 
-/// d#85
+/// d#87
 fn Decoder_opentype_layout_sequence_context<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_sequence_context<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13589,13 +14072,13 @@ opentype_layout_sequence_context_subst::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(973408085875818710u64));
+return Err(ParseError::FailToken(13431462572241034712u64));
 }
 };
 PResult::Ok(opentype_layout_sequence_context { table_scope, format, subst })
 }
 
-/// d#86
+/// d#88
 fn Decoder_opentype_layout_chained_sequence_context<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_chained_sequence_context<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -13620,13 +14103,13 @@ opentype_layout_chained_sequence_context_subst::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(15557503981608772456u64));
+return Err(ParseError::FailToken(3433937857563719729u64));
 }
 };
 PResult::Ok(opentype_layout_chained_sequence_context { table_scope, format, subst })
 }
 
-/// d#87
+/// d#89
 fn Decoder_opentype_layout_reverse_chain_single_subst<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_reverse_chain_single_subst<'input>, ParseError> {
 let table_view = _input.view();
 let subst_format = {
@@ -13641,7 +14124,7 @@ subst_format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2154669163482751322u64));
+return Err(ParseError::FalsifiedWhere(13516986665125759073u64));
 }
 };
 let table_scope = table_view;
@@ -13709,7 +14192,7 @@ accum
 PResult::Ok(opentype_layout_reverse_chain_single_subst { subst_format, table_scope, coverage, backtrack_glyph_count, backtrack_coverage_tables, lookahead_glyph_count, lookahead_coverage_tables, glyph_count, substitute_glyph_ids })
 }
 
-/// d#88
+/// d#90
 fn Decoder_opentype_coverage_table(_input: &mut Parser<'_>) -> Result<opentype_coverage_table, ParseError> {
 let coverage_format = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -13772,13 +14255,13 @@ opentype_coverage_table_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(10263667190582992611u64));
+return Err(ParseError::FailToken(14751251992141172493u64));
 }
 };
 PResult::Ok(opentype_coverage_table { coverage_format, data })
 }
 
-/// d#89
+/// d#91
 fn Decoder_opentype_layout_chained_sequence_context_format1<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_chained_sequence_context_format1<'input>, ParseError> {
 let coverage = {
 let offset = {
@@ -13810,7 +14293,7 @@ accum
 PResult::Ok(opentype_layout_chained_sequence_context_format1 { coverage, chained_seq_rule_set_count, chained_seq_rule_sets })
 }
 
-/// d#90
+/// d#92
 fn Decoder_opentype_layout_chained_sequence_context_format2<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_chained_sequence_context_format2<'input>, ParseError> {
 let coverage = {
 let offset = {
@@ -13866,7 +14349,7 @@ accum
 PResult::Ok(opentype_layout_chained_sequence_context_format2 { coverage, backtrack_class_def, input_class_def, lookahead_class_def, chained_class_seq_rule_set_count, chained_class_seq_rule_sets })
 }
 
-/// d#91
+/// d#93
 fn Decoder_opentype_layout_chained_sequence_context_format3<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_chained_sequence_context_format3, ParseError> {
 let backtrack_glyph_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -13940,7 +14423,7 @@ accum
 PResult::Ok(opentype_layout_chained_sequence_context_format3 { backtrack_glyph_count, backtrack_coverages, input_glyph_count, input_coverages, lookahead_glyph_count, lookahead_coverages, seq_lookup_count, seq_lookup_records })
 }
 
-/// d#92
+/// d#94
 fn Decoder_opentype_layout_sequence_lookup(_input: &mut Parser<'_>) -> Result<opentype_layout_sequence_lookup, ParseError> {
 let sequence_index = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -13953,7 +14436,7 @@ u16be(x)
 PResult::Ok(opentype_layout_sequence_lookup { sequence_index, lookup_list_index })
 }
 
-/// d#93
+/// d#95
 fn Decoder_opentype_class_def(_input: &mut Parser<'_>) -> Result<opentype_class_def, ParseError> {
 let class_format = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14020,13 +14503,13 @@ opentype_class_def_data::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(5482396765248532989u64));
+return Err(ParseError::FailToken(5733880678136728614u64));
 }
 };
 PResult::Ok(opentype_class_def { class_format, data })
 }
 
-/// d#94
+/// d#96
 fn Decoder_opentype_layout_chained_sequence_rule_set<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_chained_sequence_rule_set<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -14052,7 +14535,7 @@ accum
 PResult::Ok(opentype_layout_chained_sequence_rule_set { table_scope, chained_seq_rule_count, chained_seq_rules })
 }
 
-/// d#95
+/// d#97
 fn Decoder_opentype_layout_chained_sequence_rule(_input: &mut Parser<'_>) -> Result<opentype_layout_chained_sequence_rule, ParseError> {
 let backtrack_glyph_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14114,7 +14597,7 @@ accum
 PResult::Ok(opentype_layout_chained_sequence_rule { backtrack_glyph_count, backtrack_sequence, input_glyph_count, input_sequence, lookahead_glyph_count, lookahead_sequence, seq_lookup_count, seq_lookup_records })
 }
 
-/// d#96
+/// d#98
 fn Decoder_opentype_layout_sequence_context_format1<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_sequence_context_format1<'input>, ParseError> {
 let coverage = {
 let offset = {
@@ -14146,7 +14629,7 @@ accum
 PResult::Ok(opentype_layout_sequence_context_format1 { coverage, seq_rule_set_count, seq_rule_sets })
 }
 
-/// d#97
+/// d#99
 fn Decoder_opentype_layout_sequence_context_format2<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_sequence_context_format2<'input>, ParseError> {
 let coverage = {
 let offset = {
@@ -14186,7 +14669,7 @@ accum
 PResult::Ok(opentype_layout_sequence_context_format2 { coverage, class_def, class_seq_rule_set_count, class_seq_rule_sets })
 }
 
-/// d#98
+/// d#100
 fn Decoder_opentype_layout_sequence_context_format3<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_sequence_context_format3, ParseError> {
 let glyph_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14222,7 +14705,7 @@ accum
 PResult::Ok(opentype_layout_sequence_context_format3 { glyph_count, seq_lookup_count, coverage_tables, seq_lookup_records })
 }
 
-/// d#99
+/// d#101
 fn Decoder_opentype_layout_sequence_context_rule_set<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_sequence_context_rule_set<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -14248,7 +14731,7 @@ accum
 PResult::Ok(opentype_layout_sequence_context_rule_set { table_scope, rule_count, rules })
 }
 
-/// d#100
+/// d#102
 fn Decoder_opentype_layout_sequence_context_rule(_input: &mut Parser<'_>) -> Result<opentype_layout_sequence_context_rule, ParseError> {
 let glyph_count = {
 let inner = {
@@ -14262,7 +14745,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12275201028130973875u64));
+return Err(ParseError::FalsifiedWhere(8997881400116719018u64));
 }
 };
 let seq_lookup_count = {
@@ -14291,7 +14774,7 @@ accum
 PResult::Ok(opentype_layout_sequence_context_rule { glyph_count, seq_lookup_count, input_sequence, seq_lookup_records })
 }
 
-/// d#101
+/// d#103
 fn Decoder_opentype_gsub_ligature_subst_ligature_set<'input>(_input: &mut Parser<'input>) -> Result<opentype_gsub_ligature_subst_ligature_set<'input>, ParseError> {
 let set_view = _input.view();
 let set_scope = set_view;
@@ -14317,7 +14800,7 @@ accum
 PResult::Ok(opentype_gsub_ligature_subst_ligature_set { set_scope, ligature_count, ligatures })
 }
 
-/// d#102
+/// d#104
 fn Decoder_opentype_gsub_ligature_subst_ligature_table(_input: &mut Parser<'_>) -> Result<opentype_gsub_ligature_subst_ligature_table, ParseError> {
 let ligature_glyph = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14341,7 +14824,7 @@ accum
 PResult::Ok(opentype_gsub_ligature_subst_ligature_table { ligature_glyph, component_count, component_glyph_ids })
 }
 
-/// d#103
+/// d#105
 fn Decoder_opentype_gsub_alternate_subst_alternate_set(_input: &mut Parser<'_>) -> Result<opentype_gsub_alternate_subst_alternate_set, ParseError> {
 let glyph_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14361,7 +14844,7 @@ accum
 PResult::Ok(opentype_gsub_alternate_subst_alternate_set { glyph_count, alternate_glyph_ids })
 }
 
-/// d#104
+/// d#106
 fn Decoder_opentype_layout_multiple_subst_sequence_table(_input: &mut Parser<'_>) -> Result<opentype_layout_multiple_subst_sequence_table, ParseError> {
 let glyph_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14381,7 +14864,7 @@ accum
 PResult::Ok(opentype_layout_multiple_subst_sequence_table { glyph_count, substitute_glyph_ids })
 }
 
-/// d#105
+/// d#107
 fn Decoder_opentype_layout_single_subst_format1<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_single_subst_format1<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -14393,13 +14876,16 @@ let _data = std::marker::PhantomData;
 opentype_gdef_attach_list_coverage { offset, _data }
 };
 let delta_glyph_id = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 PResult::Ok(opentype_layout_single_subst_format1 { table_scope, coverage, delta_glyph_id })
 }
 
-/// d#106
+/// d#108
 fn Decoder_opentype_layout_single_subst_format2<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_single_subst_format2<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -14428,9 +14914,9 @@ accum
 PResult::Ok(opentype_layout_single_subst_format2 { table_scope, coverage, glyph_count, substitute_glyph_ids })
 }
 
-/// d#107
+/// d#109
 fn Decoder_opentype_layout_feature_record<'input>(_input: &mut Parser<'input>, list_view: View<'input>) -> Result<opentype_layout_feature_record<'input>, ParseError> {
-let feature_tag = (Decoder53(_input))?;
+let feature_tag = (Decoder55(_input))?;
 let feature = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14442,9 +14928,9 @@ opentype_layout_feature_record_feature { offset, _data }
 PResult::Ok(opentype_layout_feature_record { feature_tag, feature })
 }
 
-/// d#108
+/// d#110
 fn Decoder_opentype_layout_script_record<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_script_record<'input>, ParseError> {
-let script_tag = (Decoder53(_input))?;
+let script_tag = (Decoder55(_input))?;
 let script = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14456,7 +14942,7 @@ opentype_layout_script_record_script { offset, _data }
 PResult::Ok(opentype_layout_script_record { script_tag, script })
 }
 
-/// d#109
+/// d#111
 fn Decoder_opentype_layout_script_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_script_table<'input>, ParseError> {
 let script_view = _input.view();
 let script_scope = script_view;
@@ -14483,7 +14969,7 @@ accum
 PResult::Ok(opentype_layout_script_table { script_scope, default_lang_sys, lang_sys_count, lang_sys_records })
 }
 
-/// d#110
+/// d#112
 fn Decoder_opentype_layout_langsys(_input: &mut Parser<'_>) -> Result<opentype_layout_langsys, ParseError> {
 let lookup_order_offset = {
 let inner = {
@@ -14497,7 +14983,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16097120758067046920u64));
+return Err(ParseError::FalsifiedWhere(13614619987783239962u64));
 }
 };
 let required_feature_index = {
@@ -14522,9 +15008,9 @@ accum
 PResult::Ok(opentype_layout_langsys { lookup_order_offset, required_feature_index, feature_index_count, feature_indices })
 }
 
-/// d#111
+/// d#113
 fn Decoder_opentype_layout_lang_sys_record<'input>(_input: &mut Parser<'input>, script_view: View<'input>) -> Result<opentype_layout_lang_sys_record, ParseError> {
-let lang_sys_tag = (Decoder53(_input))?;
+let lang_sys_tag = (Decoder55(_input))?;
 let lang_sys = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -14536,7 +15022,7 @@ opentype_layout_script_table_default_lang_sys { offset, _data }
 PResult::Ok(opentype_layout_lang_sys_record { lang_sys_tag, lang_sys })
 }
 
-/// d#112
+/// d#114
 fn Decoder_opentype_gpos_lookup_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_gpos_lookup_list<'input>, ParseError> {
 let list_view = _input.view();
 let list_scope = list_view;
@@ -14562,7 +15048,7 @@ accum
 PResult::Ok(opentype_gpos_lookup_list { list_scope, lookup_count, lookups })
 }
 
-/// d#113
+/// d#115
 fn Decoder_opentype_gpos_lookup_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_gpos_lookup_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -14615,7 +15101,7 @@ None
 PResult::Ok(opentype_gpos_lookup_table { table_scope, lookup_type, lookup_flag, sub_table_count, subtables, mark_filtering_set })
 }
 
-/// d#114
+/// d#116
 fn Decoder_opentype_gpos_lookup_subtable<'input>(_input: &mut Parser<'input>, lookup_type: u16) -> Result<opentype_gpos_lookup_subtable<'input>, ParseError> {
 PResult::Ok(match lookup_type {
 9u16 => {
@@ -14630,7 +15116,7 @@ opentype_gpos_lookup_subtable::GroundPos(inner)
 })
 }
 
-/// d#115
+/// d#117
 fn Decoder_opentype_layout_pos_extension<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_pos_extension<'input>, ParseError> {
 let table_view = _input.view();
 let format = {
@@ -14645,7 +15131,7 @@ format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9331632426086095927u64));
+return Err(ParseError::FalsifiedWhere(6915530142412472120u64));
 }
 };
 let table_scope = table_view;
@@ -14661,7 +15147,7 @@ matches!(x, 1u16..=8u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14959848987246965519u64));
+return Err(ParseError::FalsifiedWhere(6949960292533894002u64));
 }
 };
 let extension_offset = {
@@ -14675,7 +15161,7 @@ opentype_layout_pos_extension_extension_offset { offset, _data }
 PResult::Ok(opentype_layout_pos_extension { format, table_scope, extension_lookup_type, extension_offset })
 }
 
-/// d#116
+/// d#118
 fn Decoder_opentype_layout_ground_pos<'input>(_input: &mut Parser<'input>, lookup_type: u16) -> Result<opentype_layout_ground_pos<'input>, ParseError> {
 PResult::Ok(match lookup_type {
 1u16 => {
@@ -14719,16 +15205,16 @@ opentype_layout_ground_pos::ChainedSequenceContext(inner)
 },
 
 9u16 => {
-return Err(ParseError::FailToken(9092905213558799443u64));
+return Err(ParseError::FailToken(1347174710810305478u64));
 },
 
 _ => {
-return Err(ParseError::FailToken(17544092807091201u64));
+return Err(ParseError::FailToken(8958899994948144829u64));
 }
 })
 }
 
-/// d#117
+/// d#119
 fn Decoder_opentype_layout_single_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_single_pos<'input>, ParseError> {
 let table_view = _input.view();
 let pos_format = {
@@ -14747,13 +15233,13 @@ opentype_layout_single_pos_subtable::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(10502127387712395480u64));
+return Err(ParseError::FailToken(15803403730818557393u64));
 }
 };
 PResult::Ok(opentype_layout_single_pos { pos_format, subtable })
 }
 
-/// d#118
+/// d#120
 fn Decoder_opentype_layout_pair_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_pair_pos<'input>, ParseError> {
 let table_view = _input.view();
 let pos_format = {
@@ -14772,13 +15258,13 @@ opentype_layout_pair_pos_subtable::Format2(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(14454034443522724586u64));
+return Err(ParseError::FailToken(8390724546948265409u64));
 }
 };
 PResult::Ok(opentype_layout_pair_pos { pos_format, subtable })
 }
 
-/// d#119
+/// d#121
 fn Decoder_opentype_layout_cursive_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_cursive_pos<'input>, ParseError> {
 let table_view = _input.view();
 let pos_format = {
@@ -14793,7 +15279,7 @@ pos_format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5322124757500927073u64));
+return Err(ParseError::FalsifiedWhere(6347242493551283856u64));
 }
 };
 let table_scope = table_view;
@@ -14820,7 +15306,7 @@ accum
 PResult::Ok(opentype_layout_cursive_pos { pos_format, table_scope, coverage, entry_exit_count, entry_exit_records })
 }
 
-/// d#120
+/// d#122
 fn Decoder_opentype_layout_mark_base_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_mark_base_pos<'input>, ParseError> {
 let table_view = _input.view();
 let format = {
@@ -14835,7 +15321,7 @@ format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17869550927478639832u64));
+return Err(ParseError::FalsifiedWhere(4251627061094365437u64));
 }
 };
 let table_scope = table_view;
@@ -14878,7 +15364,7 @@ opentype_layout_mark_base_pos_base_array { offset, _data }
 PResult::Ok(opentype_layout_mark_base_pos { format, table_scope, mark_coverage, base_coverage, mark_class_count, mark_array, base_array })
 }
 
-/// d#121
+/// d#123
 fn Decoder_opentype_layout_mark_lig_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_mark_lig_pos<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -14894,7 +15380,7 @@ format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13431462572241034712u64));
+return Err(ParseError::FalsifiedWhere(11915580511665106140u64));
 }
 };
 let mark_coverage = {
@@ -14936,7 +15422,7 @@ opentype_layout_mark_lig_pos_ligature_array { offset, _data }
 PResult::Ok(opentype_layout_mark_lig_pos { table_scope, format, mark_coverage, ligature_coverage, mark_class_count, mark_array, ligature_array })
 }
 
-/// d#122
+/// d#124
 fn Decoder_opentype_layout_mark_mark_pos<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_mark_mark_pos<'input>, ParseError> {
 let table_view = _input.view();
 let format = {
@@ -14951,7 +15437,7 @@ format == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3433937857563719729u64));
+return Err(ParseError::FalsifiedWhere(17324980155911269375u64));
 }
 };
 let table_scope = table_view;
@@ -14994,7 +15480,7 @@ opentype_layout_mark_mark_pos_mark2_array { offset, _data }
 PResult::Ok(opentype_layout_mark_mark_pos { format, table_scope, mark1_coverage, mark2_coverage, mark_class_count, mark1_array, mark2_array })
 }
 
-/// d#123
+/// d#125
 fn Decoder_opentype_layout_mark_array<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_mark_array<'input>, ParseError> {
 let array_view = _input.view();
 let array_scope = array_view;
@@ -15013,7 +15499,7 @@ accum
 PResult::Ok(opentype_layout_mark_array { array_scope, mark_count, mark_records })
 }
 
-/// d#124
+/// d#126
 fn Decoder_opentype_layout_mark2_array<'input>(_input: &mut Parser<'input>, mark_class_count: u16) -> Result<opentype_layout_mark2_array<'input>, ParseError> {
 let array_view = _input.view();
 let array_scope = array_view;
@@ -15032,7 +15518,7 @@ accum
 PResult::Ok(opentype_layout_mark2_array { array_scope, mark2_count, mark2_records })
 }
 
-/// d#125
+/// d#127
 fn Decoder_opentype_layout_mark2_array_mark2_record<'input>(_input: &mut Parser<'input>, mark_class_count: u16, _array_view: View<'input>) -> Result<opentype_layout_mark2_array_mark2_record<'input>, ParseError> {
 let mark2_anchor_offsets = {
 let mut accum = Vec::new();
@@ -15049,7 +15535,7 @@ let _mark2_anchors = std::marker::PhantomData;
 PResult::Ok(opentype_layout_mark2_array_mark2_record { mark2_anchor_offsets, _mark2_anchors })
 }
 
-/// d#126
+/// d#128
 fn Decoder_opentype_layout_anchor_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_anchor_table<'input>, ParseError> {
 let table_view = _input.view();
 let anchor_format = {
@@ -15060,12 +15546,18 @@ let table = match anchor_format {
 1u16 => {
 let inner = {
 let x_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let y_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_layout_anchor_table_table_Format1 { x_coordinate, y_coordinate }
 };
@@ -15075,12 +15567,18 @@ opentype_layout_anchor_table_table::Format1(inner)
 2u16 => {
 let inner = {
 let x_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let y_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let anchor_point = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -15097,22 +15595,28 @@ opentype_layout_anchor_table_table::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(13516986665125759073u64));
+return Err(ParseError::FailToken(17670535809278048255u64));
 }
 };
 PResult::Ok(opentype_layout_anchor_table { anchor_format, table })
 }
 
-/// d#127
+/// d#129
 fn Decoder_opentype_layout_anchor_table_format3<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_anchor_table_format3<'input>, ParseError> {
 let table_scope = table_view;
 let x_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let y_coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let x_device = {
 let offset = {
@@ -15133,7 +15637,7 @@ opentype_gdef_caret_value_data_format3_table { offset, _data }
 PResult::Ok(opentype_layout_anchor_table_format3 { table_scope, x_coordinate, y_coordinate, x_device, y_device })
 }
 
-/// d#128
+/// d#130
 fn Decoder_opentype_common_device_or_variation_index_table(_input: &mut Parser<'_>) -> Result<opentype_common_device_or_variation_index_table, ParseError> {
 let delta_format = {
 _input.open_peek_context();
@@ -15242,7 +15746,7 @@ let b = _input.read_byte()?;
 if b == 128 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14751251992141172493u64));
+return Err(ParseError::ExcludedBranch(2444204717155307095u64));
 }
 };
 let arg1 = {
@@ -15250,7 +15754,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5733880678136728614u64));
+return Err(ParseError::ExcludedBranch(1278184758971178969u64));
 }
 };
 (arg0, arg1)
@@ -15278,7 +15782,7 @@ opentype_common_device_or_variation_index_table::OtherTable(inner)
 })
 }
 
-/// d#129
+/// d#131
 fn Decoder_opentype_layout_mark_record<'input>(_input: &mut Parser<'input>, array_view: View<'input>) -> Result<opentype_layout_mark_record<'input>, ParseError> {
 let mark_class = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -15295,7 +15799,7 @@ opentype_layout_entry_exit_record_entry_anchor { offset, _data }
 PResult::Ok(opentype_layout_mark_record { mark_class, mark_anchor })
 }
 
-/// d#130
+/// d#132
 fn Decoder_opentype_layout_ligature_array<'input>(_input: &mut Parser<'input>, mark_class_count: u16) -> Result<opentype_layout_ligature_array<'input>, ParseError> {
 let array_view = _input.view();
 let array_scope = array_view;
@@ -15319,7 +15823,7 @@ let _ligature_attaches = std::marker::PhantomData;
 PResult::Ok(opentype_layout_ligature_array { array_scope, mark_class_count, ligature_count, ligature_attach_offsets, _ligature_attaches })
 }
 
-/// d#131
+/// d#133
 fn Decoder_opentype_layout_ligature_attach<'input>(_input: &mut Parser<'input>, mark_class_count: u16) -> Result<opentype_layout_ligature_attach<'input>, ParseError> {
 let table_view = _input.view();
 let component_count = {
@@ -15337,7 +15841,7 @@ accum
 PResult::Ok(opentype_layout_ligature_attach { component_count, component_records })
 }
 
-/// d#132
+/// d#134
 fn Decoder_opentype_layout_ligature_attach_component_record<'input>(_input: &mut Parser<'input>, mark_class_count: u16, table_view: View<'input>) -> Result<opentype_layout_ligature_attach_component_record<'input>, ParseError> {
 let record_scope = table_view;
 let ligature_anchor_offsets = {
@@ -15355,7 +15859,7 @@ let _ligature_anchors = std::marker::PhantomData;
 PResult::Ok(opentype_layout_ligature_attach_component_record { record_scope, ligature_anchor_offsets, _ligature_anchors })
 }
 
-/// d#133
+/// d#135
 fn Decoder_opentype_layout_base_array<'input>(_input: &mut Parser<'input>, mark_class_count: u16) -> Result<opentype_layout_base_array<'input>, ParseError> {
 let array_view = _input.view();
 let array_scope = array_view;
@@ -15374,7 +15878,7 @@ accum
 PResult::Ok(opentype_layout_base_array { array_scope, base_count, base_records })
 }
 
-/// d#134
+/// d#136
 fn Decoder_opentype_layout_base_array_base_record<'input>(_input: &mut Parser<'input>, mark_class_count: u16, _array_view: View<'input>) -> Result<opentype_layout_base_array_base_record<'input>, ParseError> {
 let base_anchor_offsets = {
 let mut accum = Vec::new();
@@ -15391,7 +15895,7 @@ let _base_anchors = std::marker::PhantomData;
 PResult::Ok(opentype_layout_base_array_base_record { base_anchor_offsets, _base_anchors })
 }
 
-/// d#135
+/// d#137
 fn Decoder_opentype_layout_entry_exit_record<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_entry_exit_record<'input>, ParseError> {
 let entry_anchor = {
 let offset = {
@@ -15412,7 +15916,7 @@ opentype_layout_entry_exit_record_entry_anchor { offset, _data }
 PResult::Ok(opentype_layout_entry_exit_record { entry_anchor, exit_anchor })
 }
 
-/// d#136
+/// d#138
 fn Decoder_opentype_layout_pair_pos_format1<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_pair_pos_format1<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -15447,7 +15951,7 @@ accum
 PResult::Ok(opentype_layout_pair_pos_format1 { table_scope, coverage, value_format1, value_format2, pair_set_count, pair_sets })
 }
 
-/// d#137
+/// d#139
 fn Decoder_opentype_layout_pair_pos_format2<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_pair_pos_format2<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -15505,7 +16009,7 @@ accum
 PResult::Ok(opentype_layout_pair_pos_format2 { table_scope, coverage, value_format1, value_format2, class_def1, class_def2, class1_count, class2_count, class1_records })
 }
 
-/// d#138
+/// d#140
 fn Decoder_opentype_layout_value_format_flags(_input: &mut Parser<'_>) -> Result<opentype_layout_value_format_flags, ParseError> {
 let _packed_bits = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -15522,7 +16026,7 @@ let x_placement = _packed_bits & 1u16 > 0u16;
 PResult::Ok(opentype_layout_value_format_flags { y_advance_device, x_advance_device, y_placement_device, x_placement_device, y_advance, x_advance, y_placement, x_placement })
 }
 
-/// d#139
+/// d#141
 fn Decoder_opentype_layout_pair_pos_class2_record<'input>(_input: &mut Parser<'input>, value_format1: opentype_layout_value_format_flags, value_format2: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_pair_pos_class2_record, ParseError> {
 let value_record1 = if value_format1.x_placement || value_format1.y_placement || value_format1.x_advance || value_format1.y_advance || value_format1.x_placement_device || value_format1.y_placement_device || value_format1.x_advance_device || value_format1.y_advance_device {
 Some((Decoder_opentype_layout_value_record(_input, value_format1, table_view))?)
@@ -15530,36 +16034,48 @@ Some((Decoder_opentype_layout_value_record(_input, value_format1, table_view))?)
 None
 };
 let value_record2 = if value_format2.x_placement || value_format2.y_placement || value_format2.x_advance || value_format2.y_advance || value_format2.x_placement_device || value_format2.y_placement_device || value_format2.x_advance_device || value_format2.y_advance_device {
-Some((Decoder141(_input, value_format2, table_view))?)
+Some((Decoder143(_input, value_format2, table_view))?)
 } else {
 None
 };
 PResult::Ok(opentype_layout_pair_pos_class2_record { value_record1, value_record2 })
 }
 
-/// d#140
+/// d#142
 fn Decoder_opentype_layout_value_record<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
 let x_placement = if flags.x_placement {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let y_placement = if flags.y_placement {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let x_advance = if flags.x_advance {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let y_advance = if flags.y_advance {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
@@ -15606,29 +16122,41 @@ None
 PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
 }
 
-/// d#141
-fn Decoder141<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
+/// d#143
+fn Decoder143<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
 let x_placement = if flags.x_placement {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let y_placement = if flags.y_placement {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let x_advance = if flags.x_advance {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
 let y_advance = if flags.y_advance {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
+u16be(x)
+};
+Some(raw as i16)
 } else {
 None
 };
@@ -15675,7 +16203,7 @@ None
 PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
 }
 
-/// d#142
+/// d#144
 fn Decoder_opentype_layout_pair_pos_pair_set<'input>(_input: &mut Parser<'input>, value_format1: opentype_layout_value_format_flags, value_format2: opentype_layout_value_format_flags) -> Result<opentype_layout_pair_pos_pair_set<'input>, ParseError> {
 let set_view = _input.view();
 let set_scope = set_view;
@@ -15694,164 +16222,188 @@ accum
 PResult::Ok(opentype_layout_pair_pos_pair_set { set_scope, pair_value_count, pair_value_records })
 }
 
-/// d#143
+/// d#145
 fn Decoder_opentype_layout_pair_pos_pair_value_record<'input>(_input: &mut Parser<'input>, value_format1: opentype_layout_value_format_flags, value_format2: opentype_layout_value_format_flags, set_view: View<'input>) -> Result<opentype_layout_pair_pos_pair_value_record, ParseError> {
 let second_glyph = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let value_record1 = if value_format1.x_placement || value_format1.y_placement || value_format1.x_advance || value_format1.y_advance || value_format1.x_placement_device || value_format1.y_placement_device || value_format1.x_advance_device || value_format1.y_advance_device {
-Some((Decoder144(_input, value_format1, set_view))?)
+Some((Decoder146(_input, value_format1, set_view))?)
 } else {
 None
 };
 let value_record2 = if value_format2.x_placement || value_format2.y_placement || value_format2.x_advance || value_format2.y_advance || value_format2.x_placement_device || value_format2.y_placement_device || value_format2.x_advance_device || value_format2.y_advance_device {
-Some((Decoder145(_input, value_format2, set_view))?)
+Some((Decoder147(_input, value_format2, set_view))?)
 } else {
 None
 };
 PResult::Ok(opentype_layout_pair_pos_pair_value_record { second_glyph, value_record1, value_record2 })
 }
 
-/// d#144
-fn Decoder144<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
-let x_placement = if flags.x_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_placement = if flags.y_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_advance = if flags.x_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_advance = if flags.y_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_placement_device = if flags.x_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_placement_device = if flags.y_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let x_advance_device = if flags.x_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_advance_device = if flags.y_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
-}
-
-/// d#145
-fn Decoder145<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
-let x_placement = if flags.x_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_placement = if flags.y_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_advance = if flags.x_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_advance = if flags.y_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_placement_device = if flags.x_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_placement_device = if flags.y_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let x_advance_device = if flags.x_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_advance_device = if flags.y_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
-}
-
 /// d#146
+fn Decoder146<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
+let x_placement = if flags.x_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_placement = if flags.y_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_advance = if flags.x_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_advance = if flags.y_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_placement_device = if flags.x_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_placement_device = if flags.y_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let x_advance_device = if flags.x_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_advance_device = if flags.y_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
+}
+
+/// d#147
+fn Decoder147<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
+let x_placement = if flags.x_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_placement = if flags.y_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_advance = if flags.x_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_advance = if flags.y_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_placement_device = if flags.x_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_placement_device = if flags.y_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let x_advance_device = if flags.x_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_advance_device = if flags.y_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
+}
+
+/// d#148
 fn Decoder_opentype_layout_single_pos_format1<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_single_pos_format1<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -15863,11 +16415,11 @@ let _data = std::marker::PhantomData;
 opentype_gdef_attach_list_coverage { offset, _data }
 };
 let value_format = (Decoder_opentype_layout_value_format_flags(_input))?;
-let value_record = (Decoder149(_input, value_format, table_view))?;
+let value_record = (Decoder151(_input, value_format, table_view))?;
 PResult::Ok(opentype_layout_single_pos_format1 { table_scope, coverage, value_format, value_record })
 }
 
-/// d#147
+/// d#149
 fn Decoder_opentype_layout_single_pos_format2<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_single_pos_format2<'input>, ParseError> {
 let table_scope = table_view;
 let coverage = {
@@ -15886,7 +16438,7 @@ u16be(x)
 let value_records = {
 let mut accum = Vec::new();
 for _ in 0..value_count {
-let next_elem = (Decoder148(_input, value_format, table_view))?;
+let next_elem = (Decoder150(_input, value_format, table_view))?;
 accum.push(next_elem)
 };
 accum
@@ -15894,145 +16446,169 @@ accum
 PResult::Ok(opentype_layout_single_pos_format2 { table_scope, coverage, value_format, value_count, value_records })
 }
 
-/// d#148
-fn Decoder148<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
-let x_placement = if flags.x_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_placement = if flags.y_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_advance = if flags.x_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_advance = if flags.y_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_placement_device = if flags.x_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_placement_device = if flags.y_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let x_advance_device = if flags.x_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_advance_device = if flags.y_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
-}
-
-/// d#149
-fn Decoder149<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
-let x_placement = if flags.x_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_placement = if flags.y_placement {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_advance = if flags.x_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let y_advance = if flags.y_advance {
-let x = (_input.read_byte()?, _input.read_byte()?);
-Some(u16be(x))
-} else {
-None
-};
-let x_placement_device = if flags.x_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_placement_device = if flags.y_placement_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let x_advance_device = if flags.x_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-let y_advance_device = if flags.y_advance_device {
-let offset = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16be(x)
-};
-let _data = std::marker::PhantomData;
-Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
-} else {
-None
-};
-PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
-}
-
 /// d#150
+fn Decoder150<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
+let x_placement = if flags.x_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_placement = if flags.y_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_advance = if flags.x_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_advance = if flags.y_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_placement_device = if flags.x_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_placement_device = if flags.y_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let x_advance_device = if flags.x_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_advance_device = if flags.y_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
+}
+
+/// d#151
+fn Decoder151<'input>(_input: &mut Parser<'input>, flags: opentype_layout_value_format_flags, table_view: View<'input>) -> Result<opentype_layout_value_record, ParseError> {
+let x_placement = if flags.x_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_placement = if flags.y_placement {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_advance = if flags.x_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let y_advance = if flags.y_advance {
+let raw = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+Some(raw as i16)
+} else {
+None
+};
+let x_placement_device = if flags.x_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_placement_device = if flags.y_placement_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let x_advance_device = if flags.x_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+let y_advance_device = if flags.y_advance_device {
+let offset = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16be(x)
+};
+let _data = std::marker::PhantomData;
+Some(opentype_gdef_caret_value_data_format3_table { offset, _data })
+} else {
+None
+};
+PResult::Ok(opentype_layout_value_record { x_placement, y_placement, x_advance, y_advance, x_placement_device, y_placement_device, x_advance_device, y_advance_device })
+}
+
+/// d#152
 fn Decoder_opentype_gdef_attach_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_attach_list<'input>, ParseError> {
 let list_view = _input.view();
 let list_scope = list_view;
@@ -16066,7 +16642,7 @@ accum
 PResult::Ok(opentype_gdef_attach_list { list_scope, coverage, glyph_count, attach_point_offsets })
 }
 
-/// d#151
+/// d#153
 fn Decoder_opentype_gdef_lig_caret_list<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_lig_caret_list<'input>, ParseError> {
 let list_view = _input.view();
 let list_scope = list_view;
@@ -16100,7 +16676,7 @@ accum
 PResult::Ok(opentype_gdef_lig_caret_list { list_scope, coverage, lig_glyph_count, lig_glyph_offsets })
 }
 
-/// d#152
+/// d#154
 fn Decoder_opentype_gdef_mark_glyph_set<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_mark_glyph_set<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16116,7 +16692,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8997881400116719018u64));
+return Err(ParseError::FalsifiedWhere(4480225125687487743u64));
 }
 };
 let mark_glyph_set_count = {
@@ -16141,7 +16717,7 @@ accum
 PResult::Ok(opentype_gdef_mark_glyph_set { table_scope, format, mark_glyph_set_count, coverage })
 }
 
-/// d#153
+/// d#155
 fn Decoder_opentype_common_item_variation_store<'input>(_input: &mut Parser<'input>) -> Result<opentype_common_item_variation_store<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16157,7 +16733,7 @@ x == 1u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13614619987783239962u64));
+return Err(ParseError::FalsifiedWhere(12879845237981630531u64));
 }
 };
 let variation_region_list = {
@@ -16190,7 +16766,7 @@ accum
 PResult::Ok(opentype_common_item_variation_store { table_scope, format, variation_region_list, item_variation_data_count, item_variation_data_list })
 }
 
-/// d#154
+/// d#156
 fn Decoder_opentype_common_variation_region_list(_input: &mut Parser<'_>) -> Result<opentype_common_variation_region_list, ParseError> {
 let axis_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16208,7 +16784,7 @@ matches!(x, 0u16..=32767u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6915530142412472120u64));
+return Err(ParseError::FalsifiedWhere(3426398976290336157u64));
 }
 };
 let variation_regions = {
@@ -16255,7 +16831,7 @@ accum
 PResult::Ok(opentype_common_variation_region_list { axis_count, region_count, variation_regions })
 }
 
-/// d#155
+/// d#157
 fn Decoder_opentype_common_item_variation_data(_input: &mut Parser<'_>) -> Result<opentype_common_item_variation_data, ParseError> {
 let item_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16295,8 +16871,11 @@ let delta_data_full_word = {
 let mut accum = Vec::new();
 for _ in 0..word_delta_count.word_count {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
+};
+raw as i32
 };
 accum.push(next_elem)
 };
@@ -16306,8 +16885,11 @@ let delta_data_half_word = {
 let mut accum = Vec::new();
 for _ in 0..try_sub!(region_index_count, word_delta_count.word_count, 7000022209644146403u64) {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -16331,8 +16913,11 @@ let delta_data_full_word = {
 let mut accum = Vec::new();
 for _ in 0..word_delta_count.word_count {
 let next_elem = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 accum.push(next_elem)
 };
@@ -16341,7 +16926,10 @@ accum
 let delta_data_half_word = {
 let mut accum = Vec::new();
 for _ in 0..try_sub!(region_index_count, word_delta_count.word_count, 8451221290566481190u64) {
-let next_elem = _input.read_byte()?;
+let next_elem = {
+let raw = _input.read_byte()?;
+raw as i8
+};
 accum.push(next_elem)
 };
 accum
@@ -16358,7 +16946,7 @@ opentype_common_item_variation_data_delta_sets::Delta16Sets(inner)
 PResult::Ok(opentype_common_item_variation_data { item_count, word_delta_count, region_index_count, region_indices, delta_sets })
 }
 
-/// d#156
+/// d#158
 fn Decoder_opentype_gdef_lig_glyph<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_lig_glyph<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16384,7 +16972,7 @@ accum
 PResult::Ok(opentype_gdef_lig_glyph { table_scope, caret_count, caret_values })
 }
 
-/// d#157
+/// d#159
 fn Decoder_opentype_gdef_caret_value<'input>(_input: &mut Parser<'input>) -> Result<opentype_gdef_caret_value<'input>, ParseError> {
 let table_view = _input.view();
 let format = {
@@ -16395,8 +16983,11 @@ let data = match format {
 1u16 => {
 let inner = {
 let coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_gdef_caret_value_data_Format1 { coordinate }
 };
@@ -16420,18 +17011,21 @@ opentype_gdef_caret_value_data::Format3(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(6949960292533894002u64));
+return Err(ParseError::FailToken(11250208753083412758u64));
 }
 };
 PResult::Ok(opentype_gdef_caret_value { format, data })
 }
 
-/// d#158
+/// d#160
 fn Decoder_opentype_gdef_caret_value_data_format3<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_gdef_caret_value_data_format3<'input>, ParseError> {
 let table_scope = table_view;
 let coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let table = {
 let offset = {
@@ -16444,7 +17038,7 @@ opentype_gdef_caret_value_data_format3_table { offset, _data }
 PResult::Ok(opentype_gdef_caret_value_data_format3 { table_scope, coordinate, table })
 }
 
-/// d#159
+/// d#161
 fn Decoder_opentype_gdef_attach_point(_input: &mut Parser<'_>) -> Result<opentype_gdef_attach_point, ParseError> {
 let point_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16464,7 +17058,7 @@ accum
 PResult::Ok(opentype_gdef_attach_point { point_count, point_indices })
 }
 
-/// d#160
+/// d#162
 fn Decoder_opentype_layout_axis_table<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_axis_table<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16487,9 +17081,9 @@ opentype_layout_axis_table_base_script_list_offset { offset, _data }
 PResult::Ok(opentype_layout_axis_table { table_scope, base_tag_list_offset, base_script_list_offset })
 }
 
-/// d#161
+/// d#163
 fn Decoder_opentype_base_base_script_record<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_base_base_script_record<'input>, ParseError> {
-let base_script_tag = (Decoder53(_input))?;
+let base_script_tag = (Decoder55(_input))?;
 let base_script = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16501,7 +17095,7 @@ opentype_base_base_script_record_base_script { offset, _data }
 PResult::Ok(opentype_base_base_script_record { base_script_tag, base_script })
 }
 
-/// d#162
+/// d#164
 fn Decoder_opentype_layout_base_script<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_base_script<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16536,7 +17130,7 @@ accum
 PResult::Ok(opentype_layout_base_script { table_scope, base_values_offset, default_min_max_offset, base_lang_sys_count, base_lang_sys_records })
 }
 
-/// d#163
+/// d#165
 fn Decoder_opentype_layout_base_values<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_base_values<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16566,7 +17160,7 @@ accum
 PResult::Ok(opentype_layout_base_values { table_scope, default_baseline_index, base_coord_count, base_coord_offsets })
 }
 
-/// d#164
+/// d#166
 fn Decoder_opentype_layout_min_max<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_min_max<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16601,9 +17195,9 @@ accum
 PResult::Ok(opentype_layout_min_max { table_scope, min_coord_offset, max_coord_offset, feat_min_max_count, feat_min_max_records })
 }
 
-/// d#165
+/// d#167
 fn Decoder_opentype_base_base_langsys<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_base_base_langsys<'input>, ParseError> {
-let base_lang_sys_tag = (Decoder53(_input))?;
+let base_lang_sys_tag = (Decoder55(_input))?;
 let min_max = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16615,7 +17209,7 @@ opentype_layout_base_script_default_min_max_offset { offset, _data }
 PResult::Ok(opentype_base_base_langsys { base_lang_sys_tag, min_max })
 }
 
-/// d#166
+/// d#168
 fn Decoder_opentype_layout_base_coord<'input>(_input: &mut Parser<'input>) -> Result<opentype_layout_base_coord<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -16624,8 +17218,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let coordinate = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let data = match format {
 1u16 => {
@@ -16663,15 +17260,15 @@ opentype_layout_base_coord_data::DeviceData(inner)
 },
 
 _ => {
-return Err(ParseError::FailToken(1347174710810305478u64));
+return Err(ParseError::FailToken(17349123374714965876u64));
 }
 };
 PResult::Ok(opentype_layout_base_coord { table_scope, format, coordinate, data })
 }
 
-/// d#167
+/// d#169
 fn Decoder_opentype_layout_feat_min_max<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_layout_feat_min_max<'input>, ParseError> {
-let feature_tag = (Decoder53(_input))?;
+let feature_tag = (Decoder55(_input))?;
 let min_coord_offset = {
 let offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -16691,41 +17288,56 @@ opentype_layout_base_values_base_coord_offsets { offset, _data }
 PResult::Ok(opentype_layout_feat_min_max { feature_tag, min_coord_offset, max_coord_offset })
 }
 
-/// d#168
+/// d#170
 fn Decoder_opentype_glyf_entry(_input: &mut Parser<'_>) -> Result<opentype_glyf_entry, ParseError> {
 let number_of_contours = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let x_min = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let y_min = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let x_max = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
+raw as i16
+};
 let y_max = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let description = (Decoder_opentype_glyf_description(_input, number_of_contours))?;
 PResult::Ok(opentype_glyf_entry { number_of_contours, x_min, y_min, x_max, y_max, description })
 }
 
-/// d#169
-fn Decoder_opentype_glyf_description(_input: &mut Parser<'_>, n_contours: u16) -> Result<opentype_glyf_description, ParseError> {
+/// d#171
+fn Decoder_opentype_glyf_description(_input: &mut Parser<'_>, n_contours: i16) -> Result<opentype_glyf_description, ParseError> {
 PResult::Ok(match n_contours {
-0u16 => {
+0 => {
 opentype_glyf_description::HeaderOnly
 },
 
-1u16..=32767u16 => {
-let inner = (Decoder_opentype_glyf_simple(_input, n_contours))?;
+1..=32767 => {
+let inner = (Decoder_opentype_glyf_simple(_input, (abs_i16_u16(n_contours)).eval()?))?;
 opentype_glyf_description::Simple(inner)
 },
 
@@ -16736,7 +17348,7 @@ opentype_glyf_description::Composite(inner)
 })
 }
 
-/// d#170
+/// d#172
 fn Decoder_opentype_glyf_simple(_input: &mut Parser<'_>, n_contours: u16) -> Result<opentype_glyf_simple, ParseError> {
 let end_points_of_contour = {
 let mut accum = Vec::new();
@@ -16813,22 +17425,15 @@ let mut accum = Vec::new();
 for flag_vals in flags.clone() {
 let next_elem = match flag_vals.x_short_vector {
 true => {
-let abs = _input.read_byte()?;
 match flag_vals.x_is_same_or_positive_x_short_vector {
 true => {
-abs as u16
+let raw = _input.read_byte()?;
+(cast_u8_i16(raw)).eval()?
 },
 
 false => {
-match abs {
-0u8 => {
-0u16
-},
-
-n => {
-try_sub!(65535u16, pred(n as u16), 15803403730818557393u64)
-}
-}
+let raw = _input.read_byte()?;
+(neg_u8_i16(raw)).eval()?
 }
 }
 },
@@ -16836,12 +17441,15 @@ try_sub!(65535u16, pred(n as u16), 15803403730818557393u64)
 false => {
 match flag_vals.x_is_same_or_positive_x_short_vector {
 true => {
-0u16
+0i16
 },
 
 false => {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 }
 }
 }
@@ -16855,22 +17463,15 @@ let mut accum = Vec::new();
 for flag_vals in flags.clone() {
 let next_elem = match flag_vals.y_short_vector {
 true => {
-let abs = _input.read_byte()?;
 match flag_vals.y_is_same_or_positive_y_short_vector {
 true => {
-abs as u16
+let raw = _input.read_byte()?;
+(cast_u8_i16(raw)).eval()?
 },
 
 false => {
-match abs {
-0u8 => {
-0u16
-},
-
-n => {
-try_sub!(65535u16, pred(n as u16), 6347242493551283856u64)
-}
-}
+let raw = _input.read_byte()?;
+(neg_u8_i16(raw)).eval()?
 }
 }
 },
@@ -16878,12 +17479,15 @@ try_sub!(65535u16, pred(n as u16), 6347242493551283856u64)
 false => {
 match flag_vals.y_is_same_or_positive_y_short_vector {
 true => {
-0u16
+0i16
 },
 
 false => {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 }
 }
 }
@@ -16895,7 +17499,7 @@ accum
 PResult::Ok(opentype_glyf_simple { end_points_of_contour, instruction_length, instructions, number_of_coordinates, flags, x_coordinates, y_coordinates })
 }
 
-/// d#171
+/// d#173
 fn Decoder_opentype_glyf_composite(_input: &mut Parser<'_>) -> Result<opentype_glyf_composite, ParseError> {
 let acc_glyphs = {
 let mut seq: Vec<opentype_glyf_composite_acc_glyphs> = Vec::new();
@@ -16956,8 +17560,11 @@ true => {
 match flags.args_are_xy_values {
 true => {
 let inner = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_glyf_composite_acc_glyphs_argument1::Int16(inner)
 },
@@ -16975,7 +17582,10 @@ opentype_glyf_composite_acc_glyphs_argument1::Uint16(inner)
 false => {
 match flags.args_are_xy_values {
 true => {
-let inner = _input.read_byte()?;
+let inner = {
+let raw = _input.read_byte()?;
+raw as i8
+};
 opentype_glyf_composite_acc_glyphs_argument1::Int8(inner)
 },
 
@@ -16991,8 +17601,11 @@ true => {
 match flags.args_are_xy_values {
 true => {
 let inner = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 opentype_glyf_composite_acc_glyphs_argument1::Int16(inner)
 },
@@ -17010,7 +17623,10 @@ opentype_glyf_composite_acc_glyphs_argument1::Uint16(inner)
 false => {
 match flags.args_are_xy_values {
 true => {
-let inner = _input.read_byte()?;
+let inner = {
+let raw = _input.read_byte()?;
+raw as i8
+};
 opentype_glyf_composite_acc_glyphs_argument1::Int8(inner)
 },
 
@@ -17137,7 +17753,7 @@ false => {
 PResult::Ok(opentype_glyf_composite { glyphs, instructions })
 }
 
-/// d#172
+/// d#174
 fn Decoder_opentype_glyph_description_simple_flags_raw(_input: &mut Parser<'_>) -> Result<opentype_glyph_description_simple_flags_raw, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let overlap_simple = _packed_bits >> 6u8 & 1u8 > 0u8;
@@ -17150,7 +17766,7 @@ let on_curve_point = _packed_bits & 1u8 > 0u8;
 PResult::Ok(opentype_glyph_description_simple_flags_raw { overlap_simple, y_is_same_or_positive_y_short_vector, x_is_same_or_positive_x_short_vector, repeat_flag, y_short_vector, x_short_vector, on_curve_point })
 }
 
-/// d#173
+/// d#175
 fn Decoder_opentype_post_version2<'input>(_input: &mut Parser<'input>) -> Result<opentype_post_version2<'input>, ParseError> {
 let num_glyphs = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17208,7 +17824,7 @@ accum
 PResult::Ok(opentype_post_version2 { num_glyphs, glyph_name_index, string_data })
 }
 
-/// d#174
+/// d#176
 fn Decoder_opentype_post_pascal_string<'input>(_input: &mut Parser<'input>) -> Result<opentype_post_pascal_string<'input>, ParseError> {
 let length = _input.read_byte()?;
 let string = {
@@ -17218,7 +17834,7 @@ pascal_string_data.read_len(length as usize)
 PResult::Ok(opentype_post_pascal_string { length, string })
 }
 
-/// d#175
+/// d#177
 fn Decoder_opentype_name_name_record<'input>(_input: &mut Parser<'input>, storage_view: View<'input>) -> Result<opentype_name_name_record<'input>, ParseError> {
 let platform = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17251,7 +17867,7 @@ opentype_name_name_record_string { offset, data }
 PResult::Ok(opentype_name_name_record { platform, encoding, language, name_id, length, string })
 }
 
-/// d#176
+/// d#178
 fn Decoder_opentype_name_name_version_1<'input>(_input: &mut Parser<'input>, storage_view: View<'input>) -> Result<opentype_name_name_version_1<'input>, ParseError> {
 let lang_tag_count = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17268,7 +17884,7 @@ accum
 PResult::Ok(opentype_name_name_version_1 { lang_tag_count, lang_tag_records })
 }
 
-/// d#177
+/// d#179
 fn Decoder_opentype_name_lang_tag_record<'input>(_input: &mut Parser<'input>, storage_view: View<'input>) -> Result<opentype_name_lang_tag_record<'input>, ParseError> {
 let length = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17285,7 +17901,7 @@ opentype_name_name_record_string { offset, data }
 PResult::Ok(opentype_name_lang_tag_record { length, lang_tag })
 }
 
-/// d#178
+/// d#180
 fn Decoder_opentype_maxp_version1(_input: &mut Parser<'_>) -> Result<opentype_maxp_version1, ParseError> {
 let max_points = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17315,7 +17931,7 @@ matches!(x, 1u16..=2u16)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4251627061094365437u64));
+return Err(ParseError::FalsifiedWhere(2153064741293804702u64));
 }
 };
 let max_twilight_points = {
@@ -17358,19 +17974,22 @@ x <= 16u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11915580511665106140u64));
+return Err(ParseError::FalsifiedWhere(1588651938759015246u64));
 }
 };
 PResult::Ok(opentype_maxp_version1 { max_points, max_contours, max_composite_points, max_composite_contours, max_zones, max_twilight_points, max_storage, max_function_defs, max_instruction_defs, max_stack_elements, max_size_of_instructions, max_component_elements, max_component_depth })
 }
 
-/// d#179
-fn Decoder179(_input: &mut Parser<'_>) -> Result<u64, ParseError> {
+/// d#181
+fn Decoder181(_input: &mut Parser<'_>) -> Result<i64, ParseError> {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-PResult::Ok(u64be(x))
+u64be(x)
+};
+PResult::Ok(raw as i64)
 }
 
-/// d#180
+/// d#182
 fn Decoder_opentype_encoding_record<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_encoding_record<'input>, ParseError> {
 let platform = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17391,7 +18010,7 @@ opentype_encoding_record_subtable { offset, _data }
 PResult::Ok(opentype_encoding_record { platform, encoding, subtable })
 }
 
-/// d#181
+/// d#183
 fn Decoder_opentype_cmap_subtable<'input>(_input: &mut Parser<'input>, _platform: u16) -> Result<opentype_cmap_subtable<'input>, ParseError> {
 let table_view = _input.view();
 let table_scope = table_view;
@@ -17441,7 +18060,7 @@ opentype_cmap_subtable_data::Format12(inner)
 },
 
 13u16 => {
-let inner = (Decoder189(_input, _platform))?;
+let inner = (Decoder191(_input, _platform))?;
 opentype_cmap_subtable_data::Format13(inner)
 },
 
@@ -17457,7 +18076,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(opentype_cmap_subtable { table_scope, format, data })
 }
 
-/// d#182
+/// d#184
 fn Decoder_opentype_cmap_subtable_format0(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format0, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -17504,7 +18123,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#183
+/// d#185
 fn Decoder_opentype_cmap_subtable_format2(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format2, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -17522,7 +18141,7 @@ x == 2u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17324980155911269375u64));
+return Err(ParseError::FalsifiedWhere(3249387167439447765u64));
 }
 };
 opentype_cmap_subtable_format0_length_lhs { format }
@@ -17538,7 +18157,7 @@ let l = inner;
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17670535809278048255u64));
+return Err(ParseError::FalsifiedWhere(7744051144774795087u64));
 })
 })())?;
 _input.close_peek_context()?;
@@ -17559,7 +18178,7 @@ x == 2u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2444204717155307095u64));
+return Err(ParseError::FalsifiedWhere(8700288293163706751u64));
 }
 };
 let length = {
@@ -17574,7 +18193,7 @@ let l = inner;
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1278184758971178969u64));
+return Err(ParseError::FalsifiedWhere(16771529512960957239u64));
 }
 };
 let language = {
@@ -17632,8 +18251,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let id_delta = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
 };
 let id_range_offset = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -17675,7 +18297,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#184
+/// d#186
 fn Decoder_opentype_cmap_subtable_format4(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format4, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -17693,7 +18315,7 @@ x == 4u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4480225125687487743u64));
+return Err(ParseError::FalsifiedWhere(13846498452079501214u64));
 }
 };
 opentype_cmap_subtable_format0_length_lhs { format }
@@ -17719,7 +18341,7 @@ x == 4u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12879845237981630531u64));
+return Err(ParseError::FalsifiedWhere(9798710097031164942u64));
 }
 };
 let length = {
@@ -17772,7 +18394,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3426398976290336157u64));
+return Err(ParseError::FalsifiedWhere(9819345728844658158u64));
 }
 };
 let start_code = {
@@ -17838,7 +18460,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#185
+/// d#187
 fn Decoder_opentype_cmap_subtable_format6(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format6, ParseError> {
 let format = {
 let inner = {
@@ -17852,7 +18474,7 @@ x == 6u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11250208753083412758u64));
+return Err(ParseError::FalsifiedWhere(18279137173405083757u64));
 }
 };
 let length = {
@@ -17885,7 +18507,7 @@ accum
 PResult::Ok(opentype_cmap_subtable_format6 { format, length, language, first_code, entry_count, glyph_id_array })
 }
 
-/// d#186
+/// d#188
 fn Decoder_opentype_cmap_subtable_format8(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format8, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -17903,7 +18525,7 @@ x == 8u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(17349123374714965876u64));
+return Err(ParseError::FalsifiedWhere(14954891776835932150u64));
 }
 };
 let __reserved = {
@@ -17918,7 +18540,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2153064741293804702u64));
+return Err(ParseError::FalsifiedWhere(11046436797737227751u64));
 }
 };
 opentype_cmap_subtable_format8_length_lhs { format, __reserved }
@@ -17944,7 +18566,7 @@ x == 8u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1588651938759015246u64));
+return Err(ParseError::FalsifiedWhere(14984809111992638634u64));
 }
 };
 {
@@ -17959,7 +18581,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3249387167439447765u64));
+return Err(ParseError::FalsifiedWhere(9342187932533045817u64));
 }
 };
 let length = {
@@ -17996,7 +18618,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#187
+/// d#189
 fn Decoder_opentype_cmap_subtable_format10(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format10, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -18014,7 +18636,7 @@ x == 10u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7744051144774795087u64));
+return Err(ParseError::FalsifiedWhere(13404710972790825894u64));
 }
 };
 let __reserved = {
@@ -18029,7 +18651,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8700288293163706751u64));
+return Err(ParseError::FalsifiedWhere(2688427941405105545u64));
 }
 };
 opentype_cmap_subtable_format8_length_lhs { format, __reserved }
@@ -18055,7 +18677,7 @@ x == 10u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16771529512960957239u64));
+return Err(ParseError::FalsifiedWhere(6279463968646665849u64));
 }
 };
 {
@@ -18070,7 +18692,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13846498452079501214u64));
+return Err(ParseError::FalsifiedWhere(10875553067752207222u64));
 }
 };
 let length = {
@@ -18106,7 +18728,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#188
+/// d#190
 fn Decoder_opentype_cmap_subtable_format12(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format12, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -18124,7 +18746,7 @@ x == 12u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9798710097031164942u64));
+return Err(ParseError::FalsifiedWhere(11323981950571132721u64));
 }
 };
 let __reserved = {
@@ -18139,7 +18761,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9819345728844658158u64));
+return Err(ParseError::FalsifiedWhere(1179945139148562335u64));
 }
 };
 opentype_cmap_subtable_format8_length_lhs { format, __reserved }
@@ -18165,7 +18787,7 @@ x == 12u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(18279137173405083757u64));
+return Err(ParseError::FalsifiedWhere(3270685119814653163u64));
 }
 };
 {
@@ -18180,7 +18802,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14954891776835932150u64));
+return Err(ParseError::FalsifiedWhere(6821845925776570829u64));
 }
 };
 let length = {
@@ -18209,8 +18831,8 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#189
-fn Decoder189(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format12, ParseError> {
+/// d#191
+fn Decoder191(_input: &mut Parser<'_>, _platform: u16) -> Result<opentype_cmap_subtable_format12, ParseError> {
 let length = {
 _input.open_peek_context();
 let ret = ((|| {
@@ -18227,7 +18849,7 @@ x == 13u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11046436797737227751u64));
+return Err(ParseError::FalsifiedWhere(15898809900392744567u64));
 }
 };
 let __reserved = {
@@ -18242,7 +18864,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(14984809111992638634u64));
+return Err(ParseError::FalsifiedWhere(5653230390980289841u64));
 }
 };
 opentype_cmap_subtable_format8_length_lhs { format, __reserved }
@@ -18268,7 +18890,7 @@ x == 13u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9342187932533045817u64));
+return Err(ParseError::FalsifiedWhere(9179996462972575343u64));
 }
 };
 {
@@ -18283,7 +18905,7 @@ x == 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13404710972790825894u64));
+return Err(ParseError::FalsifiedWhere(3675496117133668659u64));
 }
 };
 let length = {
@@ -18312,7 +18934,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#190
+/// d#192
 fn Decoder_opentype_cmap_subtable_format14<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_cmap_subtable_format14, ParseError> {
 let length = {
 _input.open_peek_context();
@@ -18330,7 +18952,7 @@ x == 14u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(2688427941405105545u64));
+return Err(ParseError::FalsifiedWhere(6495907546257147840u64));
 }
 };
 opentype_cmap_subtable_format0_length_lhs { format }
@@ -18356,7 +18978,7 @@ x == 14u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(6279463968646665849u64));
+return Err(ParseError::FalsifiedWhere(8327471529801851430u64));
 }
 };
 let length = {
@@ -18381,7 +19003,7 @@ _input.end_slice()?;
 PResult::Ok(ret)
 }
 
-/// d#191
+/// d#193
 fn Decoder_opentype_variation_selector<'input>(_input: &mut Parser<'input>, table_view: View<'input>) -> Result<opentype_variation_selector, ParseError> {
 let var_selector = {
 let x = (0u8, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -18406,7 +19028,7 @@ opentype_variation_selector_non_default_uvs_offset { offset, _data }
 PResult::Ok(opentype_variation_selector { var_selector, default_uvs_offset, non_default_uvs_offset })
 }
 
-/// d#192
+/// d#194
 fn Decoder_opentype_types_sequential_map_record(_input: &mut Parser<'_>) -> Result<opentype_types_sequential_map_record, ParseError> {
 let start_char_code = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -18423,7 +19045,7 @@ u32be(x)
 PResult::Ok(opentype_types_sequential_map_record { start_char_code, end_char_code, start_glyph_id })
 }
 
-/// d#193
+/// d#195
 fn Decoder_elf_header(_input: &mut Parser<'_>) -> Result<elf_header, ParseError> {
 let ident = {
 let sz = 16u32 as usize;
@@ -18432,24 +19054,24 @@ let ret = (Decoder_elf_header_ident(_input))?;
 _input.end_slice()?;
 ret
 };
-let r#type = (Decoder213(_input, ident.data == 2u8))?;
-let machine = (Decoder214(_input, ident.data == 2u8))?;
-let version = (Decoder215(_input, ident.data == 2u8))?;
+let r#type = (Decoder215(_input, ident.data == 2u8))?;
+let machine = (Decoder216(_input, ident.data == 2u8))?;
+let version = (Decoder217(_input, ident.data == 2u8))?;
 let entry = (Decoder_elf_types_elf_addr(_input, ident.data == 2u8, ident.class))?;
 let phoff = (Decoder_elf_types_elf_off(_input, ident.data == 2u8, ident.class))?;
 let shoff = (Decoder_elf_types_elf_off(_input, ident.data == 2u8, ident.class))?;
-let flags = (Decoder198(_input, ident.data == 2u8))?;
-let ehsize = (Decoder216(_input, ident.data == 2u8))?;
-let phentsize = (Decoder216(_input, ident.data == 2u8))?;
-let phnum = (Decoder216(_input, ident.data == 2u8))?;
-let shentsize = (Decoder216(_input, ident.data == 2u8))?;
-let shnum = (Decoder216(_input, ident.data == 2u8))?;
-let shstrndx = (Decoder216(_input, ident.data == 2u8))?;
+let flags = (Decoder200(_input, ident.data == 2u8))?;
+let ehsize = (Decoder218(_input, ident.data == 2u8))?;
+let phentsize = (Decoder218(_input, ident.data == 2u8))?;
+let phnum = (Decoder218(_input, ident.data == 2u8))?;
+let shentsize = (Decoder218(_input, ident.data == 2u8))?;
+let shnum = (Decoder218(_input, ident.data == 2u8))?;
+let shstrndx = (Decoder218(_input, ident.data == 2u8))?;
 PResult::Ok(elf_header { ident, r#type, machine, version, entry, phoff, shoff, flags, ehsize, phentsize, phnum, shentsize, shnum, shstrndx })
 }
 
-/// d#194
-fn Decoder194(_input: &mut Parser<'_>, is_be: bool, class: u8, phnum: u16) -> Result<Vec<elf_phdr>, ParseError> {
+/// d#196
+fn Decoder196(_input: &mut Parser<'_>, is_be: bool, class: u8, phnum: u16) -> Result<Vec<elf_phdr>, ParseError> {
 let mut accum = Vec::new();
 for _ in 0..phnum {
 let next_elem = (Decoder_elf_phdr(_input, is_be, class))?;
@@ -18458,8 +19080,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#195
-fn Decoder195(_input: &mut Parser<'_>, is_be: bool, class: u8, shnum: u16) -> Result<Vec<elf_shdr>, ParseError> {
+/// d#197
+fn Decoder197(_input: &mut Parser<'_>, is_be: bool, class: u8, shnum: u16) -> Result<Vec<elf_shdr>, ParseError> {
 let mut accum = Vec::new();
 for _ in 0..shnum {
 let next_elem = (Decoder_elf_shdr(_input, is_be, class))?;
@@ -18468,8 +19090,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#196
-fn Decoder196(_input: &mut Parser<'_>, r#type: u32, size: u64) -> Result<Vec<u8>, ParseError> {
+/// d#198
+fn Decoder198(_input: &mut Parser<'_>, r#type: u32, size: u64) -> Result<Vec<u8>, ParseError> {
 PResult::Ok({
 let _ = r#type;
 let mut accum = Vec::new();
@@ -18481,23 +19103,23 @@ accum
 })
 }
 
-/// d#197
+/// d#199
 fn Decoder_elf_shdr(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<elf_shdr, ParseError> {
-let name = (Decoder198(_input, is_be))?;
-let r#type = (Decoder199(_input, is_be))?;
+let name = (Decoder200(_input, is_be))?;
+let r#type = (Decoder201(_input, is_be))?;
 let flags = (Decoder_elf_types_elf_full(_input, is_be, class))?;
 let addr = (Decoder_elf_types_elf_addr(_input, is_be, class))?;
 let offset = (Decoder_elf_types_elf_off(_input, is_be, class))?;
 let size = (Decoder_elf_types_elf_full(_input, is_be, class))?;
-let link = (Decoder198(_input, is_be))?;
-let info = (Decoder203(_input, is_be))?;
+let link = (Decoder200(_input, is_be))?;
+let info = (Decoder205(_input, is_be))?;
 let addralign = (Decoder_elf_types_elf_full(_input, is_be, class))?;
 let entsize = (Decoder_elf_types_elf_full(_input, is_be, class))?;
 PResult::Ok(elf_shdr { name, r#type, flags, addr, offset, size, link, info, addralign, entsize })
 }
 
-/// d#198
-fn Decoder198(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
+/// d#200
+fn Decoder200(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
 _input.skip_align(4)?;
 PResult::Ok(match is_be {
 true => {
@@ -18512,9 +19134,9 @@ u32le(x)
 })
 }
 
-/// d#199
-fn Decoder199(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
-let inner = (Decoder198(_input, is_be))?;
+/// d#201
+fn Decoder201(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
+let inner = (Decoder200(_input, is_be))?;
 let is_valid = {
 let sh_type = inner;
 matches!(sh_type, 0u32..=11u32 | 14u32..=18u32 | 1610612736u32..=4294967295u32)
@@ -18522,20 +19144,20 @@ matches!(sh_type, 0u32..=11u32 | 14u32..=18u32 | 1610612736u32..=4294967295u32)
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10875553067752207222u64));
+return Err(ParseError::FalsifiedWhere(10310785543736156275u64));
 })
 }
 
-/// d#200
+/// d#202
 fn Decoder_elf_types_elf_full(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<elf_types_elf_full, ParseError> {
 PResult::Ok(match class {
 1u8 => {
-let inner = (Decoder198(_input, is_be))?;
+let inner = (Decoder200(_input, is_be))?;
 elf_types_elf_full::Full32(inner)
 },
 
 2u8 => {
-let inner = (Decoder208(_input, is_be))?;
+let inner = (Decoder210(_input, is_be))?;
 elf_types_elf_full::Full64(inner)
 },
 
@@ -18545,16 +19167,16 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#201
+/// d#203
 fn Decoder_elf_types_elf_addr(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<elf_types_elf_addr, ParseError> {
 PResult::Ok(match class {
 1u8 => {
-let inner = (Decoder206(_input, is_be))?;
+let inner = (Decoder208(_input, is_be))?;
 elf_types_elf_addr::Addr32(inner)
 },
 
 2u8 => {
-let inner = (Decoder207(_input, is_be))?;
+let inner = (Decoder209(_input, is_be))?;
 elf_types_elf_addr::Addr64(inner)
 },
 
@@ -18564,16 +19186,16 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#202
+/// d#204
 fn Decoder_elf_types_elf_off(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<elf_types_elf_off, ParseError> {
 PResult::Ok(match class {
 1u8 => {
-let inner = (Decoder204(_input, is_be))?;
+let inner = (Decoder206(_input, is_be))?;
 elf_types_elf_off::Off32(inner)
 },
 
 2u8 => {
-let inner = (Decoder205(_input, is_be))?;
+let inner = (Decoder207(_input, is_be))?;
 elf_types_elf_off::Off64(inner)
 },
 
@@ -18583,41 +19205,9 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#203
-fn Decoder203(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
-Decoder198(_input, is_be)
-}
-
-/// d#204
-fn Decoder204(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
-_input.skip_align(4)?;
-PResult::Ok(match is_be {
-true => {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u32be(x)
-},
-
-false => {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u32le(x)
-}
-})
-}
-
 /// d#205
-fn Decoder205(_input: &mut Parser<'_>, is_be: bool) -> Result<u64, ParseError> {
-_input.skip_align(8)?;
-PResult::Ok(match is_be {
-true => {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u64be(x)
-},
-
-false => {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u64le(x)
-}
-})
+fn Decoder205(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
+Decoder200(_input, is_be)
 }
 
 /// d#206
@@ -18653,7 +19243,23 @@ u64le(x)
 }
 
 /// d#208
-fn Decoder208(_input: &mut Parser<'_>, is_be: bool) -> Result<u64, ParseError> {
+fn Decoder208(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
+_input.skip_align(4)?;
+PResult::Ok(match is_be {
+true => {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32be(x)
+},
+
+false => {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32le(x)
+}
+})
+}
+
+/// d#209
+fn Decoder209(_input: &mut Parser<'_>, is_be: bool) -> Result<u64, ParseError> {
 _input.skip_align(8)?;
 PResult::Ok(match is_be {
 true => {
@@ -18668,39 +19274,55 @@ u64le(x)
 })
 }
 
-/// d#209
+/// d#210
+fn Decoder210(_input: &mut Parser<'_>, is_be: bool) -> Result<u64, ParseError> {
+_input.skip_align(8)?;
+PResult::Ok(match is_be {
+true => {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u64be(x)
+},
+
+false => {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u64le(x)
+}
+})
+}
+
+/// d#211
 fn Decoder_elf_phdr(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<elf_phdr, ParseError> {
-let r#type = (Decoder198(_input, is_be))?;
-let flags64 = (Decoder210(_input, is_be, class))?;
+let r#type = (Decoder200(_input, is_be))?;
+let flags64 = (Decoder212(_input, is_be, class))?;
 let offset = (Decoder_elf_types_elf_off(_input, is_be, class))?;
 let vaddr = (Decoder_elf_types_elf_addr(_input, is_be, class))?;
 let paddr = (Decoder_elf_types_elf_addr(_input, is_be, class))?;
 let filesz = (Decoder_elf_types_elf_full(_input, is_be, class))?;
 let memsz = (Decoder_elf_types_elf_full(_input, is_be, class))?;
-let flags32 = (Decoder211(_input, is_be, class))?;
+let flags32 = (Decoder213(_input, is_be, class))?;
 let align = (Decoder_elf_types_elf_full(_input, is_be, class))?;
 PResult::Ok(elf_phdr { r#type, flags64, offset, vaddr, paddr, filesz, memsz, flags32, align })
 }
 
-/// d#210
-fn Decoder210(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<Option<u32>, ParseError> {
-PResult::Ok(if class == 2u8 {
-Some((Decoder198(_input, is_be))?)
-} else {
-None
-})
-}
-
-/// d#211
-fn Decoder211(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<Option<u32>, ParseError> {
-PResult::Ok(if class == 1u8 {
-Some((Decoder198(_input, is_be))?)
-} else {
-None
-})
-}
-
 /// d#212
+fn Decoder212(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<Option<u32>, ParseError> {
+PResult::Ok(if class == 2u8 {
+Some((Decoder200(_input, is_be))?)
+} else {
+None
+})
+}
+
+/// d#213
+fn Decoder213(_input: &mut Parser<'_>, is_be: bool, class: u8) -> Result<Option<u32>, ParseError> {
+PResult::Ok(if class == 1u8 {
+Some((Decoder200(_input, is_be))?)
+} else {
+None
+})
+}
+
+/// d#214
 fn Decoder_elf_header_ident(_input: &mut Parser<'_>) -> Result<elf_header_ident, ParseError> {
 {
 let arg0 = {
@@ -18708,7 +19330,7 @@ let b = _input.read_byte()?;
 if b == 127 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11323981950571132721u64));
+return Err(ParseError::ExcludedBranch(16594239496794104967u64));
 }
 };
 let arg1 = {
@@ -18716,7 +19338,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1179945139148562335u64));
+return Err(ParseError::ExcludedBranch(16529910322175208638u64));
 }
 };
 let arg2 = {
@@ -18724,7 +19346,7 @@ let b = _input.read_byte()?;
 if b == 76 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3270685119814653163u64));
+return Err(ParseError::ExcludedBranch(12187643960709778443u64));
 }
 };
 let arg3 = {
@@ -18732,16 +19354,16 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6821845925776570829u64));
+return Err(ParseError::ExcludedBranch(8766708729375264031u64));
 }
 };
 (arg0, arg1, arg2, arg3)
 };
-let class = (Decoder217(_input))?;
-let data = (Decoder218(_input))?;
-let version = (Decoder219(_input))?;
-let os_abi = (Decoder220(_input))?;
-let abi_version = (Decoder221(_input))?;
+let class = (Decoder219(_input))?;
+let data = (Decoder220(_input))?;
+let version = (Decoder221(_input))?;
+let os_abi = (Decoder222(_input))?;
+let abi_version = (Decoder223(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -18764,7 +19386,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15898809900392744567u64));
+return Err(ParseError::ExcludedBranch(1369437808023015077u64));
 }
 };
 accum.push(next_elem)
@@ -18777,9 +19399,9 @@ accum
 PResult::Ok(elf_header_ident { class, data, version, os_abi, abi_version })
 }
 
-/// d#213
-fn Decoder213(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
-let inner = (Decoder216(_input, is_be))?;
+/// d#215
+fn Decoder215(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
+let inner = (Decoder218(_input, is_be))?;
 let is_valid = {
 let r#type = inner;
 matches!(r#type, 0u16..=4u16 | 65024u16..=65279u16 | 65280u16..=65535u16)
@@ -18787,18 +19409,18 @@ matches!(r#type, 0u16..=4u16 | 65024u16..=65279u16 | 65280u16..=65535u16)
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5653230390980289841u64));
+return Err(ParseError::FalsifiedWhere(163858356033350300u64));
 })
 }
 
-/// d#214
-fn Decoder214(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
-Decoder216(_input, is_be)
+/// d#216
+fn Decoder216(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
+Decoder218(_input, is_be)
 }
 
-/// d#215
-fn Decoder215(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
-let inner = (Decoder198(_input, is_be))?;
+/// d#217
+fn Decoder217(_input: &mut Parser<'_>, is_be: bool) -> Result<u32, ParseError> {
+let inner = (Decoder200(_input, is_be))?;
 let is_valid = {
 let x = inner;
 x <= 1u32
@@ -18806,12 +19428,12 @@ x <= 1u32
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9179996462972575343u64));
+return Err(ParseError::FalsifiedWhere(888161872995526095u64));
 })
 }
 
-/// d#216
-fn Decoder216(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
+/// d#218
+fn Decoder218(_input: &mut Parser<'_>, is_be: bool) -> Result<u16, ParseError> {
 _input.skip_align(2)?;
 PResult::Ok(match is_be {
 true => {
@@ -18826,36 +19448,36 @@ u16le(x)
 })
 }
 
-/// d#217
-fn Decoder217(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
-let inner = _input.read_byte()?;
-let is_valid = {
-let x = inner;
-x <= 2u8
-};
-PResult::Ok(if is_valid {
-inner
-} else {
-return Err(ParseError::FalsifiedWhere(3675496117133668659u64));
-})
-}
-
-/// d#218
-fn Decoder218(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
-let inner = _input.read_byte()?;
-let is_valid = {
-let x = inner;
-x <= 2u8
-};
-PResult::Ok(if is_valid {
-inner
-} else {
-return Err(ParseError::FalsifiedWhere(6495907546257147840u64));
-})
-}
-
 /// d#219
 fn Decoder219(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+let inner = _input.read_byte()?;
+let is_valid = {
+let x = inner;
+x <= 2u8
+};
+PResult::Ok(if is_valid {
+inner
+} else {
+return Err(ParseError::FalsifiedWhere(4770836931378141069u64));
+})
+}
+
+/// d#220
+fn Decoder220(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+let inner = _input.read_byte()?;
+let is_valid = {
+let x = inner;
+x <= 2u8
+};
+PResult::Ok(if is_valid {
+inner
+} else {
+return Err(ParseError::FalsifiedWhere(9976720501248819272u64));
+})
+}
+
+/// d#221
+fn Decoder221(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
 let inner = _input.read_byte()?;
 let is_valid = {
 let x = inner;
@@ -18864,21 +19486,21 @@ x <= 1u8
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(8327471529801851430u64));
+return Err(ParseError::FalsifiedWhere(3595277668730903043u64));
 })
 }
 
-/// d#220
-fn Decoder220(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
-_input.read_byte()
-}
-
-/// d#221
-fn Decoder221(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
-_input.read_byte()
-}
-
 /// d#222
+fn Decoder222(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+_input.read_byte()
+}
+
+/// d#223
+fn Decoder223(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+_input.read_byte()
+}
+
+/// d#224
 fn Decoder_tar_header_with_data(_input: &mut Parser<'_>) -> Result<tar_header_with_data, ParseError> {
 let header = (Decoder_tar_header(_input))?;
 let file = {
@@ -18893,7 +19515,7 @@ _input.skip_align(512)?;
 PResult::Ok(tar_header_with_data { header, file })
 }
 
-/// d#223
+/// d#225
 fn Decoder_tar_header(_input: &mut Parser<'_>) -> Result<tar_header, ParseError> {
 let sz = 512u32 as usize;
 _input.start_slice(sz)?;
@@ -18925,7 +19547,7 @@ byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10310785543736156275u64));
+return Err(ParseError::ExcludedBranch(5446531490235636452u64));
 }
 };
 _input.close_peek_context()?;
@@ -18938,7 +19560,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16594239496794104967u64));
+return Err(ParseError::ExcludedBranch(12530712830475607577u64));
 }
 };
 accum.push(next_elem)
@@ -18948,7 +19570,7 @@ break
 };
 accum
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -18971,7 +19593,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16529910322175208638u64));
+return Err(ParseError::ExcludedBranch(1386817607731947864u64));
 }
 };
 accum.push(next_elem)
@@ -19006,7 +19628,7 @@ byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12187643960709778443u64));
+return Err(ParseError::ExcludedBranch(4795509455376621436u64));
 }
 };
 _input.close_peek_context()?;
@@ -19019,7 +19641,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8766708729375264031u64));
+return Err(ParseError::ExcludedBranch(3923207427992258326u64));
 }
 };
 accum.push(next_elem)
@@ -19029,7 +19651,7 @@ break
 };
 accum
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19052,7 +19674,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1369437808023015077u64));
+return Err(ParseError::ExcludedBranch(5174369311102857850u64));
 }
 };
 accum.push(next_elem)
@@ -19087,7 +19709,7 @@ byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(163858356033350300u64));
+return Err(ParseError::ExcludedBranch(15995337135637623051u64));
 }
 };
 _input.close_peek_context()?;
@@ -19100,7 +19722,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(888161872995526095u64));
+return Err(ParseError::ExcludedBranch(4063460887563813446u64));
 }
 };
 accum.push(next_elem)
@@ -19110,7 +19732,7 @@ break
 };
 accum
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19133,7 +19755,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4770836931378141069u64));
+return Err(ParseError::ExcludedBranch(10243418979491025991u64));
 }
 };
 accum.push(next_elem)
@@ -19156,10 +19778,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9976720501248819272u64));
+return Err(ParseError::ExcludedBranch(6726475111737435495u64));
 }
 };
-try_sub!(bit as u8, 48u8, 5446531490235636452u64)
+try_sub!(bit as u8, 48u8, 14926982082392674388u64)
 };
 let _o9 = {
 let bit = {
@@ -19167,10 +19789,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12530712830475607577u64));
+return Err(ParseError::ExcludedBranch(13281230340934385869u64));
 }
 };
-try_sub!(bit as u8, 48u8, 4795509455376621436u64)
+try_sub!(bit as u8, 48u8, 8862619478422395719u64)
 };
 let _o8 = {
 let bit = {
@@ -19178,10 +19800,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3923207427992258326u64));
+return Err(ParseError::ExcludedBranch(7200474585457206375u64));
 }
 };
-try_sub!(bit as u8, 48u8, 15995337135637623051u64)
+try_sub!(bit as u8, 48u8, 13264741506377240721u64)
 };
 let _o7 = {
 let bit = {
@@ -19189,10 +19811,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4063460887563813446u64));
+return Err(ParseError::ExcludedBranch(16152968816646114000u64));
 }
 };
-try_sub!(bit as u8, 48u8, 6726475111737435495u64)
+try_sub!(bit as u8, 48u8, 2508979988921372290u64)
 };
 let _o6 = {
 let bit = {
@@ -19200,10 +19822,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3702191162545267776u64));
+return Err(ParseError::ExcludedBranch(10057441536650509049u64));
 }
 };
-try_sub!(bit as u8, 48u8, 13281230340934385869u64)
+try_sub!(bit as u8, 48u8, 829032137919921844u64)
 };
 let _o5 = {
 let bit = {
@@ -19211,10 +19833,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2229770659268432585u64));
+return Err(ParseError::ExcludedBranch(5170050512307443704u64));
 }
 };
-try_sub!(bit as u8, 48u8, 7200474585457206375u64)
+try_sub!(bit as u8, 48u8, 11309019127259385425u64)
 };
 let _o4 = {
 let bit = {
@@ -19222,10 +19844,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13266006752343456203u64));
+return Err(ParseError::ExcludedBranch(5159371628350638829u64));
 }
 };
-try_sub!(bit as u8, 48u8, 16152968816646114000u64)
+try_sub!(bit as u8, 48u8, 16134612799304961491u64)
 };
 let _o3 = {
 let bit = {
@@ -19233,10 +19855,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12815986247090051214u64));
+return Err(ParseError::ExcludedBranch(5308477118997970057u64));
 }
 };
-try_sub!(bit as u8, 48u8, 10057441536650509049u64)
+try_sub!(bit as u8, 48u8, 173922233423713068u64)
 };
 let _o2 = {
 let bit = {
@@ -19244,10 +19866,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11815677057767015929u64));
+return Err(ParseError::ExcludedBranch(12540117573097456360u64));
 }
 };
-try_sub!(bit as u8, 48u8, 5170050512307443704u64)
+try_sub!(bit as u8, 48u8, 9277543013594125416u64)
 };
 let _o1 = {
 let bit = {
@@ -19255,10 +19877,10 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18440348483137307888u64));
+return Err(ParseError::ExcludedBranch(5955168674639093440u64));
 }
 };
-try_sub!(bit as u8, 48u8, 5159371628350638829u64)
+try_sub!(bit as u8, 48u8, 13319523888327217639u64)
 };
 let _o0 = {
 let bit = {
@@ -19266,12 +19888,12 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7762269623995317946u64));
+return Err(ParseError::ExcludedBranch(824589811577025210u64));
 }
 };
-try_sub!(bit as u8, 48u8, 5308477118997970057u64)
+try_sub!(bit as u8, 48u8, 16096650375442290768u64)
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 let value = (((0u8 as u32) << 3u32 | (_oA as u32)) << 6u32 | (_o9 as u32) << 3u32 | (_o8 as u32)) << 24u32 | (((_o7 as u32) << 3u32 | (_o6 as u32)) << 6u32 | (_o5 as u32) << 3u32 | (_o4 as u32)) << 12u32 | ((_o3 as u32) << 3u32 | (_o2 as u32)) << 6u32 | (_o1 as u32) << 3u32 | (_o0 as u32);
 tar_header_size_lhs { value }
 };
@@ -19297,7 +19919,7 @@ byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16190528142421852545u64));
+return Err(ParseError::ExcludedBranch(14339975513692068616u64));
 }
 };
 _input.close_peek_context()?;
@@ -19310,7 +19932,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(173922233423713068u64));
+return Err(ParseError::ExcludedBranch(16299205781335471965u64));
 }
 };
 accum.push(next_elem)
@@ -19320,7 +19942,7 @@ break
 };
 accum
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19343,7 +19965,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12540117573097456360u64));
+return Err(ParseError::ExcludedBranch(1479153625485860551u64));
 }
 };
 accum.push(next_elem)
@@ -19359,179 +19981,6 @@ _input.end_slice()?;
 ret
 };
 let chksum = {
-let sz = 8u16 as usize;
-_input.start_slice(sz)?;
-let ret = ((|| {
-let string = {
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-{
-let ret = match _input.read_byte()? {
-byte if ((ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(byte)) => {
-0
-},
-
-byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte)) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(515819609734101411u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
-b
-} else {
-return Err(ParseError::ExcludedBranch(9277543013594125416u64));
-}
-};
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-(Decoder225(_input))?;
-{
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(5955168674639093440u64));
-}
-};
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-PResult::Ok(tar_ascii_string_opt0_nonempty { string })
-})())?;
-_input.end_slice()?;
-ret
-};
-let typeflag = _input.read_byte()?;
-let linkname = {
-let sz = 100u16 as usize;
-_input.start_slice(sz)?;
-let ret = (Decoder226(_input))?;
-_input.end_slice()?;
-ret
-};
-let magic = {
-let arg0 = {
-let b = _input.read_byte()?;
-if b == 117 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(4471438437047399494u64));
-}
-};
-let arg1 = {
-let b = _input.read_byte()?;
-if b == 115 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(13319523888327217639u64));
-}
-};
-let arg2 = {
-let b = _input.read_byte()?;
-if b == 116 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(824589811577025210u64));
-}
-};
-let arg3 = {
-let b = _input.read_byte()?;
-if b == 97 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(4649034608147552416u64));
-}
-};
-let arg4 = {
-let b = _input.read_byte()?;
-if b == 114 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(16096650375442290768u64));
-}
-};
-let arg5 = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(14339975513692068616u64));
-}
-};
-(arg0, arg1, arg2, arg3, arg4, arg5)
-};
-let version = {
-let arg0 = {
-let b = _input.read_byte()?;
-if b == 48 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(16299205781335471965u64));
-}
-};
-let arg1 = {
-let b = _input.read_byte()?;
-if b == 48 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(1479153625485860551u64));
-}
-};
-(arg0, arg1)
-};
-let uname = {
-let sz = 32u16 as usize;
-_input.start_slice(sz)?;
-let ret = (Decoder227(_input))?;
-_input.end_slice()?;
-ret
-};
-let gname = {
-let sz = 32u16 as usize;
-_input.start_slice(sz)?;
-let ret = (Decoder227(_input))?;
-_input.end_slice()?;
-ret
-};
-let devmajor = {
 let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| {
@@ -19574,7 +20023,7 @@ break
 };
 accum
 };
-(Decoder225(_input))?;
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19612,7 +20061,99 @@ PResult::Ok(tar_ascii_string_opt0_nonempty { string })
 _input.end_slice()?;
 ret
 };
-let devminor = {
+let typeflag = _input.read_byte()?;
+let linkname = {
+let sz = 100u16 as usize;
+_input.start_slice(sz)?;
+let ret = (Decoder228(_input))?;
+_input.end_slice()?;
+ret
+};
+let magic = {
+let arg0 = {
+let b = _input.read_byte()?;
+if b == 117 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(4839194687019048322u64));
+}
+};
+let arg1 = {
+let b = _input.read_byte()?;
+if b == 115 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(7230273548678969972u64));
+}
+};
+let arg2 = {
+let b = _input.read_byte()?;
+if b == 116 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(14903563845775542749u64));
+}
+};
+let arg3 = {
+let b = _input.read_byte()?;
+if b == 97 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(1969670610881234889u64));
+}
+};
+let arg4 = {
+let b = _input.read_byte()?;
+if b == 114 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(9038350950373664822u64));
+}
+};
+let arg5 = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(7281717462557989541u64));
+}
+};
+(arg0, arg1, arg2, arg3, arg4, arg5)
+};
+let version = {
+let arg0 = {
+let b = _input.read_byte()?;
+if b == 48 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(15510952803379905659u64));
+}
+};
+let arg1 = {
+let b = _input.read_byte()?;
+if b == 48 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(14681668243282477517u64));
+}
+};
+(arg0, arg1)
+};
+let uname = {
+let sz = 32u16 as usize;
+_input.start_slice(sz)?;
+let ret = (Decoder229(_input))?;
+_input.end_slice()?;
+ret
+};
+let gname = {
+let sz = 32u16 as usize;
+_input.start_slice(sz)?;
+let ret = (Decoder229(_input))?;
+_input.end_slice()?;
+ret
+};
+let devmajor = {
 let sz = 8u16 as usize;
 _input.start_slice(sz)?;
 let ret = ((|| {
@@ -19632,7 +20173,7 @@ byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte))
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4839194687019048322u64));
+return Err(ParseError::ExcludedBranch(6209434968043366837u64));
 }
 };
 _input.close_peek_context()?;
@@ -19645,203 +20186,6 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7230273548678969972u64));
-}
-};
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-(Decoder225(_input))?;
-{
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(14903563845775542749u64));
-}
-};
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-PResult::Ok(tar_ascii_string_opt0_nonempty { string })
-})())?;
-_input.end_slice()?;
-ret
-};
-let prefix = {
-let sz = 155u16 as usize;
-_input.start_slice(sz)?;
-let ret = (Decoder226(_input))?;
-_input.end_slice()?;
-ret
-};
-let pad = {
-let mut accum = Vec::new();
-for _ in 0..12u32 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(1969670610881234889u64));
-}
-};
-accum.push(next_elem)
-};
-accum
-};
-PResult::Ok(tar_header { name, mode, uid, gid, size, mtime, chksum, typeflag, linkname, magic, version, uname, gname, devmajor, devminor, prefix, pad })
-})())?;
-_input.end_slice()?;
-PResult::Ok(ret)
-}
-
-/// d#224
-fn Decoder_tar_ascii_string_opt0_nonempty(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
-let string = {
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-{
-let ret = match _input.read_byte()? {
-0u8 => {
-0
-},
-
-byte if (byte != 0) => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9038350950373664822u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-if accum.is_empty() {
-return Err(ParseError::InsufficientRepeats);
-} else {
-break
-}
-} else {
-let next_elem = {
-let b = _input.read_byte()?;
-if b != 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(7281717462557989541u64));
-}
-};
-accum.push(next_elem)
-}
-};
-accum
-};
-{
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-let b = _input.read_byte()?;
-{
-let ret = if b == 0 {
-0
-} else {
-1
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b == 0 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(15510952803379905659u64));
-}
-};
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-PResult::Ok(tar_ascii_string_opt0_nonempty { string })
-}
-
-/// d#225
-fn Decoder225(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
-let b = _input.read_byte()?;
-PResult::Ok(if (ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(b) {
-b
-} else {
-return Err(ParseError::ExcludedBranch(14681668243282477517u64));
-})
-}
-
-/// d#226
-fn Decoder226(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
-let string = {
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-{
-let ret = match _input.read_byte()? {
-byte if (byte != 0) => {
-0
-},
-
-0u8 => {
-1
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6209434968043366837u64));
-}
-};
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = {
-let b = _input.read_byte()?;
-if b != 0 {
-b
-} else {
 return Err(ParseError::ExcludedBranch(16474038368490899078u64));
 }
 };
@@ -19852,6 +20196,7 @@ break
 };
 accum
 };
+(Decoder227(_input))?;
 {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19885,10 +20230,211 @@ break
 accum
 };
 PResult::Ok(tar_ascii_string_opt0_nonempty { string })
+})())?;
+_input.end_slice()?;
+ret
+};
+let devminor = {
+let sz = 8u16 as usize;
+_input.start_slice(sz)?;
+let ret = ((|| {
+let string = {
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+{
+let ret = match _input.read_byte()? {
+byte if ((ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(byte)) => {
+0
+},
+
+byte if ((ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(byte)) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8399572043096922156u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if (ByteSet::from_bits([71776119061217280u64, 0u64, 0u64, 0u64])).contains(b) {
+b
+} else {
+return Err(ParseError::ExcludedBranch(7832192330748800109u64));
+}
+};
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+(Decoder227(_input))?;
+{
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(9815657591077818003u64));
+}
+};
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+PResult::Ok(tar_ascii_string_opt0_nonempty { string })
+})())?;
+_input.end_slice()?;
+ret
+};
+let prefix = {
+let sz = 155u16 as usize;
+_input.start_slice(sz)?;
+let ret = (Decoder228(_input))?;
+_input.end_slice()?;
+ret
+};
+let pad = {
+let mut accum = Vec::new();
+for _ in 0..12u32 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(2197379665604321609u64));
+}
+};
+accum.push(next_elem)
+};
+accum
+};
+PResult::Ok(tar_header { name, mode, uid, gid, size, mtime, chksum, typeflag, linkname, magic, version, uname, gname, devmajor, devminor, prefix, pad })
+})())?;
+_input.end_slice()?;
+PResult::Ok(ret)
+}
+
+/// d#226
+fn Decoder_tar_ascii_string_opt0_nonempty(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
+let string = {
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+{
+let ret = match _input.read_byte()? {
+0u8 => {
+0
+},
+
+byte if (byte != 0) => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16624020278885696461u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+if accum.is_empty() {
+return Err(ParseError::InsufficientRepeats);
+} else {
+break
+}
+} else {
+let next_elem = {
+let b = _input.read_byte()?;
+if b != 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(14485842416732585139u64));
+}
+};
+accum.push(next_elem)
+}
+};
+accum
+};
+{
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(8179432974518885725u64));
+}
+};
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+PResult::Ok(tar_ascii_string_opt0_nonempty { string })
 }
 
 /// d#227
-fn Decoder227(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
+fn Decoder227(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+let b = _input.read_byte()?;
+PResult::Ok(if (ByteSet::from_bits([4294967297u64, 0u64, 0u64, 0u64])).contains(b) {
+b
+} else {
+return Err(ParseError::ExcludedBranch(5152282179373241998u64));
+})
+}
+
+/// d#228
+fn Decoder228(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
 let string = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -19905,7 +20451,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8399572043096922156u64));
+return Err(ParseError::ExcludedBranch(13780055874544357936u64));
 }
 };
 _input.close_peek_context()?;
@@ -19918,7 +20464,83 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7832192330748800109u64));
+return Err(ParseError::ExcludedBranch(16909208071962620789u64));
+}
+};
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+{
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+let b = _input.read_byte()?;
+{
+let ret = if b == 0 {
+0
+} else {
+1
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b == 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(7933266403838225878u64));
+}
+};
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+PResult::Ok(tar_ascii_string_opt0_nonempty { string })
+}
+
+/// d#229
+fn Decoder229(_input: &mut Parser<'_>) -> Result<tar_ascii_string_opt0_nonempty, ParseError> {
+let string = {
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+{
+let ret = match _input.read_byte()? {
+byte if (byte != 0) => {
+0
+},
+
+0u8 => {
+1
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12100308281236296642u64));
+}
+};
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = {
+let b = _input.read_byte()?;
+if b != 0 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(9041056097467752267u64));
 }
 };
 accum.push(next_elem)
@@ -19956,7 +20578,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9815657591077818003u64));
+return Err(ParseError::ExcludedBranch(5025197102194587315u64));
 }
 };
 accum.push(next_elem)
@@ -19967,7 +20589,7 @@ accum
 PResult::Ok(tar_ascii_string_opt0_nonempty { string })
 }
 
-/// d#228
+/// d#230
 fn Decoder_tiff_byte_order(_input: &mut Parser<'_>) -> Result<tiff_byte_order, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -19982,7 +20604,7 @@ let ret = match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5152282179373241998u64));
+return Err(ParseError::ExcludedBranch(2988545765690796708u64));
 }
 };
 _input.close_peek_context()?;
@@ -19996,7 +20618,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2197379665604321609u64));
+return Err(ParseError::ExcludedBranch(3810055094392728880u64));
 }
 };
 let arg1 = {
@@ -20004,7 +20626,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16624020278885696461u64));
+return Err(ParseError::ExcludedBranch(15252450768049745444u64));
 }
 };
 tiff_byte_order::le(arg0, arg1)
@@ -20016,7 +20638,7 @@ let b = _input.read_byte()?;
 if b == 77 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14485842416732585139u64));
+return Err(ParseError::ExcludedBranch(5599331855309773603u64));
 }
 };
 let arg1 = {
@@ -20024,93 +20646,93 @@ let b = _input.read_byte()?;
 if b == 77 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8179432974518885725u64));
+return Err(ParseError::ExcludedBranch(16437491640759399344u64));
 }
 };
 tiff_byte_order::be(arg0, arg1)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13780055874544357936u64));
+return Err(ParseError::ExcludedBranch(6215067399528787845u64));
 }
 })
-}
-
-/// d#229
-fn Decoder_tiff_ifd_le(_input: &mut Parser<'_>, byte_order: tiff_byte_order) -> Result<tiff_ifd_le, ParseError> {
-PResult::Ok(match byte_order {
-tiff_byte_order::le(..) => {
-(Decoder230(_input))?
-},
-
-tiff_byte_order::be(..) => {
-(Decoder231(_input))?
-}
-})
-}
-
-/// d#230
-fn Decoder230(_input: &mut Parser<'_>) -> Result<tiff_ifd_le, ParseError> {
-let num_fields = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16le(x)
-};
-let fields = {
-let mut accum = Vec::new();
-for _ in 0..num_fields {
-let next_elem = {
-let tag = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16le(x)
-};
-let r#type = {
-let x = (_input.read_byte()?, _input.read_byte()?);
-u16le(x)
-};
-let length = {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u32le(x)
-};
-let offset_or_data = {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u32le(x)
-};
-tiff_ifd_le_fields { tag, r#type, length, offset_or_data }
-};
-accum.push(next_elem)
-};
-accum
-};
-let next_ifd_offset = {
-let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
-u32le(x)
-};
-let next_ifd = {
-let mut accum = Vec::new();
-while _input.remaining() > 0 {
-let matching_ix = {
-_input.open_peek_context();
-_input.read_byte()?;
-{
-let ret = 0;
-_input.close_peek_context()?;
-ret
-}
-};
-if matching_ix == 0 {
-let next_elem = _input.read_byte()?;
-accum.push(next_elem)
-} else {
-break
-}
-};
-accum
-};
-PResult::Ok(tiff_ifd_le { num_fields, fields, next_ifd_offset, next_ifd })
 }
 
 /// d#231
-fn Decoder231(_input: &mut Parser<'_>) -> Result<tiff_ifd_le, ParseError> {
+fn Decoder_tiff_ifd_le(_input: &mut Parser<'_>, byte_order: tiff_byte_order) -> Result<tiff_ifd_le, ParseError> {
+PResult::Ok(match byte_order {
+tiff_byte_order::le(..) => {
+(Decoder232(_input))?
+},
+
+tiff_byte_order::be(..) => {
+(Decoder233(_input))?
+}
+})
+}
+
+/// d#232
+fn Decoder232(_input: &mut Parser<'_>) -> Result<tiff_ifd_le, ParseError> {
+let num_fields = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16le(x)
+};
+let fields = {
+let mut accum = Vec::new();
+for _ in 0..num_fields {
+let next_elem = {
+let tag = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16le(x)
+};
+let r#type = {
+let x = (_input.read_byte()?, _input.read_byte()?);
+u16le(x)
+};
+let length = {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32le(x)
+};
+let offset_or_data = {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32le(x)
+};
+tiff_ifd_le_fields { tag, r#type, length, offset_or_data }
+};
+accum.push(next_elem)
+};
+accum
+};
+let next_ifd_offset = {
+let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
+u32le(x)
+};
+let next_ifd = {
+let mut accum = Vec::new();
+while _input.remaining() > 0 {
+let matching_ix = {
+_input.open_peek_context();
+_input.read_byte()?;
+{
+let ret = 0;
+_input.close_peek_context()?;
+ret
+}
+};
+if matching_ix == 0 {
+let next_elem = _input.read_byte()?;
+accum.push(next_elem)
+} else {
+break
+}
+};
+accum
+};
+PResult::Ok(tiff_ifd_le { num_fields, fields, next_ifd_offset, next_ifd })
+}
+
+/// d#233
+fn Decoder233(_input: &mut Parser<'_>) -> Result<tiff_ifd_le, ParseError> {
 let num_fields = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
@@ -20169,9 +20791,9 @@ accum
 PResult::Ok(tiff_ifd_le { num_fields, fields, next_ifd_offset, next_ifd })
 }
 
-/// d#232
+/// d#234
 fn Decoder_riff_subchunks(_input: &mut Parser<'_>) -> Result<riff_subchunks, ParseError> {
-let tag = (Decoder233(_input))?;
+let tag = (Decoder235(_input))?;
 let chunks = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -20196,14 +20818,14 @@ accum
 PResult::Ok(riff_subchunks { tag, chunks })
 }
 
-/// d#233
-fn Decoder233(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
+/// d#235
+fn Decoder235(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
 PResult::Ok((_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?))
 }
 
-/// d#234
+/// d#236
 fn Decoder_riff_chunk(_input: &mut Parser<'_>) -> Result<riff_chunk, ParseError> {
-let tag = (Decoder233(_input))?;
+let tag = (Decoder235(_input))?;
 let length = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32le(x)
@@ -20240,7 +20862,7 @@ let b = _input.read_byte()?;
 Some(if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16909208071962620789u64));
+return Err(ParseError::ExcludedBranch(17176374570344757031u64));
 })
 } else {
 None
@@ -20248,7 +20870,7 @@ None
 PResult::Ok(riff_chunk { tag, length, data, pad })
 }
 
-/// d#235
+/// d#237
 fn Decoder_png_ihdr(_input: &mut Parser<'_>) -> Result<png_ihdr, ParseError> {
 let length = {
 let inner = {
@@ -20262,10 +20884,10 @@ length <= 2147483647u32
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7933266403838225878u64));
+return Err(ParseError::FalsifiedWhere(3566920116549027235u64));
 }
 };
-let tag = (Decoder281(_input))?;
+let tag = (Decoder283(_input))?;
 let data = {
 let sz = length as usize;
 _input.start_slice(sz)?;
@@ -20280,7 +20902,7 @@ u32be(x)
 PResult::Ok(png_ihdr { length, tag, data, crc })
 }
 
-/// d#236
+/// d#238
 fn Decoder_png_chunk(_input: &mut Parser<'_>, ihdr: png_ihdr) -> Result<png_chunk, ParseError> {
 let length = {
 let inner = {
@@ -20294,16 +20916,16 @@ length <= 2147483647u32
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12100308281236296642u64));
+return Err(ParseError::FalsifiedWhere(7979287392867129207u64));
 }
 };
-let tag = (Decoder251(_input))?;
+let tag = (Decoder253(_input))?;
 let data = {
 let sz = length as usize;
 _input.start_slice(sz)?;
 let ret = match slice_all(&tag) {
 [80u8, 76u8, 84u8, 69u8] => {
-let inner = (Decoder252(_input))?;
+let inner = (Decoder254(_input))?;
 png_chunk_data::PLTE(inner)
 },
 
@@ -20412,7 +21034,7 @@ u32be(x)
 PResult::Ok(png_chunk { length, tag, data, crc })
 }
 
-/// d#237
+/// d#239
 fn Decoder_png_idat(_input: &mut Parser<'_>) -> Result<png_idat, ParseError> {
 let length = {
 let inner = {
@@ -20426,14 +21048,14 @@ length <= 2147483647u32
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9041056097467752267u64));
+return Err(ParseError::FalsifiedWhere(3653195934333285574u64));
 }
 };
-let tag = (Decoder249(_input))?;
+let tag = (Decoder251(_input))?;
 let data = {
 let sz = length as usize;
 _input.start_slice(sz)?;
-let ret = (Decoder250(_input))?;
+let ret = (Decoder252(_input))?;
 _input.end_slice()?;
 ret
 };
@@ -20444,7 +21066,7 @@ u32be(x)
 PResult::Ok(png_idat { length, tag, data, crc })
 }
 
-/// d#238
+/// d#240
 fn Decoder_zlib_main(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
 let compression_method_flags = {
 let inner = {
@@ -20460,7 +21082,7 @@ method_info.compression_method == 8u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(5025197102194587315u64));
+return Err(ParseError::FalsifiedWhere(16671136947067655757u64));
 }
 };
 let flags = {
@@ -20489,7 +21111,7 @@ u32be(x)
 PResult::Ok(zlib_main { compression_method_flags, flags, dict_id, data, adler32 })
 }
 
-/// d#239
+/// d#241
 fn Decoder_png_iend(_input: &mut Parser<'_>) -> Result<png_iend, ParseError> {
 let length = {
 let inner = {
@@ -20503,10 +21125,10 @@ length == 0u32
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(3810055094392728880u64));
+return Err(ParseError::FalsifiedWhere(10721249873135158334u64));
 }
 };
-let tag = (Decoder240(_input))?;
+let tag = (Decoder242(_input))?;
 let crc = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
@@ -20514,14 +21136,14 @@ u32be(x)
 PResult::Ok(png_iend { length, tag, crc })
 }
 
-/// d#240
-fn Decoder240(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
+/// d#242
+fn Decoder242(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
 let arg0 = {
 let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15252450768049745444u64));
+return Err(ParseError::ExcludedBranch(8898504689444561451u64));
 }
 };
 let arg1 = {
@@ -20529,7 +21151,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5599331855309773603u64));
+return Err(ParseError::ExcludedBranch(441240706992005484u64));
 }
 };
 let arg2 = {
@@ -20537,7 +21159,7 @@ let b = _input.read_byte()?;
 if b == 78 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16437491640759399344u64));
+return Err(ParseError::ExcludedBranch(3950014938140253048u64));
 }
 };
 let arg3 = {
@@ -20545,13 +21167,13 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2988545765690796708u64));
+return Err(ParseError::ExcludedBranch(10046433636842398056u64));
 }
 };
 PResult::Ok((arg0, arg1, arg2, arg3))
 }
 
-/// d#241
+/// d#243
 fn Decoder_deflate_main(_input: &mut Parser<'_>) -> Result<deflate_main, ParseError> {
 let blocks = {
 let mut accum = Vec::new();
@@ -20604,7 +21226,7 @@ let ix = (try_sub!((buffer.len()) as u32, r.distance as u32, 1620020790274171531
 PResult::Ok(deflate_main { blocks, codes, inflate })
 }
 
-/// d#242
+/// d#244
 fn Decoder_deflate_block(_input: &mut Parser<'_>) -> Result<deflate_block, ParseError> {
 let r#final = _input.read_byte()?;
 let r#type = {
@@ -20634,7 +21256,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(deflate_block { r#final, r#type, data })
 }
 
-/// d#243
+/// d#245
 fn Decoder_deflate_uncompressed(_input: &mut Parser<'_>) -> Result<deflate_uncompressed, ParseError> {
 _input.skip_align(8)?;
 let len = {
@@ -20660,7 +21282,7 @@ let codes_values = (try_flat_map_vec(bytes.iter().cloned(), |x: u8| PResult::Ok(
 PResult::Ok(deflate_uncompressed { len, nlen, bytes, codes_values })
 }
 
-/// d#244
+/// d#246
 fn Decoder_deflate_fixed_huffman(_input: &mut Parser<'_>) -> Result<deflate_fixed_huffman, ParseError> {
 let codes = {
 let format = parse_huffman([8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 9u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 7u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8, 8u8].to_vec(), None);
@@ -21305,7 +21927,7 @@ _ => {
 PResult::Ok(deflate_fixed_huffman { codes, codes_values })
 }
 
-/// d#245
+/// d#247
 fn Decoder_deflate_dynamic_huffman(_input: &mut Parser<'_>) -> Result<deflate_dynamic_huffman, ParseError> {
 let hlit = {
 let bits = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -21330,7 +21952,7 @@ accum.push(next_elem)
 };
 accum
 };
-let literal_length_distance_alphabet_code_lengths = (Decoder246(_input, hlit, hdist, &code_length_alphabet_code_lengths))?;
+let literal_length_distance_alphabet_code_lengths = (Decoder248(_input, hlit, hdist, &code_length_alphabet_code_lengths))?;
 let literal_length_distance_alphabet_code_lengths_value = (try_fold_map_curried(literal_length_distance_alphabet_code_lengths.iter().cloned(), None, |tuple_var: (Option<u8>, deflate_dynamic_huffman_literal_length_distance_alphabet_code_lengths)| PResult::Ok({
 let (last_symbol, cl_code_extra) = tuple_var;
 match cl_code_extra.code as u8 {
@@ -21721,8 +22343,8 @@ _ => {
 PResult::Ok(deflate_dynamic_huffman { hlit, hdist, hclen, code_length_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths, literal_length_distance_alphabet_code_lengths_value, literal_length_alphabet_code_lengths_value, distance_alphabet_code_lengths_value, codes, codes_values })
 }
 
-/// d#246
-fn Decoder246(_input: &mut Parser<'_>, hlit: u8, hdist: u8, code_length_alphabet_code_lengths: &[u8]) -> Result<Vec<deflate_dynamic_huffman_literal_length_distance_alphabet_code_lengths>, ParseError> {
+/// d#248
+fn Decoder248(_input: &mut Parser<'_>, hlit: u8, hdist: u8, code_length_alphabet_code_lengths: &[u8]) -> Result<Vec<deflate_dynamic_huffman_literal_length_distance_alphabet_code_lengths>, ParseError> {
 let code_length_alphabet_format = parse_huffman(code_length_alphabet_code_lengths.clone(), Some([16u8, 17u8, 18u8, 0u8, 8u8, 7u8, 9u8, 6u8, 10u8, 5u8, 11u8, 4u8, 12u8, 3u8, 13u8, 2u8, 14u8, 1u8, 15u8].to_vec()));
 let mut accum = Vec::new();
 loop {
@@ -21764,7 +22386,7 @@ x
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17176374570344757031u64));
+return Err(ParseError::ExcludedBranch(757122060916971772u64));
 }
 }))
 },
@@ -21792,131 +22414,131 @@ break
 PResult::Ok(accum)
 }
 
-/// d#247
+/// d#249
 fn Decoder_deflate_distance_record0(_input: &mut Parser<'_>, distance_code: u16) -> Result<deflate_distance_record0, ParseError> {
 PResult::Ok(match distance_code as u8 {
 0u8 => {
-(Decoder248(_input, 0u8, 1u16))?
+(Decoder250(_input, 0u8, 1u16))?
 },
 
 1u8 => {
-(Decoder248(_input, 0u8, 2u16))?
+(Decoder250(_input, 0u8, 2u16))?
 },
 
 2u8 => {
-(Decoder248(_input, 0u8, 3u16))?
+(Decoder250(_input, 0u8, 3u16))?
 },
 
 3u8 => {
-(Decoder248(_input, 0u8, 4u16))?
+(Decoder250(_input, 0u8, 4u16))?
 },
 
 4u8 => {
-(Decoder248(_input, 1u8, 5u16))?
+(Decoder250(_input, 1u8, 5u16))?
 },
 
 5u8 => {
-(Decoder248(_input, 1u8, 7u16))?
+(Decoder250(_input, 1u8, 7u16))?
 },
 
 6u8 => {
-(Decoder248(_input, 2u8, 9u16))?
+(Decoder250(_input, 2u8, 9u16))?
 },
 
 7u8 => {
-(Decoder248(_input, 2u8, 13u16))?
+(Decoder250(_input, 2u8, 13u16))?
 },
 
 8u8 => {
-(Decoder248(_input, 3u8, 17u16))?
+(Decoder250(_input, 3u8, 17u16))?
 },
 
 9u8 => {
-(Decoder248(_input, 3u8, 25u16))?
+(Decoder250(_input, 3u8, 25u16))?
 },
 
 10u8 => {
-(Decoder248(_input, 4u8, 33u16))?
+(Decoder250(_input, 4u8, 33u16))?
 },
 
 11u8 => {
-(Decoder248(_input, 4u8, 49u16))?
+(Decoder250(_input, 4u8, 49u16))?
 },
 
 12u8 => {
-(Decoder248(_input, 5u8, 65u16))?
+(Decoder250(_input, 5u8, 65u16))?
 },
 
 13u8 => {
-(Decoder248(_input, 5u8, 97u16))?
+(Decoder250(_input, 5u8, 97u16))?
 },
 
 14u8 => {
-(Decoder248(_input, 6u8, 129u16))?
+(Decoder250(_input, 6u8, 129u16))?
 },
 
 15u8 => {
-(Decoder248(_input, 6u8, 193u16))?
+(Decoder250(_input, 6u8, 193u16))?
 },
 
 16u8 => {
-(Decoder248(_input, 7u8, 257u16))?
+(Decoder250(_input, 7u8, 257u16))?
 },
 
 17u8 => {
-(Decoder248(_input, 7u8, 385u16))?
+(Decoder250(_input, 7u8, 385u16))?
 },
 
 18u8 => {
-(Decoder248(_input, 8u8, 513u16))?
+(Decoder250(_input, 8u8, 513u16))?
 },
 
 19u8 => {
-(Decoder248(_input, 8u8, 769u16))?
+(Decoder250(_input, 8u8, 769u16))?
 },
 
 20u8 => {
-(Decoder248(_input, 9u8, 1025u16))?
+(Decoder250(_input, 9u8, 1025u16))?
 },
 
 21u8 => {
-(Decoder248(_input, 9u8, 1537u16))?
+(Decoder250(_input, 9u8, 1537u16))?
 },
 
 22u8 => {
-(Decoder248(_input, 10u8, 2049u16))?
+(Decoder250(_input, 10u8, 2049u16))?
 },
 
 23u8 => {
-(Decoder248(_input, 10u8, 3073u16))?
+(Decoder250(_input, 10u8, 3073u16))?
 },
 
 24u8 => {
-(Decoder248(_input, 11u8, 4097u16))?
+(Decoder250(_input, 11u8, 4097u16))?
 },
 
 25u8 => {
-(Decoder248(_input, 11u8, 6145u16))?
+(Decoder250(_input, 11u8, 6145u16))?
 },
 
 26u8 => {
-(Decoder248(_input, 12u8, 8193u16))?
+(Decoder250(_input, 12u8, 8193u16))?
 },
 
 27u8 => {
-(Decoder248(_input, 12u8, 12289u16))?
+(Decoder250(_input, 12u8, 12289u16))?
 },
 
 28u8 => {
-(Decoder248(_input, 13u8, 16385u16))?
+(Decoder250(_input, 13u8, 16385u16))?
 },
 
 29u8 => {
-(Decoder248(_input, 13u8, 24577u16))?
+(Decoder250(_input, 13u8, 24577u16))?
 },
 
 30u8..=31u8 => {
-return Err(ParseError::FailToken(3566920116549027235u64));
+return Err(ParseError::FailToken(5986772336072340665u64));
 },
 
 _other => {
@@ -21925,8 +22547,8 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#248
-fn Decoder248(_input: &mut Parser<'_>, extra_bits: u8, start: u16) -> Result<deflate_distance_record0, ParseError> {
+/// d#250
+fn Decoder250(_input: &mut Parser<'_>, extra_bits: u8, start: u16) -> Result<deflate_distance_record0, ParseError> {
 let distance_extra_bits = match extra_bits {
 0u8 => {
 0u16
@@ -22005,14 +22627,14 @@ let distance = start + distance_extra_bits;
 PResult::Ok(deflate_distance_record0 { distance_extra_bits, distance })
 }
 
-/// d#249
-fn Decoder249(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
+/// d#251
+fn Decoder251(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
 let arg0 = {
 let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7979287392867129207u64));
+return Err(ParseError::ExcludedBranch(8812292064350598352u64));
 }
 };
 let arg1 = {
@@ -22020,7 +22642,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3653195934333285574u64));
+return Err(ParseError::ExcludedBranch(10645729856418057640u64));
 }
 };
 let arg2 = {
@@ -22028,7 +22650,7 @@ let b = _input.read_byte()?;
 if b == 65 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16671136947067655757u64));
+return Err(ParseError::ExcludedBranch(2908689796368760670u64));
 }
 };
 let arg3 = {
@@ -22036,14 +22658,14 @@ let b = _input.read_byte()?;
 if b == 84 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10721249873135158334u64));
+return Err(ParseError::ExcludedBranch(4316175446384649956u64));
 }
 };
 PResult::Ok((arg0, arg1, arg2, arg3))
 }
 
-/// d#250
-fn Decoder250(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#252
+fn Decoder252(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -22065,8 +22687,8 @@ break
 PResult::Ok(accum)
 }
 
-/// d#251
-fn Decoder251(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#253
+fn Decoder253(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 {
 _input.open_peek_not_context();
 let res = (|| (|| {
@@ -22078,7 +22700,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8898504689444561451u64));
+return Err(ParseError::ExcludedBranch(13311790038092155306u64));
 }
 };
 let arg1 = {
@@ -22086,7 +22708,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(441240706992005484u64));
+return Err(ParseError::ExcludedBranch(4598583460226006268u64));
 }
 };
 let arg2 = {
@@ -22094,7 +22716,7 @@ let b = _input.read_byte()?;
 if b == 65 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3950014938140253048u64));
+return Err(ParseError::ExcludedBranch(275550262640764009u64));
 }
 };
 let arg3 = {
@@ -22102,7 +22724,7 @@ let b = _input.read_byte()?;
 if b == 84 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10046433636842398056u64));
+return Err(ParseError::ExcludedBranch(11490274700962832028u64));
 }
 };
 (arg0, arg1, arg2, arg3)
@@ -22125,7 +22747,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11079395374415646537u64));
+return Err(ParseError::ExcludedBranch(15680765559661576738u64));
 }
 };
 let arg1 = {
@@ -22133,7 +22755,7 @@ let b = _input.read_byte()?;
 if b == 69 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(757122060916971772u64));
+return Err(ParseError::ExcludedBranch(1587806253186841834u64));
 }
 };
 let arg2 = {
@@ -22141,7 +22763,7 @@ let b = _input.read_byte()?;
 if b == 78 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5986772336072340665u64));
+return Err(ParseError::ExcludedBranch(11297314001547702431u64));
 }
 };
 let arg3 = {
@@ -22149,7 +22771,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8812292064350598352u64));
+return Err(ParseError::ExcludedBranch(18399269270080151498u64));
 }
 };
 (arg0, arg1, arg2, arg3)
@@ -22179,7 +22801,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([0u64, 576460743847706622u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10645729856418057640u64));
+return Err(ParseError::ExcludedBranch(30874382969105279u64));
 }
 };
 accum.push(next_elem)
@@ -22187,8 +22809,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#252
-fn Decoder252(_input: &mut Parser<'_>) -> Result<Vec<gif_color_table_entry>, ParseError> {
+/// d#254
+fn Decoder254(_input: &mut Parser<'_>) -> Result<Vec<gif_color_table_entry>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -22219,7 +22841,7 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#253
+/// d#255
 fn Decoder_png_trns(_input: &mut Parser<'_>, ihdr: png_ihdr) -> Result<png_trns, ParseError> {
 PResult::Ok(match ihdr.data.color_type {
 0u8 => {
@@ -22286,7 +22908,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#254
+/// d#256
 fn Decoder_png_chrm(_input: &mut Parser<'_>) -> Result<png_chrm, ParseError> {
 let whitepoint_x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -22323,7 +22945,7 @@ u32be(x)
 PResult::Ok(png_chrm { whitepoint_x, whitepoint_y, red_x, red_y, green_x, green_y, blue_x, blue_y })
 }
 
-/// d#255
+/// d#257
 fn Decoder_png_gama(_input: &mut Parser<'_>) -> Result<png_gama, ParseError> {
 let gamma = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -22332,16 +22954,16 @@ u32be(x)
 PResult::Ok(png_gama { gamma })
 }
 
-/// d#256
+/// d#258
 fn Decoder_png_iccp(_input: &mut Parser<'_>) -> Result<png_iccp, ParseError> {
 let profile_name = {
-let val = (Decoder279(_input))?;
+let val = (Decoder281(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2908689796368760670u64));
+return Err(ParseError::ExcludedBranch(9791114990321288281u64));
 }
 };
 val.clone()
@@ -22351,14 +22973,14 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4316175446384649956u64));
+return Err(ParseError::ExcludedBranch(1595897747104696027u64));
 }
 };
-let compressed_profile = (Decoder280(_input))?;
+let compressed_profile = (Decoder282(_input))?;
 PResult::Ok(png_iccp { profile_name, compression_method, compressed_profile })
 }
 
-/// d#257
+/// d#259
 fn Decoder_png_sbit(_input: &mut Parser<'_>, ihdr: png_ihdr) -> Result<png_sbit, ParseError> {
 PResult::Ok(match ihdr.data.color_type {
 0u8 => {
@@ -22415,7 +23037,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#258
+/// d#260
 fn Decoder_png_srgb(_input: &mut Parser<'_>) -> Result<png_srgb, ParseError> {
 let rendering_intent = {
 let inner = _input.read_byte()?;
@@ -22426,22 +23048,22 @@ x <= 3u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13311790038092155306u64));
+return Err(ParseError::FalsifiedWhere(2481175643332430741u64));
 }
 };
 PResult::Ok(png_srgb { rendering_intent })
 }
 
-/// d#259
+/// d#261
 fn Decoder_png_itxt(_input: &mut Parser<'_>) -> Result<png_itxt, ParseError> {
 let keyword = {
-let val = (Decoder273(_input))?;
+let val = (Decoder275(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4598583460226006268u64));
+return Err(ParseError::ExcludedBranch(15702070659753069395u64));
 }
 };
 val.clone()
@@ -22451,7 +23073,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([3u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(275550262640764009u64));
+return Err(ParseError::ExcludedBranch(4338497647520366709u64));
 }
 };
 let compression_method = {
@@ -22459,7 +23081,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11490274700962832028u64));
+return Err(ParseError::ExcludedBranch(14600508952542130472u64));
 }
 };
 let language_tag = {
@@ -22479,7 +23101,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15680765559661576738u64));
+return Err(ParseError::ExcludedBranch(460669108121189046u64));
 }
 };
 _input.close_peek_context()?;
@@ -22492,7 +23114,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1587806253186841834u64));
+return Err(ParseError::ExcludedBranch(8971553008180040990u64));
 }
 };
 accum.push(next_elem)
@@ -22507,19 +23129,19 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11297314001547702431u64));
+return Err(ParseError::ExcludedBranch(1310624491311340594u64));
 }
 };
 chars.clone()
 };
 let translated_keyword = {
-let val = (Decoder274(_input))?;
+let val = (Decoder276(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18399269270080151498u64));
+return Err(ParseError::ExcludedBranch(11225936372640404826u64));
 }
 };
 val.clone()
@@ -22531,10 +23153,10 @@ _input.start_alt();
 let res = (|| {
 let inner = {
 let inner = {
-let zlib = (Decoder275(_input))?;
+let zlib = (Decoder277(_input))?;
 let mut buf_parser = Parser::new(slice_all(&zlib.data.inflate));
 let buf_input = &mut buf_parser;
-(Decoder276(buf_input))?
+(Decoder278(buf_input))?
 };
 png_itxt_text_compressed::valid(inner)
 };
@@ -22589,23 +23211,23 @@ Err(_e)
 },
 
 false => {
-let inner = (Decoder277(_input))?;
+let inner = (Decoder279(_input))?;
 png_itxt_text::uncompressed(inner)
 }
 };
 PResult::Ok(png_itxt { keyword, compression_flag, compression_method, language_tag, translated_keyword, text })
 }
 
-/// d#260
+/// d#262
 fn Decoder_png_text(_input: &mut Parser<'_>) -> Result<png_text, ParseError> {
 let keyword = {
-let val = (Decoder272(_input))?;
+let val = (Decoder274(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(30874382969105279u64));
+return Err(ParseError::ExcludedBranch(1029952099207838423u64));
 }
 };
 val.clone()
@@ -22634,16 +23256,16 @@ accum
 PResult::Ok(png_text { keyword, text })
 }
 
-/// d#261
+/// d#263
 fn Decoder_png_ztxt(_input: &mut Parser<'_>) -> Result<png_ztxt, ParseError> {
 let keyword = {
-let val = (Decoder268(_input))?;
+let val = (Decoder270(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9791114990321288281u64));
+return Err(ParseError::ExcludedBranch(17327099206515189757u64));
 }
 };
 val.clone()
@@ -22653,19 +23275,19 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1595897747104696027u64));
+return Err(ParseError::ExcludedBranch(14652068248613900169u64));
 }
 };
 let compressed_text = {
-let zlib = (Decoder269(_input))?;
+let zlib = (Decoder271(_input))?;
 let mut buf_parser = Parser::new(slice_all(&zlib.data.inflate));
 let buf_input = &mut buf_parser;
-(Decoder270(buf_input))?
+(Decoder272(buf_input))?
 };
 PResult::Ok(png_ztxt { keyword, compression_method, compressed_text })
 }
 
-/// d#262
+/// d#264
 fn Decoder_png_bkgd(_input: &mut Parser<'_>, ihdr: png_ihdr) -> Result<png_bkgd, ParseError> {
 PResult::Ok(match ihdr.data.color_type {
 0u8 => {
@@ -22742,7 +23364,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#263
+/// d#265
 fn Decoder_png_hist(_input: &mut Parser<'_>) -> Result<png_hist, ParseError> {
 let histogram = {
 let mut accum = Vec::new();
@@ -22771,7 +23393,7 @@ accum
 PResult::Ok(png_hist { histogram })
 }
 
-/// d#264
+/// d#266
 fn Decoder_png_phys(_input: &mut Parser<'_>) -> Result<png_phys, ParseError> {
 let pixels_per_unit_x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -22785,16 +23407,16 @@ let unit_specifier = _input.read_byte()?;
 PResult::Ok(png_phys { pixels_per_unit_x, pixels_per_unit_y, unit_specifier })
 }
 
-/// d#265
+/// d#267
 fn Decoder_png_splt(_input: &mut Parser<'_>) -> Result<png_splt, ParseError> {
 let palette_name = {
-let val = (Decoder267(_input))?;
+let val = (Decoder269(_input))?;
 {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2481175643332430741u64));
+return Err(ParseError::ExcludedBranch(3089242474000390105u64));
 }
 };
 val.clone()
@@ -22804,7 +23426,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([65792u64, 0u64, 0u64, 0u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15702070659753069395u64));
+return Err(ParseError::ExcludedBranch(8785324329127396734u64));
 }
 };
 let palette = match sample_depth {
@@ -22897,7 +23519,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(png_splt { palette_name, sample_depth, palette })
 }
 
-/// d#266
+/// d#268
 fn Decoder_png_time(_input: &mut Parser<'_>) -> Result<png_time, ParseError> {
 let year = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -22911,8 +23533,8 @@ let second = _input.read_byte()?;
 PResult::Ok(png_time { year, month, day, hour, minute, second })
 }
 
-/// d#267
-fn Decoder267(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#269
+fn Decoder269(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let reps_left = {
@@ -23393,72 +24015,6 @@ match _input.read_byte()? {
 
 byte if ((ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(byte)) => {
 79
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4338497647520366709u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14600508952542130472u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(460669108121189046u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8971553008180040990u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1310624491311340594u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11225936372640404826u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1029952099207838423u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17327099206515189757u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14652068248613900169u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3089242474000390105u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8785324329127396734u64));
-}
-}
 },
 
 _ => {
@@ -23866,6 +24422,72 @@ return Err(ParseError::ExcludedBranch(11863749907612277673u64));
 _ => {
 return Err(ParseError::ExcludedBranch(8408007422644693463u64));
 }
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2137824516769298342u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17504519908837839248u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5377488665469248769u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(10179224889113195865u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2526895115167988738u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7617559532652678498u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4051432836859471288u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14741532803131558705u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(10276185770177327434u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16586067667342674799u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(2497564037439806374u64));
+}
 };
 _input.close_peek_context()?;
 ret
@@ -23879,7 +24501,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2137824516769298342u64));
+return Err(ParseError::ExcludedBranch(8400230153663738380u64));
 }
 };
 accum.push(next_elem)
@@ -23888,8 +24510,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#268
-fn Decoder268(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#270
+fn Decoder270(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let reps_left = {
@@ -24370,72 +24992,6 @@ match _input.read_byte()? {
 
 byte if ((ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(byte)) => {
 79
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17504519908837839248u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(5377488665469248769u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10179224889113195865u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2526895115167988738u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7617559532652678498u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4051432836859471288u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14741532803131558705u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10276185770177327434u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16586067667342674799u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2497564037439806374u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8400230153663738380u64));
-}
-}
 },
 
 _ => {
@@ -24843,6 +25399,72 @@ return Err(ParseError::ExcludedBranch(10727170711560529872u64));
 _ => {
 return Err(ParseError::ExcludedBranch(17095884813960222885u64));
 }
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(974442582679666596u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4054889295781446756u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14775695284177607002u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6914153644311469309u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11188141958235814565u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15180040648844909945u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(18312372211249290289u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6298802191889347847u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11017185023542530489u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15395924218065814216u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14060832500024730160u64));
+}
 };
 _input.close_peek_context()?;
 ret
@@ -24856,7 +25478,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(974442582679666596u64));
+return Err(ParseError::ExcludedBranch(3344470983013526080u64));
 }
 };
 accum.push(next_elem)
@@ -24865,8 +25487,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#269
-fn Decoder269(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
+/// d#271
+fn Decoder271(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
 let compression_method_flags = {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -24881,7 +25503,7 @@ method_info.compression_method == 8u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(4054889295781446756u64));
+return Err(ParseError::FalsifiedWhere(10251322642913008199u64));
 }
 };
 let flags = {
@@ -24910,13 +25532,13 @@ u32be(x)
 PResult::Ok(zlib_main { compression_method_flags, flags, dict_id, data, adler32 })
 }
 
-/// d#270
-fn Decoder270(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
-Decoder271(_input)
+/// d#272
+fn Decoder272(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+Decoder273(_input)
 }
 
-/// d#271
-fn Decoder271(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+/// d#273
+fn Decoder273(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -24964,7 +25586,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14775695284177607002u64));
+return Err(ParseError::ExcludedBranch(10455173543833790502u64));
 }
 };
 _input.close_peek_context()?;
@@ -24972,7 +25594,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder18(_input))?;
+let next_elem = (Decoder19(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -24981,8 +25603,8 @@ break
 PResult::Ok(accum)
 }
 
-/// d#272
-fn Decoder272(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#274
+fn Decoder274(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let reps_left = {
@@ -25463,72 +26085,6 @@ match _input.read_byte()? {
 
 byte if ((ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(byte)) => {
 79
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6914153644311469309u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11188141958235814565u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15180040648844909945u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(18312372211249290289u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6298802191889347847u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11017185023542530489u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(15395924218065814216u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14060832500024730160u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(3344470983013526080u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10251322642913008199u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(10455173543833790502u64));
-}
-}
 },
 
 _ => {
@@ -25936,6 +26492,72 @@ return Err(ParseError::ExcludedBranch(12230053902523648559u64));
 _ => {
 return Err(ParseError::ExcludedBranch(6309917041149428265u64));
 }
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14708340496221370872u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8149951888585961823u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9665308631980535174u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(17114848294724579474u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6471433373632717886u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11488186652992817125u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(16428598146864409139u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11934620222090497034u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7597388605883543966u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1942606498606899849u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(9288520242296510642u64));
+}
 };
 _input.close_peek_context()?;
 ret
@@ -25949,7 +26571,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14708340496221370872u64));
+return Err(ParseError::ExcludedBranch(12753818979092594971u64));
 }
 };
 accum.push(next_elem)
@@ -25958,8 +26580,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#273
-fn Decoder273(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#275
+fn Decoder275(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let reps_left = {
@@ -26440,72 +27062,6 @@ match _input.read_byte()? {
 
 byte if ((ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(byte)) => {
 79
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8149951888585961823u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9665308631980535174u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17114848294724579474u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(6471433373632717886u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11488186652992817125u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(16428598146864409139u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11934620222090497034u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7597388605883543966u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(1942606498606899849u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9288520242296510642u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(12753818979092594971u64));
-}
-}
 },
 
 _ => {
@@ -26913,6 +27469,72 @@ return Err(ParseError::ExcludedBranch(10396295304006156759u64));
 _ => {
 return Err(ParseError::ExcludedBranch(14603388329461445014u64));
 }
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15092052115449480204u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5644646321622228807u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(12876869868341544086u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(6757475294452472580u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5316076842439816359u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(13241229060561103069u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8896324603808149952u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8480214967847684808u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4089331332020821320u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7660172056721883940u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8118664158941399609u64));
+}
 };
 _input.close_peek_context()?;
 ret
@@ -26926,7 +27548,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15092052115449480204u64));
+return Err(ParseError::ExcludedBranch(11259402406166723834u64));
 }
 };
 accum.push(next_elem)
@@ -26935,8 +27557,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#274
-fn Decoder274(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+/// d#276
+fn Decoder276(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -26984,7 +27606,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5644646321622228807u64));
+return Err(ParseError::ExcludedBranch(2562653558681619679u64));
 }
 };
 _input.close_peek_context()?;
@@ -26992,7 +27614,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder19(_input))?;
+let next_elem = (Decoder20(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -27001,8 +27623,8 @@ break
 PResult::Ok(accum)
 }
 
-/// d#275
-fn Decoder275(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
+/// d#277
+fn Decoder277(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
 let compression_method_flags = {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -27017,7 +27639,7 @@ method_info.compression_method == 8u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12876869868341544086u64));
+return Err(ParseError::FalsifiedWhere(9066549901844041194u64));
 }
 };
 let flags = {
@@ -27046,8 +27668,8 @@ u32be(x)
 PResult::Ok(zlib_main { compression_method_flags, flags, dict_id, data, adler32 })
 }
 
-/// d#276
-fn Decoder276(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+/// d#278
+fn Decoder278(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -27091,7 +27713,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6757475294452472580u64));
+return Err(ParseError::ExcludedBranch(17788403991563985894u64));
 }
 };
 _input.close_peek_context()?;
@@ -27099,7 +27721,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder19(_input))?;
+let next_elem = (Decoder20(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -27108,13 +27730,13 @@ break
 PResult::Ok(accum)
 }
 
-/// d#277
-fn Decoder277(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
-Decoder278(_input)
+/// d#279
+fn Decoder279(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+Decoder280(_input)
 }
 
-/// d#278
-fn Decoder278(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
+/// d#280
+fn Decoder280(_input: &mut Parser<'_>) -> Result<Vec<char>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -27162,7 +27784,7 @@ byte if ((ByteSet::from_bits([0u64, 0u64, 0u64, 3940649673949184u64])).contains(
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(5316076842439816359u64));
+return Err(ParseError::ExcludedBranch(14014946361797352706u64));
 }
 };
 _input.close_peek_context()?;
@@ -27170,7 +27792,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder18(_input))?;
+let next_elem = (Decoder19(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -27179,8 +27801,8 @@ break
 PResult::Ok(accum)
 }
 
-/// d#279
-fn Decoder279(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#281
+fn Decoder281(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let reps_left = {
@@ -27664,72 +28286,6 @@ byte if ((ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 1
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13241229060561103069u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8896324603808149952u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8480214967847684808u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(4089331332020821320u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(7660172056721883940u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(8118664158941399609u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(11259402406166723834u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(2562653558681619679u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(9066549901844041194u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(17788403991563985894u64));
-}
-}
-},
-
-_ => {
-return Err(ParseError::ExcludedBranch(14014946361797352706u64));
-}
-}
-},
-
-_ => {
 return Err(ParseError::ExcludedBranch(17148278567107839372u64));
 }
 }
@@ -28134,6 +28690,72 @@ return Err(ParseError::ExcludedBranch(12223407337737822059u64));
 _ => {
 return Err(ParseError::ExcludedBranch(6072942808717419822u64));
 }
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(15560056883377919848u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7977419944699061624u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(8323252642575612937u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(11678443062630698028u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(14832405617500840744u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1398536204687975789u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(7336714497745271452u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4152914559762097168u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(1152534299541961510u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(5095757730543354711u64));
+}
+}
+},
+
+_ => {
+return Err(ParseError::ExcludedBranch(4668055697655854201u64));
+}
 };
 _input.close_peek_context()?;
 ret
@@ -28147,7 +28769,7 @@ let b = _input.read_byte()?;
 if (ByteSet::from_bits([18446744069414584320u64, 9223372036854775807u64, 18446744065119617024u64, 18446744073709551615u64])).contains(b) {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15560056883377919848u64));
+return Err(ParseError::ExcludedBranch(6515957116553005671u64));
 }
 };
 accum.push(next_elem)
@@ -28156,8 +28778,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#280
-fn Decoder280(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
+/// d#282
+fn Decoder282(_input: &mut Parser<'_>) -> Result<zlib_main, ParseError> {
 let compression_method_flags = {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -28172,7 +28794,7 @@ method_info.compression_method == 8u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7977419944699061624u64));
+return Err(ParseError::FalsifiedWhere(2017059186547121525u64));
 }
 };
 let flags = {
@@ -28201,14 +28823,14 @@ u32be(x)
 PResult::Ok(zlib_main { compression_method_flags, flags, dict_id, data, adler32 })
 }
 
-/// d#281
-fn Decoder281(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
+/// d#283
+fn Decoder283(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
 let arg0 = {
 let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8323252642575612937u64));
+return Err(ParseError::ExcludedBranch(11789784461021426583u64));
 }
 };
 let arg1 = {
@@ -28216,7 +28838,7 @@ let b = _input.read_byte()?;
 if b == 72 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11678443062630698028u64));
+return Err(ParseError::ExcludedBranch(16022216421479351095u64));
 }
 };
 let arg2 = {
@@ -28224,7 +28846,7 @@ let b = _input.read_byte()?;
 if b == 68 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14832405617500840744u64));
+return Err(ParseError::ExcludedBranch(15337804701822118436u64));
 }
 };
 let arg3 = {
@@ -28232,13 +28854,13 @@ let b = _input.read_byte()?;
 if b == 82 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1398536204687975789u64));
+return Err(ParseError::ExcludedBranch(2750471357152633230u64));
 }
 };
 PResult::Ok((arg0, arg1, arg2, arg3))
 }
 
-/// d#282
+/// d#284
 fn Decoder_png_ihdr_data(_input: &mut Parser<'_>) -> Result<png_ihdr_data, ParseError> {
 let width = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -28256,13 +28878,13 @@ let interlace_method = _input.read_byte()?;
 PResult::Ok(png_ihdr_data { width, height, bit_depth, color_type, compression_method, filter_method, interlace_method })
 }
 
-/// d#283
+/// d#285
 fn Decoder_mpeg4_atom(_input: &mut Parser<'_>) -> Result<mpeg4_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -28273,7 +28895,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 4152914559762097168u64)
+try_sub!(x, 16u64, 8033982984919675631u64)
 },
 
 _ => {
@@ -28382,14 +29004,14 @@ ret
 PResult::Ok(mpeg4_atom { size_field, r#type, size, data })
 }
 
-/// d#284
-fn Decoder284(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
+/// d#286
+fn Decoder286(_input: &mut Parser<'_>) -> Result<(u8, u8, u8, u8), ParseError> {
 PResult::Ok((_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?))
 }
 
-/// d#285
+/// d#287
 fn Decoder_mpeg4_ftyp_data(_input: &mut Parser<'_>) -> Result<mpeg4_ftyp_data, ParseError> {
-let major_brand = (Decoder284(_input))?;
+let major_brand = (Decoder286(_input))?;
 let minor_version = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
@@ -28407,7 +29029,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder284(_input))?;
+let next_elem = (Decoder286(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -28418,13 +29040,13 @@ accum
 PResult::Ok(mpeg4_ftyp_data { major_brand, minor_version, compatible_brands })
 }
 
-/// d#286
+/// d#288
 fn Decoder_mpeg4_meta_atom(_input: &mut Parser<'_>) -> Result<mpeg4_meta_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -28435,7 +29057,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 5095757730543354711u64)
+try_sub!(x, 16u64, 1283209893442238385u64)
 },
 
 _ => {
@@ -28452,13 +29074,13 @@ ret
 PResult::Ok(mpeg4_meta_atom { size_field, r#type, size, data })
 }
 
-/// d#287
+/// d#289
 fn Decoder_mpeg4_moov_atom(_input: &mut Parser<'_>) -> Result<mpeg4_moov_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -28469,7 +29091,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 6515957116553005671u64)
+try_sub!(x, 16u64, 7474037925185307628u64)
 },
 
 _ => {
@@ -28566,7 +29188,7 @@ ret
 PResult::Ok(mpeg4_moov_atom { size_field, r#type, size, data })
 }
 
-/// d#288
+/// d#290
 fn Decoder_mpeg4_mvhd_data(_input: &mut Parser<'_>) -> Result<mpeg4_mvhd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -28673,13 +29295,13 @@ u32be(x)
 PResult::Ok(mpeg4_mvhd_data { version, flags, fields, rate, volume, reserved1, reserved2, matrix, pre_defined, next_track_ID })
 }
 
-/// d#289
+/// d#291
 fn Decoder_mpeg4_trak_atom(_input: &mut Parser<'_>) -> Result<mpeg4_trak_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -28690,7 +29312,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 11789784461021426583u64)
+try_sub!(x, 16u64, 17780439059155340308u64)
 },
 
 _ => {
@@ -28787,13 +29409,13 @@ ret
 PResult::Ok(mpeg4_trak_atom { size_field, r#type, size, data })
 }
 
-/// d#290
+/// d#292
 fn Decoder_mpeg4_udta_atom(_input: &mut Parser<'_>) -> Result<mpeg4_udta_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -28804,7 +29426,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 15337804701822118436u64)
+try_sub!(x, 16u64, 10170756778737993654u64)
 },
 
 _ => {
@@ -28875,7 +29497,7 @@ ret
 PResult::Ok(mpeg4_udta_atom { size_field, r#type, size, data })
 }
 
-/// d#291
+/// d#293
 fn Decoder_mpeg4_tkhd_data(_input: &mut Parser<'_>) -> Result<mpeg4_tkhd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -28987,13 +29609,13 @@ u32be(x)
 PResult::Ok(mpeg4_tkhd_data { version, flags, fields, reserved2, layer, alternate_group, volume, reserved1, matrix, width, height })
 }
 
-/// d#292
+/// d#294
 fn Decoder_mpeg4_edts_atom(_input: &mut Parser<'_>) -> Result<mpeg4_edts_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29004,7 +29626,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 8306706226429158303u64)
+try_sub!(x, 16u64, 8902666087419502325u64)
 },
 
 _ => {
@@ -29051,13 +29673,13 @@ ret
 PResult::Ok(mpeg4_edts_atom { size_field, r#type, size, data })
 }
 
-/// d#293
+/// d#295
 fn Decoder_mpeg4_mdia_atom(_input: &mut Parser<'_>) -> Result<mpeg4_mdia_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29068,7 +29690,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 7258731811542513498u64)
+try_sub!(x, 16u64, 7807103255128873628u64)
 },
 
 _ => {
@@ -29085,7 +29707,7 @@ ret
 PResult::Ok(mpeg4_mdia_atom { size_field, r#type, size, data })
 }
 
-/// d#294
+/// d#296
 fn Decoder_mpeg4_mdia_atom_data(_input: &mut Parser<'_>, r#type: (u8, u8, u8, u8)) -> Result<mpeg4_mdia_atom_data, ParseError> {
 PResult::Ok(match r#type {
 (104u8, 100u8, 108u8, 114u8) => {
@@ -29150,7 +29772,7 @@ mpeg4_mdia_atom_data::unknown(inner)
 })
 }
 
-/// d#295
+/// d#297
 fn Decoder_mpeg4_mdia_hdlr_data(_input: &mut Parser<'_>) -> Result<mpeg4_mdia_hdlr_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29158,7 +29780,7 @@ let component_type = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let component_subtype = (Decoder284(_input))?;
+let component_subtype = (Decoder286(_input))?;
 let component_manufacturer = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
@@ -29188,7 +29810,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1283209893442238385u64));
+return Err(ParseError::ExcludedBranch(7840596951976883698u64));
 }
 };
 _input.close_peek_context()?;
@@ -29201,7 +29823,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1920187793319100008u64));
+return Err(ParseError::ExcludedBranch(8004105446758774533u64));
 }
 };
 accum.push(next_elem)
@@ -29216,7 +29838,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7474037925185307628u64));
+return Err(ParseError::ExcludedBranch(12569316739694558801u64));
 }
 };
 chars.clone()
@@ -29224,7 +29846,7 @@ chars.clone()
 PResult::Ok(mpeg4_mdia_hdlr_data { version, flags, component_type, component_subtype, component_manufacturer, component_flags, component_flags_mask, component_name })
 }
 
-/// d#296
+/// d#298
 fn Decoder_mpeg4_mdhd_data(_input: &mut Parser<'_>) -> Result<mpeg4_mdhd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29290,13 +29912,13 @@ u16be(x)
 PResult::Ok(mpeg4_mdhd_data { version, flags, fields, language, pre_defined })
 }
 
-/// d#297
+/// d#299
 fn Decoder_mpeg4_minf_atom(_input: &mut Parser<'_>) -> Result<mpeg4_minf_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29307,7 +29929,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 17780439059155340308u64)
+try_sub!(x, 16u64, 7227788188777836434u64)
 },
 
 _ => {
@@ -29409,7 +30031,7 @@ ret
 PResult::Ok(mpeg4_minf_atom { size_field, r#type, size, data })
 }
 
-/// d#298
+/// d#300
 fn Decoder_mpeg4_vmhd_data(_input: &mut Parser<'_>) -> Result<mpeg4_vmhd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29431,7 +30053,7 @@ accum
 PResult::Ok(mpeg4_vmhd_data { version, flags, graphicsmode, opcolor })
 }
 
-/// d#299
+/// d#301
 fn Decoder_mpeg4_smhd_data(_input: &mut Parser<'_>) -> Result<mpeg4_smhd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29446,13 +30068,13 @@ u16be(x)
 PResult::Ok(mpeg4_smhd_data { version, flags, balance, reserved })
 }
 
-/// d#300
+/// d#302
 fn Decoder_mpeg4_dinf_atom(_input: &mut Parser<'_>) -> Result<mpeg4_dinf_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29463,7 +30085,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 10170756778737993654u64)
+try_sub!(x, 16u64, 12550558264664848853u64)
 },
 
 _ => {
@@ -29510,13 +30132,13 @@ ret
 PResult::Ok(mpeg4_dinf_atom { size_field, r#type, size, data })
 }
 
-/// d#301
+/// d#303
 fn Decoder_mpeg4_stbl_atom(_input: &mut Parser<'_>) -> Result<mpeg4_stbl_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29527,7 +30149,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 8902666087419502325u64)
+try_sub!(x, 16u64, 1891774877762105457u64)
 },
 
 _ => {
@@ -29619,7 +30241,7 @@ ret
 PResult::Ok(mpeg4_stbl_atom { size_field, r#type, size, data })
 }
 
-/// d#302
+/// d#304
 fn Decoder_mpeg4_stsd_data(_input: &mut Parser<'_>) -> Result<mpeg4_stsd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29638,7 +30260,7 @@ accum
 PResult::Ok(mpeg4_stsd_data { version, flags, entry_count, sample_entries })
 }
 
-/// d#303
+/// d#305
 fn Decoder_mpeg4_stts_data(_input: &mut Parser<'_>) -> Result<mpeg4_stts_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29657,7 +30279,7 @@ accum
 PResult::Ok(mpeg4_stts_data { version, flags, entry_count, sample_entries })
 }
 
-/// d#304
+/// d#306
 fn Decoder_mpeg4_ctts_data(_input: &mut Parser<'_>) -> Result<mpeg4_ctts_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29676,7 +30298,7 @@ accum
 PResult::Ok(mpeg4_ctts_data { version, flags, entry_count, sample_entries })
 }
 
-/// d#305
+/// d#307
 fn Decoder_mpeg4_stss_data(_input: &mut Parser<'_>) -> Result<mpeg4_stss_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29698,7 +30320,7 @@ accum
 PResult::Ok(mpeg4_stss_data { version, flags, entry_count, sample_number })
 }
 
-/// d#306
+/// d#308
 fn Decoder_mpeg4_stsc_data(_input: &mut Parser<'_>) -> Result<mpeg4_stsc_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29731,7 +30353,7 @@ accum
 PResult::Ok(mpeg4_stsc_data { version, flags, entry_count, chunk_entries })
 }
 
-/// d#307
+/// d#309
 fn Decoder_mpeg4_stsz_data(_input: &mut Parser<'_>) -> Result<mpeg4_stsz_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29759,7 +30381,7 @@ None
 PResult::Ok(mpeg4_stsz_data { version, flags, sample_size, sample_count, entry_size })
 }
 
-/// d#308
+/// d#310
 fn Decoder_mpeg4_stco_data(_input: &mut Parser<'_>) -> Result<mpeg4_stco_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29781,7 +30403,7 @@ accum
 PResult::Ok(mpeg4_stco_data { version, flags, entry_count, chunk_offset })
 }
 
-/// d#309
+/// d#311
 fn Decoder_mpeg4_co64_data(_input: &mut Parser<'_>) -> Result<mpeg4_co64_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29803,7 +30425,7 @@ accum
 PResult::Ok(mpeg4_co64_data { version, flags, entry_count, chunk_offset })
 }
 
-/// d#310
+/// d#312
 fn Decoder_mpeg4_sgpd_data(_input: &mut Parser<'_>) -> Result<mpeg4_sgpd_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29850,7 +30472,7 @@ accum
 PResult::Ok(mpeg4_sgpd_data { version, flags, grouping_type, default_length, entry_count, sample_groups })
 }
 
-/// d#311
+/// d#313
 fn Decoder_mpeg4_sbgp_data(_input: &mut Parser<'_>) -> Result<mpeg4_sbgp_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29889,7 +30511,7 @@ accum
 PResult::Ok(mpeg4_sbgp_data { version, flags, grouping_type, grouping_type_parameter, entry_count, sample_groups })
 }
 
-/// d#312
+/// d#314
 fn Decoder_mpeg4_ctts_sample_entry(_input: &mut Parser<'_>) -> Result<mpeg4_ctts_sample_entry, ParseError> {
 let sample_count = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29902,7 +30524,7 @@ u32be(x)
 PResult::Ok(mpeg4_ctts_sample_entry { sample_count, sample_offset })
 }
 
-/// d#313
+/// d#315
 fn Decoder_mpeg4_stts_sample_entry(_input: &mut Parser<'_>) -> Result<mpeg4_stts_sample_entry, ParseError> {
 let sample_count = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29915,13 +30537,13 @@ u32be(x)
 PResult::Ok(mpeg4_stts_sample_entry { sample_count, sample_delta })
 }
 
-/// d#314
+/// d#316
 fn Decoder_mpeg4_dref_data_data(_input: &mut Parser<'_>) -> Result<mpeg4_dref_data_data, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -29932,7 +30554,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 7807103255128873628u64)
+try_sub!(x, 16u64, 5515497093089591991u64)
 },
 
 _ => {
@@ -29969,7 +30591,7 @@ ret
 PResult::Ok(mpeg4_dref_data_data { size_field, r#type, size, data })
 }
 
-/// d#315
+/// d#317
 fn Decoder_mpeg4_dref_data(_input: &mut Parser<'_>) -> Result<mpeg4_dref_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -29990,7 +30612,7 @@ ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder316(_input))?;
+let next_elem = (Decoder318(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -30001,13 +30623,13 @@ accum
 PResult::Ok(mpeg4_dref_data { version, flags, number_of_entries, data })
 }
 
-/// d#316
-fn Decoder316(_input: &mut Parser<'_>) -> Result<mpeg4_dref_data_data, ParseError> {
+/// d#318
+fn Decoder318(_input: &mut Parser<'_>) -> Result<mpeg4_dref_data_data, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30018,7 +30640,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 8004105446758774533u64)
+try_sub!(x, 16u64, 6882184431082022206u64)
 },
 
 _ => {
@@ -30055,7 +30677,7 @@ ret
 PResult::Ok(mpeg4_dref_data_data { size_field, r#type, size, data })
 }
 
-/// d#317
+/// d#319
 fn Decoder_mpeg4_elst_data(_input: &mut Parser<'_>) -> Result<mpeg4_elst_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30074,7 +30696,7 @@ accum
 PResult::Ok(mpeg4_elst_data { version, flags, number_of_entries, edit_list_table })
 }
 
-/// d#318
+/// d#320
 fn Decoder_mpeg4_elst_data_entry(_input: &mut Parser<'_>) -> Result<mpeg4_elst_data_entry, ParseError> {
 let track_duration = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30091,7 +30713,7 @@ u32be(x)
 PResult::Ok(mpeg4_elst_data_entry { track_duration, media_time, media_rate })
 }
 
-/// d#319
+/// d#321
 fn Decoder_mpeg4_meta_atom_data(_input: &mut Parser<'_>, r#type: (u8, u8, u8, u8)) -> Result<mpeg4_meta_atom_data, ParseError> {
 PResult::Ok(match r#type {
 (100u8, 105u8, 110u8, 102u8) => {
@@ -30221,7 +30843,7 @@ mpeg4_meta_atom_data::unknown(inner)
 })
 }
 
-/// d#320
+/// d#322
 fn Decoder_mpeg4_meta_hdlr_data(_input: &mut Parser<'_>) -> Result<mpeg4_meta_hdlr_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30229,7 +30851,7 @@ let predefined = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let handler_type = (Decoder284(_input))?;
+let handler_type = (Decoder286(_input))?;
 let reserved = {
 let arg0 = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30262,7 +30884,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(12569316739694558801u64));
+return Err(ParseError::ExcludedBranch(3998072683184925592u64));
 }
 };
 _input.close_peek_context()?;
@@ -30275,7 +30897,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2967911718584065013u64));
+return Err(ParseError::ExcludedBranch(29850628954056690u64));
 }
 };
 accum.push(next_elem)
@@ -30290,7 +30912,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7227788188777836434u64));
+return Err(ParseError::ExcludedBranch(7279615132236188739u64));
 }
 };
 chars.clone()
@@ -30298,7 +30920,7 @@ chars.clone()
 PResult::Ok(mpeg4_meta_hdlr_data { version, flags, predefined, handler_type, reserved, name })
 }
 
-/// d#321
+/// d#323
 fn Decoder_mpeg4_pitm_atom_data(_input: &mut Parser<'_>) -> Result<mpeg4_pitm_atom_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30322,7 +30944,7 @@ mpeg4_pitm_atom_data_item_ID::Id32(inner)
 PResult::Ok(mpeg4_pitm_atom_data { version, flags, item_ID })
 }
 
-/// d#322
+/// d#324
 fn Decoder_mpeg4_iinf(_input: &mut Parser<'_>) -> Result<mpeg4_iinf, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30351,7 +30973,7 @@ accum
 PResult::Ok(mpeg4_iinf { version, flags, entry_count, item_info_entry })
 }
 
-/// d#323
+/// d#325
 fn Decoder_mpeg4_iref_data(_input: &mut Parser<'_>) -> Result<mpeg4_iref_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30413,7 +31035,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(mpeg4_iref_data { version, flags, single_item_reference })
 }
 
-/// d#324
+/// d#326
 fn Decoder_mpeg4_iloc_atom_data(_input: &mut Parser<'_>) -> Result<mpeg4_iloc_atom_data, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30516,13 +31138,13 @@ accum
 PResult::Ok(mpeg4_iloc_atom_data { version, flags, offset_size, length_size, base_offset_size, index_size, item_count, items })
 }
 
-/// d#325
+/// d#327
 fn Decoder_mpeg4_ilst_atom(_input: &mut Parser<'_>) -> Result<mpeg4_ilst_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30533,7 +31155,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 12550558264664848853u64)
+try_sub!(x, 16u64, 13863787293436782080u64)
 },
 
 _ => {
@@ -30600,13 +31222,13 @@ ret
 PResult::Ok(mpeg4_ilst_atom { size_field, r#type, size, data })
 }
 
-/// d#326
+/// d#328
 fn Decoder_mpeg4_tool_atom(_input: &mut Parser<'_>) -> Result<mpeg4_tool_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30617,7 +31239,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 1891774877762105457u64)
+try_sub!(x, 16u64, 2157707350523277837u64)
 },
 
 _ => {
@@ -30664,7 +31286,7 @@ ret
 PResult::Ok(mpeg4_tool_atom { size_field, r#type, size, data })
 }
 
-/// d#327
+/// d#329
 fn Decoder_mpeg4_tool_atom_data_data(_input: &mut Parser<'_>) -> Result<mpeg4_tool_atom_data_data, ParseError> {
 let type_indicator = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30698,7 +31320,7 @@ accum
 PResult::Ok(mpeg4_tool_atom_data_data { type_indicator, locale_indicator, value })
 }
 
-/// d#328
+/// d#330
 fn Decoder_mpeg4_iloc_extent(_input: &mut Parser<'_>, offset_size: u8, length_size: u8, index_size: u8) -> Result<mpeg4_iloc_extent, ParseError> {
 let extent_index = match index_size {
 0u8 => {
@@ -30769,13 +31391,13 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 PResult::Ok(mpeg4_iloc_extent { extent_index, extent_offset, extent_length })
 }
 
-/// d#329
+/// d#331
 fn Decoder_mpeg4_iref_data_single_item_reference_small(_input: &mut Parser<'_>) -> Result<mpeg4_iref_data_single_item_reference_small, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30786,7 +31408,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 5515497093089591991u64)
+try_sub!(x, 16u64, 14950271805613481359u64)
 },
 
 _ => {
@@ -30824,13 +31446,13 @@ ret
 PResult::Ok(mpeg4_iref_data_single_item_reference_small { size_field, r#type, size, data })
 }
 
-/// d#330
+/// d#332
 fn Decoder_mpeg4_iref_data_single_item_reference_large(_input: &mut Parser<'_>) -> Result<mpeg4_iref_data_single_item_reference_large, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30841,7 +31463,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 6882184431082022206u64)
+try_sub!(x, 16u64, 11265176092564100083u64)
 },
 
 _ => {
@@ -30879,13 +31501,13 @@ ret
 PResult::Ok(mpeg4_iref_data_single_item_reference_large { size_field, r#type, size, data })
 }
 
-/// d#331
+/// d#333
 fn Decoder_mpeg4_iinf_atom(_input: &mut Parser<'_>) -> Result<mpeg4_iinf_atom, ParseError> {
 let size_field = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u32be(x)
 };
-let r#type = (Decoder284(_input))?;
+let r#type = (Decoder286(_input))?;
 let size = match size_field {
 0u32 => {
 0u64
@@ -30896,7 +31518,7 @@ let x = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
 u64be(x)
 };
-try_sub!(x, 16u64, 29850628954056690u64)
+try_sub!(x, 16u64, 10473830801714814973u64)
 },
 
 _ => {
@@ -30943,7 +31565,7 @@ ret
 PResult::Ok(mpeg4_iinf_atom { size_field, r#type, size, data })
 }
 
-/// d#332
+/// d#334
 fn Decoder_mpeg4_iinf_atom_data_infe(_input: &mut Parser<'_>) -> Result<mpeg4_iinf_atom_data_infe, ParseError> {
 let version = _input.read_byte()?;
 let flags = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -30951,7 +31573,7 @@ let fields = (Decoder_mpeg4_infe_data_fields(_input, version))?;
 PResult::Ok(mpeg4_iinf_atom_data_infe { version, flags, fields })
 }
 
-/// d#333
+/// d#335
 fn Decoder_mpeg4_infe_data_fields(_input: &mut Parser<'_>, version: u8) -> Result<mpeg4_infe_data_fields, ParseError> {
 PResult::Ok(match version < 2u8 {
 true => {
@@ -30966,7 +31588,7 @@ mpeg4_infe_data_fields::Version2(inner)
 })
 }
 
-/// d#334
+/// d#336
 fn Decoder_mpeg4_infe_data_fields_version_lt2(_input: &mut Parser<'_>) -> Result<mpeg4_infe_data_fields_version_lt2, ParseError> {
 let item_ID = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -30993,7 +31615,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7279615132236188739u64));
+return Err(ParseError::ExcludedBranch(5334325531610156978u64));
 }
 };
 _input.close_peek_context()?;
@@ -31006,7 +31628,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17636172564439370608u64));
+return Err(ParseError::ExcludedBranch(16975008930446149745u64));
 }
 };
 accum.push(next_elem)
@@ -31021,7 +31643,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13863787293436782080u64));
+return Err(ParseError::ExcludedBranch(760820951392925727u64));
 }
 };
 chars.clone()
@@ -31043,7 +31665,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16714498072262546943u64));
+return Err(ParseError::ExcludedBranch(14363790737598139216u64));
 }
 };
 _input.close_peek_context()?;
@@ -31056,7 +31678,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2157707350523277837u64));
+return Err(ParseError::ExcludedBranch(4600414761378562541u64));
 }
 };
 accum.push(next_elem)
@@ -31071,7 +31693,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15134222038433106385u64));
+return Err(ParseError::ExcludedBranch(18313399323903636110u64));
 }
 };
 chars.clone()
@@ -31093,7 +31715,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14950271805613481359u64));
+return Err(ParseError::ExcludedBranch(15786118691017431738u64));
 }
 };
 _input.close_peek_context()?;
@@ -31106,7 +31728,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5499566165243611472u64));
+return Err(ParseError::ExcludedBranch(16165934354425559621u64));
 }
 };
 accum.push(next_elem)
@@ -31121,7 +31743,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11265176092564100083u64));
+return Err(ParseError::ExcludedBranch(16399036514137665776u64));
 }
 };
 chars.clone()
@@ -31129,7 +31751,7 @@ chars.clone()
 PResult::Ok(mpeg4_infe_data_fields_version_lt2 { item_ID, item_protection_index, item_name, content_type, content_encoding })
 }
 
-/// d#335
+/// d#337
 fn Decoder_mpeg4_infe_data_fields_version_gte2(_input: &mut Parser<'_>, version: u8) -> Result<mpeg4_infe_data_fields_version_gte2, ParseError> {
 let item_ID = match version == 2u8 {
 true => {
@@ -31149,7 +31771,7 @@ let item_protection_index = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
-let item_type = (Decoder284(_input))?;
+let item_type = (Decoder286(_input))?;
 let item_name = {
 let chars = {
 let mut accum = Vec::new();
@@ -31167,7 +31789,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14916894554939814670u64));
+return Err(ParseError::ExcludedBranch(7931358881575056193u64));
 }
 };
 _input.close_peek_context()?;
@@ -31180,7 +31802,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10473830801714814973u64));
+return Err(ParseError::ExcludedBranch(17863486658382945784u64));
 }
 };
 accum.push(next_elem)
@@ -31195,7 +31817,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5334325531610156978u64));
+return Err(ParseError::ExcludedBranch(11515797873012483658u64));
 }
 };
 chars.clone()
@@ -31204,7 +31826,7 @@ let extra_fields = (Decoder_mpeg4_infe_atom_data_extra_fields(_input, item_type)
 PResult::Ok(mpeg4_infe_data_fields_version_gte2 { item_ID, item_protection_index, item_type, item_name, extra_fields })
 }
 
-/// d#336
+/// d#338
 fn Decoder_mpeg4_infe_atom_data_extra_fields(_input: &mut Parser<'_>, item_type: (u8, u8, u8, u8)) -> Result<mpeg4_infe_atom_data_extra_fields, ParseError> {
 PResult::Ok(match item_type {
 (109u8, 105u8, 109u8, 101u8) => {
@@ -31223,7 +31845,7 @@ mpeg4_infe_atom_data_extra_fields::unknown
 })
 }
 
-/// d#337
+/// d#339
 fn Decoder_mpeg4_infe_atom_data_extra_fields_mime(_input: &mut Parser<'_>) -> Result<mpeg4_infe_atom_data_extra_fields_mime, ParseError> {
 let content_type = {
 let chars = {
@@ -31242,7 +31864,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16975008930446149745u64));
+return Err(ParseError::ExcludedBranch(8584109755265226714u64));
 }
 };
 _input.close_peek_context()?;
@@ -31255,7 +31877,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(760820951392925727u64));
+return Err(ParseError::ExcludedBranch(8076978189295213982u64));
 }
 };
 accum.push(next_elem)
@@ -31270,7 +31892,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14363790737598139216u64));
+return Err(ParseError::ExcludedBranch(11570281271401624317u64));
 }
 };
 chars.clone()
@@ -31278,7 +31900,7 @@ chars.clone()
 PResult::Ok(mpeg4_infe_atom_data_extra_fields_mime { content_type })
 }
 
-/// d#338
+/// d#340
 fn Decoder_mpeg4_infe_atom_data_extra_fields_uri(_input: &mut Parser<'_>) -> Result<mpeg4_infe_atom_data_extra_fields_uri, ParseError> {
 let item_uri_type = {
 let chars = {
@@ -31297,7 +31919,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4600414761378562541u64));
+return Err(ParseError::ExcludedBranch(14687724984806605719u64));
 }
 };
 _input.close_peek_context()?;
@@ -31310,7 +31932,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18313399323903636110u64));
+return Err(ParseError::ExcludedBranch(1378805635639824117u64));
 }
 };
 accum.push(next_elem)
@@ -31325,7 +31947,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15786118691017431738u64));
+return Err(ParseError::ExcludedBranch(8385173961957899741u64));
 }
 };
 chars.clone()
@@ -31333,14 +31955,14 @@ chars.clone()
 PResult::Ok(mpeg4_infe_atom_data_extra_fields_uri { item_uri_type })
 }
 
-/// d#339
+/// d#341
 fn Decoder_jpeg_soi(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16165934354425559621u64));
+return Err(ParseError::ExcludedBranch(8407356061009412694u64));
 }
 };
 let marker = {
@@ -31348,13 +31970,13 @@ let b = _input.read_byte()?;
 if b == 216 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16399036514137665776u64));
+return Err(ParseError::ExcludedBranch(6881565717664829242u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
 }
 
-/// d#340
+/// d#342
 fn Decoder_jpeg_frame(_input: &mut Parser<'_>) -> Result<jpeg_frame, ParseError> {
 let initial_segment = (Decoder_jpeg_frame_initial_segment(_input))?;
 let segments = {
@@ -31503,11 +32125,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(7931358881575056193u64));
+return Err(ParseError::ExcludedBranch(13752480002470540422u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(17863486658382945784u64));
+return Err(ParseError::ExcludedBranch(17107648091243309207u64));
 };
 _input.close_peek_context()?;
 ret
@@ -31628,11 +32250,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11515797873012483658u64));
+return Err(ParseError::ExcludedBranch(5534609128357633386u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(8584109755265226714u64));
+return Err(ParseError::ExcludedBranch(14539762430836305896u64));
 };
 _input.close_peek_context()?;
 ret
@@ -31648,7 +32270,7 @@ None
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8076978189295213982u64));
+return Err(ParseError::ExcludedBranch(16625761205375889740u64));
 }
 }
 };
@@ -31754,18 +32376,18 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11570281271401624317u64));
+return Err(ParseError::ExcludedBranch(2662265345698212949u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(14687724984806605719u64));
+return Err(ParseError::ExcludedBranch(3344648651879382526u64));
 };
 _input.close_peek_context()?;
 ret
 }
 };
 if matching_ix == 0 {
-let next_elem = (Decoder347(_input))?;
+let next_elem = (Decoder349(_input))?;
 accum.push(next_elem)
 } else {
 break
@@ -31776,14 +32398,14 @@ accum
 PResult::Ok(jpeg_frame { initial_segment, segments, header, scan, dnl, scans })
 }
 
-/// d#341
-fn Decoder341(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
+/// d#343
+fn Decoder343(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1378805635639824117u64));
+return Err(ParseError::ExcludedBranch(8599210436172030522u64));
 }
 };
 let marker = {
@@ -31791,13 +32413,13 @@ let b = _input.read_byte()?;
 if b == 217 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8385173961957899741u64));
+return Err(ParseError::ExcludedBranch(3484767027554133518u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
 }
 
-/// d#342
+/// d#344
 fn Decoder_jpeg_frame_initial_segment(_input: &mut Parser<'_>) -> Result<jpeg_frame_initial_segment, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -31814,11 +32436,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8407356061009412694u64));
+return Err(ParseError::ExcludedBranch(15403934492100194569u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(6881565717664829242u64));
+return Err(ParseError::ExcludedBranch(12041148194529633639u64));
 };
 _input.close_peek_context()?;
 ret
@@ -31836,12 +32458,12 @@ jpeg_frame_initial_segment::app1(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13752480002470540422u64));
+return Err(ParseError::ExcludedBranch(2288772415159374970u64));
 }
 })
 }
 
-/// d#343
+/// d#345
 fn Decoder_jpeg_table_or_misc(_input: &mut Parser<'_>) -> Result<jpeg_table_or_misc, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -31934,11 +32556,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17107648091243309207u64));
+return Err(ParseError::ExcludedBranch(17888323854924040413u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(5534609128357633386u64));
+return Err(ParseError::ExcludedBranch(6279087434444973374u64));
 };
 _input.close_peek_context()?;
 ret
@@ -31981,82 +32603,82 @@ jpeg_table_or_misc::app2(inner)
 },
 
 7 => {
-let inner = (Decoder388(_input))?;
+let inner = (Decoder390(_input))?;
 jpeg_table_or_misc::app3(inner)
 },
 
 8 => {
-let inner = (Decoder389(_input))?;
+let inner = (Decoder391(_input))?;
 jpeg_table_or_misc::app4(inner)
 },
 
 9 => {
-let inner = (Decoder390(_input))?;
+let inner = (Decoder392(_input))?;
 jpeg_table_or_misc::app5(inner)
 },
 
 10 => {
-let inner = (Decoder391(_input))?;
+let inner = (Decoder393(_input))?;
 jpeg_table_or_misc::app6(inner)
 },
 
 11 => {
-let inner = (Decoder392(_input))?;
+let inner = (Decoder394(_input))?;
 jpeg_table_or_misc::app7(inner)
 },
 
 12 => {
-let inner = (Decoder393(_input))?;
+let inner = (Decoder395(_input))?;
 jpeg_table_or_misc::app8(inner)
 },
 
 13 => {
-let inner = (Decoder394(_input))?;
+let inner = (Decoder396(_input))?;
 jpeg_table_or_misc::app9(inner)
 },
 
 14 => {
-let inner = (Decoder395(_input))?;
+let inner = (Decoder397(_input))?;
 jpeg_table_or_misc::app10(inner)
 },
 
 15 => {
-let inner = (Decoder396(_input))?;
+let inner = (Decoder398(_input))?;
 jpeg_table_or_misc::app11(inner)
 },
 
 16 => {
-let inner = (Decoder397(_input))?;
+let inner = (Decoder399(_input))?;
 jpeg_table_or_misc::app12(inner)
 },
 
 17 => {
-let inner = (Decoder398(_input))?;
+let inner = (Decoder400(_input))?;
 jpeg_table_or_misc::app13(inner)
 },
 
 18 => {
-let inner = (Decoder399(_input))?;
+let inner = (Decoder401(_input))?;
 jpeg_table_or_misc::app14(inner)
 },
 
 19 => {
-let inner = (Decoder400(_input))?;
+let inner = (Decoder402(_input))?;
 jpeg_table_or_misc::app15(inner)
 },
 
 20 => {
-let inner = (Decoder401(_input))?;
+let inner = (Decoder403(_input))?;
 jpeg_table_or_misc::com(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14539762430836305896u64));
+return Err(ParseError::ExcludedBranch(11074951631636946051u64));
 }
 })
 }
 
-/// d#344
+/// d#346
 fn Decoder_jpeg_frame_header(_input: &mut Parser<'_>) -> Result<jpeg_frame_header, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -32117,11 +32739,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16625761205375889740u64));
+return Err(ParseError::ExcludedBranch(15601622509425384091u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(2662265345698212949u64));
+return Err(ParseError::ExcludedBranch(13675295148592556047u64));
 };
 _input.close_peek_context()?;
 ret
@@ -32134,72 +32756,72 @@ jpeg_frame_header::sof0(inner)
 },
 
 1 => {
-let inner = (Decoder367(_input))?;
+let inner = (Decoder369(_input))?;
 jpeg_frame_header::sof1(inner)
 },
 
 2 => {
-let inner = (Decoder368(_input))?;
+let inner = (Decoder370(_input))?;
 jpeg_frame_header::sof2(inner)
 },
 
 3 => {
-let inner = (Decoder369(_input))?;
+let inner = (Decoder371(_input))?;
 jpeg_frame_header::sof3(inner)
 },
 
 4 => {
-let inner = (Decoder370(_input))?;
+let inner = (Decoder372(_input))?;
 jpeg_frame_header::sof5(inner)
 },
 
 5 => {
-let inner = (Decoder371(_input))?;
+let inner = (Decoder373(_input))?;
 jpeg_frame_header::sof6(inner)
 },
 
 6 => {
-let inner = (Decoder372(_input))?;
+let inner = (Decoder374(_input))?;
 jpeg_frame_header::sof7(inner)
 },
 
 7 => {
-let inner = (Decoder373(_input))?;
+let inner = (Decoder375(_input))?;
 jpeg_frame_header::sof9(inner)
 },
 
 8 => {
-let inner = (Decoder374(_input))?;
+let inner = (Decoder376(_input))?;
 jpeg_frame_header::sof10(inner)
 },
 
 9 => {
-let inner = (Decoder375(_input))?;
+let inner = (Decoder377(_input))?;
 jpeg_frame_header::sof11(inner)
 },
 
 10 => {
-let inner = (Decoder376(_input))?;
+let inner = (Decoder378(_input))?;
 jpeg_frame_header::sof13(inner)
 },
 
 11 => {
-let inner = (Decoder377(_input))?;
+let inner = (Decoder379(_input))?;
 jpeg_frame_header::sof14(inner)
 },
 
 12 => {
-let inner = (Decoder378(_input))?;
+let inner = (Decoder380(_input))?;
 jpeg_frame_header::sof15(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3344648651879382526u64));
+return Err(ParseError::ExcludedBranch(4569970360394099475u64));
 }
 })
 }
 
-/// d#345
+/// d#347
 fn Decoder_jpeg_scan(_input: &mut Parser<'_>) -> Result<jpeg_scan, ParseError> {
 let segments = {
 let mut accum = Vec::new();
@@ -32299,11 +32921,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8599210436172030522u64));
+return Err(ParseError::ExcludedBranch(9110520999974091875u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(3484767027554133518u64));
+return Err(ParseError::ExcludedBranch(15293691521783146694u64));
 };
 _input.close_peek_context()?;
 ret
@@ -32319,11 +32941,11 @@ break
 accum
 };
 let sos = (Decoder_jpeg_sos(_input))?;
-let data = (Decoder365(_input))?;
+let data = (Decoder367(_input))?;
 PResult::Ok(jpeg_scan { segments, sos, data })
 }
 
-/// d#346
+/// d#348
 fn Decoder_jpeg_dnl(_input: &mut Parser<'_>) -> Result<jpeg_dnl, ParseError> {
 let marker = {
 {
@@ -32331,7 +32953,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15403934492100194569u64));
+return Err(ParseError::ExcludedBranch(15433822888775103886u64));
 }
 };
 let marker = {
@@ -32339,7 +32961,7 @@ let b = _input.read_byte()?;
 if b == 220 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12041148194529633639u64));
+return Err(ParseError::ExcludedBranch(8403192837054512577u64));
 }
 };
 jpeg_soi { marker }
@@ -32358,8 +32980,8 @@ ret
 PResult::Ok(jpeg_dnl { marker, length, data })
 }
 
-/// d#347
-fn Decoder347(_input: &mut Parser<'_>) -> Result<jpeg_scan, ParseError> {
+/// d#349
+fn Decoder349(_input: &mut Parser<'_>) -> Result<jpeg_scan, ParseError> {
 let segments = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -32458,11 +33080,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2288772415159374970u64));
+return Err(ParseError::ExcludedBranch(17073037115051226650u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(17888323854924040413u64));
+return Err(ParseError::ExcludedBranch(3975307768385535064u64));
 };
 _input.close_peek_context()?;
 ret
@@ -32482,7 +33104,7 @@ let data = (Decoder_jpeg_scan_data(_input))?;
 PResult::Ok(jpeg_scan { segments, sos, data })
 }
 
-/// d#348
+/// d#350
 fn Decoder_jpeg_sos(_input: &mut Parser<'_>) -> Result<jpeg_sos, ParseError> {
 let marker = {
 {
@@ -32490,7 +33112,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6279087434444973374u64));
+return Err(ParseError::ExcludedBranch(10599514554463239458u64));
 }
 };
 let marker = {
@@ -32498,7 +33120,7 @@ let b = _input.read_byte()?;
 if b == 218 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11074951631636946051u64));
+return Err(ParseError::ExcludedBranch(16112061863928357291u64));
 }
 };
 jpeg_soi { marker }
@@ -32517,7 +33139,7 @@ ret
 PResult::Ok(jpeg_sos { marker, length, data })
 }
 
-/// d#349
+/// d#351
 fn Decoder_jpeg_scan_data(_input: &mut Parser<'_>) -> Result<jpeg_scan_data, ParseError> {
 let scan_data = {
 let mut accum = Vec::new();
@@ -32661,13 +33283,13 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15601622509425384091u64));
+return Err(ParseError::ExcludedBranch(12017601628070515145u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13675295148592556047u64));
+return Err(ParseError::ExcludedBranch(1872233699568519226u64));
 }
 };
 _input.close_peek_context()?;
@@ -32723,7 +33345,7 @@ jpeg_scan_data_entropy_coded_segment::rst7(..) => {
 PResult::Ok(jpeg_scan_data { scan_data, scan_data_stream })
 }
 
-/// d#350
+/// d#352
 fn Decoder_jpeg_scan_data_entropy_coded_segment(_input: &mut Parser<'_>) -> Result<jpeg_scan_data_entropy_coded_segment, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -32772,13 +33394,13 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4569970360394099475u64));
+return Err(ParseError::ExcludedBranch(10708294527730390829u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9110520999974091875u64));
+return Err(ParseError::ExcludedBranch(7432469293302627017u64));
 }
 };
 _input.close_peek_context()?;
@@ -32787,58 +33409,58 @@ ret
 };
 PResult::Ok(match tree_index {
 0 => {
-let inner = (Decoder351(_input))?;
+let inner = (Decoder353(_input))?;
 jpeg_scan_data_entropy_coded_segment::mcu(inner)
 },
 
 1 => {
-let inner = (Decoder352(_input))?;
+let inner = (Decoder354(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst0(inner)
 },
 
 2 => {
-let inner = (Decoder353(_input))?;
+let inner = (Decoder355(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst1(inner)
 },
 
 3 => {
-let inner = (Decoder354(_input))?;
+let inner = (Decoder356(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst2(inner)
 },
 
 4 => {
-let inner = (Decoder355(_input))?;
+let inner = (Decoder357(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst3(inner)
 },
 
 5 => {
-let inner = (Decoder356(_input))?;
+let inner = (Decoder358(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst4(inner)
 },
 
 6 => {
-let inner = (Decoder357(_input))?;
+let inner = (Decoder359(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst5(inner)
 },
 
 7 => {
-let inner = (Decoder358(_input))?;
+let inner = (Decoder360(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst6(inner)
 },
 
 8 => {
-let inner = (Decoder359(_input))?;
+let inner = (Decoder361(_input))?;
 jpeg_scan_data_entropy_coded_segment::rst7(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(15293691521783146694u64));
+return Err(ParseError::ExcludedBranch(13181260675040079306u64));
 }
 })
 }
 
-/// d#351
-fn Decoder351(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+/// d#353
+fn Decoder353(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
 let tree_index = {
 _input.open_peek_context();
 {
@@ -32852,7 +33474,7 @@ byte if (byte != 255) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(3975307768385535064u64));
+return Err(ParseError::ExcludedBranch(9331389203258424019u64));
 }
 };
 _input.close_peek_context()?;
@@ -32865,7 +33487,7 @@ let b = _input.read_byte()?;
 if b != 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15433822888775103886u64));
+return Err(ParseError::ExcludedBranch(9159119361499271180u64));
 }
 },
 
@@ -32876,7 +33498,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8403192837054512577u64));
+return Err(ParseError::ExcludedBranch(7795160901559545235u64));
 }
 };
 let arg1 = {
@@ -32884,7 +33506,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17073037115051226650u64));
+return Err(ParseError::ExcludedBranch(3490919313637905107u64));
 }
 };
 (arg0, arg1)
@@ -32893,51 +33515,9 @@ return Err(ParseError::ExcludedBranch(17073037115051226650u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10599514554463239458u64));
+return Err(ParseError::ExcludedBranch(16679512278832019969u64));
 }
 })
-}
-
-/// d#352
-fn Decoder352(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
-{
-let b = _input.read_byte()?;
-if b == 255 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(16112061863928357291u64));
-}
-};
-let marker = {
-let b = _input.read_byte()?;
-if b == 208 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(12017601628070515145u64));
-}
-};
-PResult::Ok(jpeg_soi { marker })
-}
-
-/// d#353
-fn Decoder353(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
-{
-let b = _input.read_byte()?;
-if b == 255 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(1872233699568519226u64));
-}
-};
-let marker = {
-let b = _input.read_byte()?;
-if b == 209 {
-b
-} else {
-return Err(ParseError::ExcludedBranch(10708294527730390829u64));
-}
-};
-PResult::Ok(jpeg_soi { marker })
 }
 
 /// d#354
@@ -32947,15 +33527,15 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7432469293302627017u64));
+return Err(ParseError::ExcludedBranch(15311158871930328757u64));
 }
 };
 let marker = {
 let b = _input.read_byte()?;
-if b == 210 {
+if b == 208 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13181260675040079306u64));
+return Err(ParseError::ExcludedBranch(9892894478446917378u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
@@ -32968,15 +33548,15 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9159119361499271180u64));
+return Err(ParseError::ExcludedBranch(3585635225240718191u64));
 }
 };
 let marker = {
 let b = _input.read_byte()?;
-if b == 211 {
+if b == 209 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7795160901559545235u64));
+return Err(ParseError::ExcludedBranch(5208404121666294786u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
@@ -32989,15 +33569,15 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3490919313637905107u64));
+return Err(ParseError::ExcludedBranch(237665900562449517u64));
 }
 };
 let marker = {
 let b = _input.read_byte()?;
-if b == 212 {
+if b == 210 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9331389203258424019u64));
+return Err(ParseError::ExcludedBranch(13751590285972774894u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
@@ -33010,15 +33590,15 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16679512278832019969u64));
+return Err(ParseError::ExcludedBranch(12552648416444111338u64));
 }
 };
 let marker = {
 let b = _input.read_byte()?;
-if b == 213 {
+if b == 211 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15311158871930328757u64));
+return Err(ParseError::ExcludedBranch(9201081899504003615u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
@@ -33031,15 +33611,15 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9892894478446917378u64));
+return Err(ParseError::ExcludedBranch(10776065777346510440u64));
 }
 };
 let marker = {
 let b = _input.read_byte()?;
-if b == 214 {
+if b == 212 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3585635225240718191u64));
+return Err(ParseError::ExcludedBranch(1821331332215525359u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
@@ -33052,7 +33632,49 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5208404121666294786u64));
+return Err(ParseError::ExcludedBranch(1550574349011231204u64));
+}
+};
+let marker = {
+let b = _input.read_byte()?;
+if b == 213 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(6867774794241173436u64));
+}
+};
+PResult::Ok(jpeg_soi { marker })
+}
+
+/// d#360
+fn Decoder360(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
+{
+let b = _input.read_byte()?;
+if b == 255 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(3475686103639625566u64));
+}
+};
+let marker = {
+let b = _input.read_byte()?;
+if b == 214 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(4130856500275801127u64));
+}
+};
+PResult::Ok(jpeg_soi { marker })
+}
+
+/// d#361
+fn Decoder361(_input: &mut Parser<'_>) -> Result<jpeg_soi, ParseError> {
+{
+let b = _input.read_byte()?;
+if b == 255 {
+b
+} else {
+return Err(ParseError::ExcludedBranch(11582380281701370059u64));
 }
 };
 let marker = {
@@ -33060,13 +33682,13 @@ let b = _input.read_byte()?;
 if b == 215 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(237665900562449517u64));
+return Err(ParseError::ExcludedBranch(7228157205966134869u64));
 }
 };
 PResult::Ok(jpeg_soi { marker })
 }
 
-/// d#360
+/// d#362
 fn Decoder_jpeg_sos_data(_input: &mut Parser<'_>) -> Result<jpeg_sos_data, ParseError> {
 let num_image_components = {
 let inner = _input.read_byte()?;
@@ -33077,7 +33699,7 @@ matches!(x, 1u8..=4u8)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13751590285972774894u64));
+return Err(ParseError::FalsifiedWhere(2184161105566707760u64));
 }
 };
 let image_components = {
@@ -33097,7 +33719,7 @@ x <= 63u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12552648416444111338u64));
+return Err(ParseError::FalsifiedWhere(9924059786910440358u64));
 }
 };
 let end_spectral_selection = {
@@ -33109,21 +33731,21 @@ x <= 63u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9201081899504003615u64));
+return Err(ParseError::FalsifiedWhere(7274029685341305701u64));
 }
 };
 let approximation_bit_position = (Decoder_jpeg_sos_data_approximation_bit_position(_input))?;
 PResult::Ok(jpeg_sos_data { num_image_components, image_components, start_spectral_selection, end_spectral_selection, approximation_bit_position })
 }
 
-/// d#361
+/// d#363
 fn Decoder_jpeg_sos_image_component(_input: &mut Parser<'_>) -> Result<jpeg_sos_image_component, ParseError> {
 let component_selector = _input.read_byte()?;
 let entropy_coding_table_ids = (Decoder_jpeg_sos_image_component_entropy_coding_table_ids(_input))?;
 PResult::Ok(jpeg_sos_image_component { component_selector, entropy_coding_table_ids })
 }
 
-/// d#362
+/// d#364
 fn Decoder_jpeg_sos_data_approximation_bit_position(_input: &mut Parser<'_>) -> Result<jpeg_sos_data_approximation_bit_position, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let high = _packed_bits >> 4u8 & 15u8;
@@ -33131,7 +33753,7 @@ let low = _packed_bits & 15u8;
 PResult::Ok(jpeg_sos_data_approximation_bit_position { high, low })
 }
 
-/// d#363
+/// d#365
 fn Decoder_jpeg_sos_image_component_entropy_coding_table_ids(_input: &mut Parser<'_>) -> Result<jpeg_sos_image_component_entropy_coding_table_ids, ParseError> {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -33146,11 +33768,11 @@ let entropy_coding_table_ids = inner;
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10776065777346510440u64));
+return Err(ParseError::FalsifiedWhere(16051783775494465147u64));
 })
 }
 
-/// d#364
+/// d#366
 fn Decoder_jpeg_dnl_data(_input: &mut Parser<'_>) -> Result<jpeg_dnl_data, ParseError> {
 let num_lines = {
 let inner = {
@@ -33164,14 +33786,14 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(1821331332215525359u64));
+return Err(ParseError::FalsifiedWhere(13744164271564421708u64));
 }
 };
 PResult::Ok(jpeg_dnl_data { num_lines })
 }
 
-/// d#365
-fn Decoder365(_input: &mut Parser<'_>) -> Result<jpeg_scan_data, ParseError> {
+/// d#367
+fn Decoder367(_input: &mut Parser<'_>) -> Result<jpeg_scan_data, ParseError> {
 let scan_data = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -33318,13 +33940,13 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1550574349011231204u64));
+return Err(ParseError::ExcludedBranch(5892114170581446733u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6867774794241173436u64));
+return Err(ParseError::ExcludedBranch(11821813774070801620u64));
 }
 };
 _input.close_peek_context()?;
@@ -33380,7 +34002,7 @@ jpeg_scan_data_entropy_coded_segment::rst7(..) => {
 PResult::Ok(jpeg_scan_data { scan_data, scan_data_stream })
 }
 
-/// d#366
+/// d#368
 fn Decoder_jpeg_sof0(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
@@ -33388,7 +34010,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3475686103639625566u64));
+return Err(ParseError::ExcludedBranch(14520503729026832983u64));
 }
 };
 let marker = {
@@ -33396,7 +34018,7 @@ let b = _input.read_byte()?;
 if b == 192 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4130856500275801127u64));
+return Err(ParseError::ExcludedBranch(5309491469191307378u64));
 }
 };
 jpeg_soi { marker }
@@ -33415,15 +34037,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#367
-fn Decoder367(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#369
+fn Decoder369(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11582380281701370059u64));
+return Err(ParseError::ExcludedBranch(17983075411320920965u64));
 }
 };
 let marker = {
@@ -33431,7 +34053,7 @@ let b = _input.read_byte()?;
 if b == 193 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7228157205966134869u64));
+return Err(ParseError::ExcludedBranch(7023661717588102849u64));
 }
 };
 jpeg_soi { marker }
@@ -33450,15 +34072,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#368
-fn Decoder368(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#370
+fn Decoder370(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2184161105566707760u64));
+return Err(ParseError::ExcludedBranch(3448575031819686448u64));
 }
 };
 let marker = {
@@ -33466,7 +34088,7 @@ let b = _input.read_byte()?;
 if b == 194 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9924059786910440358u64));
+return Err(ParseError::ExcludedBranch(9960855096836829935u64));
 }
 };
 jpeg_soi { marker }
@@ -33485,15 +34107,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#369
-fn Decoder369(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#371
+fn Decoder371(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7274029685341305701u64));
+return Err(ParseError::ExcludedBranch(218475477370319322u64));
 }
 };
 let marker = {
@@ -33501,7 +34123,7 @@ let b = _input.read_byte()?;
 if b == 195 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16051783775494465147u64));
+return Err(ParseError::ExcludedBranch(18357658168615546095u64));
 }
 };
 jpeg_soi { marker }
@@ -33520,15 +34142,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#370
-fn Decoder370(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#372
+fn Decoder372(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13744164271564421708u64));
+return Err(ParseError::ExcludedBranch(10650412753233146525u64));
 }
 };
 let marker = {
@@ -33536,7 +34158,7 @@ let b = _input.read_byte()?;
 if b == 197 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5892114170581446733u64));
+return Err(ParseError::ExcludedBranch(15859964085544252343u64));
 }
 };
 jpeg_soi { marker }
@@ -33555,15 +34177,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#371
-fn Decoder371(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#373
+fn Decoder373(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11821813774070801620u64));
+return Err(ParseError::ExcludedBranch(653325817133119558u64));
 }
 };
 let marker = {
@@ -33571,7 +34193,7 @@ let b = _input.read_byte()?;
 if b == 198 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14520503729026832983u64));
+return Err(ParseError::ExcludedBranch(3349032559334020401u64));
 }
 };
 jpeg_soi { marker }
@@ -33590,15 +34212,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#372
-fn Decoder372(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#374
+fn Decoder374(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5309491469191307378u64));
+return Err(ParseError::ExcludedBranch(14115009527471272688u64));
 }
 };
 let marker = {
@@ -33606,7 +34228,7 @@ let b = _input.read_byte()?;
 if b == 199 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17983075411320920965u64));
+return Err(ParseError::ExcludedBranch(8350850950759220429u64));
 }
 };
 jpeg_soi { marker }
@@ -33625,15 +34247,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#373
-fn Decoder373(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#375
+fn Decoder375(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7023661717588102849u64));
+return Err(ParseError::ExcludedBranch(15412400192383838763u64));
 }
 };
 let marker = {
@@ -33641,7 +34263,7 @@ let b = _input.read_byte()?;
 if b == 201 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3448575031819686448u64));
+return Err(ParseError::ExcludedBranch(16334217566159141080u64));
 }
 };
 jpeg_soi { marker }
@@ -33660,15 +34282,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#374
-fn Decoder374(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#376
+fn Decoder376(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9960855096836829935u64));
+return Err(ParseError::ExcludedBranch(15032955882314050195u64));
 }
 };
 let marker = {
@@ -33676,7 +34298,7 @@ let b = _input.read_byte()?;
 if b == 202 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(218475477370319322u64));
+return Err(ParseError::ExcludedBranch(12522857579864693834u64));
 }
 };
 jpeg_soi { marker }
@@ -33695,15 +34317,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#375
-fn Decoder375(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#377
+fn Decoder377(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18357658168615546095u64));
+return Err(ParseError::ExcludedBranch(15286713778088114821u64));
 }
 };
 let marker = {
@@ -33711,7 +34333,7 @@ let b = _input.read_byte()?;
 if b == 203 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10650412753233146525u64));
+return Err(ParseError::ExcludedBranch(17055268834995250246u64));
 }
 };
 jpeg_soi { marker }
@@ -33730,15 +34352,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#376
-fn Decoder376(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#378
+fn Decoder378(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15859964085544252343u64));
+return Err(ParseError::ExcludedBranch(15014773733126201031u64));
 }
 };
 let marker = {
@@ -33746,7 +34368,7 @@ let b = _input.read_byte()?;
 if b == 205 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(653325817133119558u64));
+return Err(ParseError::ExcludedBranch(9895655502210650925u64));
 }
 };
 jpeg_soi { marker }
@@ -33765,15 +34387,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#377
-fn Decoder377(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#379
+fn Decoder379(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3349032559334020401u64));
+return Err(ParseError::ExcludedBranch(3344835778759068560u64));
 }
 };
 let marker = {
@@ -33781,7 +34403,7 @@ let b = _input.read_byte()?;
 if b == 206 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14115009527471272688u64));
+return Err(ParseError::ExcludedBranch(2014773054382805425u64));
 }
 };
 jpeg_soi { marker }
@@ -33800,15 +34422,15 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#378
-fn Decoder378(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#380
+fn Decoder380(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8350850950759220429u64));
+return Err(ParseError::ExcludedBranch(3011460078285478248u64));
 }
 };
 let marker = {
@@ -33816,7 +34438,7 @@ let b = _input.read_byte()?;
 if b == 207 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15412400192383838763u64));
+return Err(ParseError::ExcludedBranch(5117297982688264891u64));
 }
 };
 jpeg_soi { marker }
@@ -33835,7 +34457,7 @@ ret
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#379
+/// d#381
 fn Decoder_jpeg_sof_data(_input: &mut Parser<'_>) -> Result<jpeg_sof_data, ParseError> {
 let sample_precision = {
 let inner = _input.read_byte()?;
@@ -33846,7 +34468,7 @@ matches!(x, 2u8..=16u8)
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16334217566159141080u64));
+return Err(ParseError::FalsifiedWhere(4614223265245060097u64));
 }
 };
 let num_lines = {
@@ -33865,7 +34487,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15032955882314050195u64));
+return Err(ParseError::FalsifiedWhere(2858990937242709991u64));
 }
 };
 let num_image_components = {
@@ -33877,7 +34499,7 @@ x != 0u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(12522857579864693834u64));
+return Err(ParseError::FalsifiedWhere(13162270726566423196u64));
 }
 };
 let image_components = {
@@ -33891,7 +34513,7 @@ accum
 PResult::Ok(jpeg_sof_data { sample_precision, num_lines, num_samples_per_line, num_image_components, image_components })
 }
 
-/// d#380
+/// d#382
 fn Decoder_jpeg_sof_image_component(_input: &mut Parser<'_>) -> Result<jpeg_sof_image_component, ParseError> {
 let id = _input.read_byte()?;
 let sampling_factor = {
@@ -33909,13 +34531,13 @@ x <= 3u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15286713778088114821u64));
+return Err(ParseError::FalsifiedWhere(6766897041260485978u64));
 }
 };
 PResult::Ok(jpeg_sof_image_component { id, sampling_factor, quantization_table_id })
 }
 
-/// d#381
+/// d#383
 fn Decoder_jpeg_dqt(_input: &mut Parser<'_>) -> Result<jpeg_dqt, ParseError> {
 let marker = {
 {
@@ -33923,7 +34545,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17055268834995250246u64));
+return Err(ParseError::ExcludedBranch(7359082011512182682u64));
 }
 };
 let marker = {
@@ -33931,7 +34553,7 @@ let b = _input.read_byte()?;
 if b == 219 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15014773733126201031u64));
+return Err(ParseError::ExcludedBranch(4005260763079064488u64));
 }
 };
 jpeg_soi { marker }
@@ -33974,7 +34596,7 @@ ret
 PResult::Ok(jpeg_dqt { marker, length, data })
 }
 
-/// d#382
+/// d#384
 fn Decoder_jpeg_dht(_input: &mut Parser<'_>) -> Result<jpeg_dht, ParseError> {
 let marker = {
 {
@@ -33982,7 +34604,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9895655502210650925u64));
+return Err(ParseError::ExcludedBranch(9895427541506148364u64));
 }
 };
 let marker = {
@@ -33990,7 +34612,7 @@ let b = _input.read_byte()?;
 if b == 196 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3344835778759068560u64));
+return Err(ParseError::ExcludedBranch(15241527188218394569u64));
 }
 };
 jpeg_soi { marker }
@@ -34009,7 +34631,7 @@ ret
 PResult::Ok(jpeg_dht { marker, length, data })
 }
 
-/// d#383
+/// d#385
 fn Decoder_jpeg_dac(_input: &mut Parser<'_>) -> Result<jpeg_dac, ParseError> {
 let marker = {
 {
@@ -34017,7 +34639,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2014773054382805425u64));
+return Err(ParseError::ExcludedBranch(5019692195244899787u64));
 }
 };
 let marker = {
@@ -34025,7 +34647,7 @@ let b = _input.read_byte()?;
 if b == 204 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3011460078285478248u64));
+return Err(ParseError::ExcludedBranch(663652071640520941u64));
 }
 };
 jpeg_soi { marker }
@@ -34044,7 +34666,7 @@ ret
 PResult::Ok(jpeg_dac { marker, length, data })
 }
 
-/// d#384
+/// d#386
 fn Decoder_jpeg_dri(_input: &mut Parser<'_>) -> Result<jpeg_dri, ParseError> {
 let marker = {
 {
@@ -34052,7 +34674,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5117297982688264891u64));
+return Err(ParseError::ExcludedBranch(16835260701216065402u64));
 }
 };
 let marker = {
@@ -34060,7 +34682,7 @@ let b = _input.read_byte()?;
 if b == 221 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4614223265245060097u64));
+return Err(ParseError::ExcludedBranch(4248622096514297129u64));
 }
 };
 jpeg_soi { marker }
@@ -34079,7 +34701,7 @@ ret
 PResult::Ok(jpeg_dri { marker, length, data })
 }
 
-/// d#385
+/// d#387
 fn Decoder_jpeg_app0(_input: &mut Parser<'_>) -> Result<jpeg_app0, ParseError> {
 let marker = {
 {
@@ -34087,7 +34709,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2858990937242709991u64));
+return Err(ParseError::ExcludedBranch(18304605036866855350u64));
 }
 };
 let marker = {
@@ -34095,7 +34717,7 @@ let b = _input.read_byte()?;
 if b == 224 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13162270726566423196u64));
+return Err(ParseError::ExcludedBranch(49400955721755355u64));
 }
 };
 jpeg_soi { marker }
@@ -34114,7 +34736,7 @@ ret
 PResult::Ok(jpeg_app0 { marker, length, data })
 }
 
-/// d#386
+/// d#388
 fn Decoder_jpeg_app1(_input: &mut Parser<'_>) -> Result<jpeg_app1, ParseError> {
 let marker = {
 {
@@ -34122,7 +34744,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6766897041260485978u64));
+return Err(ParseError::ExcludedBranch(8882217996184815919u64));
 }
 };
 let marker = {
@@ -34130,7 +34752,7 @@ let b = _input.read_byte()?;
 if b == 225 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7359082011512182682u64));
+return Err(ParseError::ExcludedBranch(11885930557202460461u64));
 }
 };
 jpeg_soi { marker }
@@ -34149,7 +34771,7 @@ ret
 PResult::Ok(jpeg_app1 { marker, length, data })
 }
 
-/// d#387
+/// d#389
 fn Decoder_jpeg_app2(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
@@ -34157,7 +34779,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4005260763079064488u64));
+return Err(ParseError::ExcludedBranch(9841369023026740320u64));
 }
 };
 let marker = {
@@ -34165,7 +34787,7 @@ let b = _input.read_byte()?;
 if b == 226 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9895427541506148364u64));
+return Err(ParseError::ExcludedBranch(15065685669539080124u64));
 }
 };
 jpeg_soi { marker }
@@ -34204,15 +34826,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#388
-fn Decoder388(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#390
+fn Decoder390(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15241527188218394569u64));
+return Err(ParseError::ExcludedBranch(4896351207164742422u64));
 }
 };
 let marker = {
@@ -34220,7 +34842,7 @@ let b = _input.read_byte()?;
 if b == 227 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5019692195244899787u64));
+return Err(ParseError::ExcludedBranch(12845528861092334564u64));
 }
 };
 jpeg_soi { marker }
@@ -34259,15 +34881,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#389
-fn Decoder389(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#391
+fn Decoder391(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(663652071640520941u64));
+return Err(ParseError::ExcludedBranch(8497774971318424699u64));
 }
 };
 let marker = {
@@ -34275,7 +34897,7 @@ let b = _input.read_byte()?;
 if b == 228 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16835260701216065402u64));
+return Err(ParseError::ExcludedBranch(13677998342346693652u64));
 }
 };
 jpeg_soi { marker }
@@ -34314,15 +34936,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#390
-fn Decoder390(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#392
+fn Decoder392(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4248622096514297129u64));
+return Err(ParseError::ExcludedBranch(18442161777584514946u64));
 }
 };
 let marker = {
@@ -34330,7 +34952,7 @@ let b = _input.read_byte()?;
 if b == 229 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18304605036866855350u64));
+return Err(ParseError::ExcludedBranch(2668737607901180946u64));
 }
 };
 jpeg_soi { marker }
@@ -34369,15 +34991,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#391
-fn Decoder391(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#393
+fn Decoder393(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(49400955721755355u64));
+return Err(ParseError::ExcludedBranch(12828788577937869717u64));
 }
 };
 let marker = {
@@ -34385,7 +35007,7 @@ let b = _input.read_byte()?;
 if b == 230 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8882217996184815919u64));
+return Err(ParseError::ExcludedBranch(4528919599938425798u64));
 }
 };
 jpeg_soi { marker }
@@ -34424,15 +35046,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#392
-fn Decoder392(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#394
+fn Decoder394(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11885930557202460461u64));
+return Err(ParseError::ExcludedBranch(12955185663715491460u64));
 }
 };
 let marker = {
@@ -34440,7 +35062,7 @@ let b = _input.read_byte()?;
 if b == 231 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9841369023026740320u64));
+return Err(ParseError::ExcludedBranch(6221053009072016381u64));
 }
 };
 jpeg_soi { marker }
@@ -34479,15 +35101,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#393
-fn Decoder393(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#395
+fn Decoder395(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15065685669539080124u64));
+return Err(ParseError::ExcludedBranch(4825757476091239776u64));
 }
 };
 let marker = {
@@ -34495,7 +35117,7 @@ let b = _input.read_byte()?;
 if b == 232 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4896351207164742422u64));
+return Err(ParseError::ExcludedBranch(13877876706306354357u64));
 }
 };
 jpeg_soi { marker }
@@ -34534,15 +35156,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#394
-fn Decoder394(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#396
+fn Decoder396(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12845528861092334564u64));
+return Err(ParseError::ExcludedBranch(12525311251009778949u64));
 }
 };
 let marker = {
@@ -34550,7 +35172,7 @@ let b = _input.read_byte()?;
 if b == 233 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8497774971318424699u64));
+return Err(ParseError::ExcludedBranch(14962551735998681614u64));
 }
 };
 jpeg_soi { marker }
@@ -34589,15 +35211,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#395
-fn Decoder395(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#397
+fn Decoder397(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13677998342346693652u64));
+return Err(ParseError::ExcludedBranch(2007599397777734421u64));
 }
 };
 let marker = {
@@ -34605,7 +35227,7 @@ let b = _input.read_byte()?;
 if b == 234 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18442161777584514946u64));
+return Err(ParseError::ExcludedBranch(18069850277258932991u64));
 }
 };
 jpeg_soi { marker }
@@ -34644,15 +35266,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#396
-fn Decoder396(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#398
+fn Decoder398(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2668737607901180946u64));
+return Err(ParseError::ExcludedBranch(180881308211696508u64));
 }
 };
 let marker = {
@@ -34660,7 +35282,7 @@ let b = _input.read_byte()?;
 if b == 235 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12828788577937869717u64));
+return Err(ParseError::ExcludedBranch(17753230141940491005u64));
 }
 };
 jpeg_soi { marker }
@@ -34699,15 +35321,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#397
-fn Decoder397(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#399
+fn Decoder399(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4528919599938425798u64));
+return Err(ParseError::ExcludedBranch(6110942357212830202u64));
 }
 };
 let marker = {
@@ -34715,7 +35337,7 @@ let b = _input.read_byte()?;
 if b == 236 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12955185663715491460u64));
+return Err(ParseError::ExcludedBranch(6596410053543851077u64));
 }
 };
 jpeg_soi { marker }
@@ -34754,15 +35376,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#398
-fn Decoder398(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#400
+fn Decoder400(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6221053009072016381u64));
+return Err(ParseError::ExcludedBranch(16339654162669176472u64));
 }
 };
 let marker = {
@@ -34770,7 +35392,7 @@ let b = _input.read_byte()?;
 if b == 237 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4825757476091239776u64));
+return Err(ParseError::ExcludedBranch(1886358831178290550u64));
 }
 };
 jpeg_soi { marker }
@@ -34809,15 +35431,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#399
-fn Decoder399(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#401
+fn Decoder401(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(13877876706306354357u64));
+return Err(ParseError::ExcludedBranch(17004441093219507547u64));
 }
 };
 let marker = {
@@ -34825,7 +35447,7 @@ let b = _input.read_byte()?;
 if b == 238 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12525311251009778949u64));
+return Err(ParseError::ExcludedBranch(3168197157646945762u64));
 }
 };
 jpeg_soi { marker }
@@ -34864,15 +35486,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#400
-fn Decoder400(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#402
+fn Decoder402(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14962551735998681614u64));
+return Err(ParseError::ExcludedBranch(360138127928998237u64));
 }
 };
 let marker = {
@@ -34880,7 +35502,7 @@ let b = _input.read_byte()?;
 if b == 239 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(2007599397777734421u64));
+return Err(ParseError::ExcludedBranch(9092411637461100444u64));
 }
 };
 jpeg_soi { marker }
@@ -34919,15 +35541,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#401
-fn Decoder401(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#403
+fn Decoder403(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(18069850277258932991u64));
+return Err(ParseError::ExcludedBranch(15117497265985508077u64));
 }
 };
 let marker = {
@@ -34935,7 +35557,7 @@ let b = _input.read_byte()?;
 if b == 254 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(180881308211696508u64));
+return Err(ParseError::ExcludedBranch(11247369915737850258u64));
 }
 };
 jpeg_soi { marker }
@@ -34974,7 +35596,7 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#402
+/// d#404
 fn Decoder_jpeg_app1_data(_input: &mut Parser<'_>) -> Result<jpeg_app1_data, ParseError> {
 let identifier = {
 let chars = {
@@ -34993,7 +35615,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17753230141940491005u64));
+return Err(ParseError::ExcludedBranch(7546547171508918509u64));
 }
 };
 _input.close_peek_context()?;
@@ -35006,7 +35628,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6110942357212830202u64));
+return Err(ParseError::ExcludedBranch(14304129837244038526u64));
 }
 };
 accum.push(next_elem)
@@ -35021,7 +35643,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6596410053543851077u64));
+return Err(ParseError::ExcludedBranch(15347994581840044382u64));
 }
 };
 chars.clone()
@@ -35030,7 +35652,7 @@ let data = (Decoder_jpeg_app1_data_data(_input, &identifier))?;
 PResult::Ok(jpeg_app1_data { identifier, data })
 }
 
-/// d#403
+/// d#405
 fn Decoder_jpeg_app1_data_data(_input: &mut Parser<'_>, identifier: &[u8]) -> Result<jpeg_app1_data_data, ParseError> {
 PResult::Ok(match slice_all(&identifier) {
 [69u8, 120u8, 105u8, 102u8] => {
@@ -35070,21 +35692,21 @@ jpeg_app1_data_data::other(inner)
 })
 }
 
-/// d#404
+/// d#406
 fn Decoder_jpeg_app1_exif(_input: &mut Parser<'_>) -> Result<jpeg_app1_exif, ParseError> {
 let padding = {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16339654162669176472u64));
+return Err(ParseError::ExcludedBranch(18237415135895269790u64));
 }
 };
 let exif = (Decoder_tiff_main(_input))?;
 PResult::Ok(jpeg_app1_exif { padding, exif })
 }
 
-/// d#405
+/// d#407
 fn Decoder_jpeg_app1_xmp(_input: &mut Parser<'_>) -> Result<jpeg_app1_xmp, ParseError> {
 let xmp = {
 let mut accum = Vec::new();
@@ -35110,7 +35732,7 @@ accum
 PResult::Ok(jpeg_app1_xmp { xmp })
 }
 
-/// d#406
+/// d#408
 fn Decoder_jpeg_app0_data(_input: &mut Parser<'_>) -> Result<jpeg_app0_data, ParseError> {
 let identifier = {
 let chars = {
@@ -35129,7 +35751,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1886358831178290550u64));
+return Err(ParseError::ExcludedBranch(4706601668945989307u64));
 }
 };
 _input.close_peek_context()?;
@@ -35142,7 +35764,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17004441093219507547u64));
+return Err(ParseError::ExcludedBranch(1678201523848816632u64));
 }
 };
 accum.push(next_elem)
@@ -35157,7 +35779,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3168197157646945762u64));
+return Err(ParseError::ExcludedBranch(13246474195614162055u64));
 }
 };
 chars.clone()
@@ -35166,7 +35788,7 @@ let data = (Decoder_jpeg_app0_data_data(_input, &identifier))?;
 PResult::Ok(jpeg_app0_data { identifier, data })
 }
 
-/// d#407
+/// d#409
 fn Decoder_jpeg_app0_data_data(_input: &mut Parser<'_>, identifier: &[u8]) -> Result<jpeg_app0_data_data, ParseError> {
 PResult::Ok(match slice_all(&identifier) {
 [74u8, 70u8, 73u8, 70u8] => {
@@ -35201,7 +35823,7 @@ jpeg_app0_data_data::other(inner)
 })
 }
 
-/// d#408
+/// d#410
 fn Decoder_jpeg_app0_jfif(_input: &mut Parser<'_>) -> Result<jpeg_app0_jfif, ParseError> {
 let version_major = _input.read_byte()?;
 let version_minor = _input.read_byte()?;
@@ -35214,7 +35836,7 @@ x <= 2u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(360138127928998237u64));
+return Err(ParseError::FalsifiedWhere(8414108255387456730u64));
 }
 };
 let density_x = {
@@ -35229,7 +35851,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9092411637461100444u64));
+return Err(ParseError::FalsifiedWhere(1432698095084823598u64));
 }
 };
 let density_y = {
@@ -35244,7 +35866,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(15117497265985508077u64));
+return Err(ParseError::FalsifiedWhere(9372987348964131232u64));
 }
 };
 let thumbnail_width = _input.read_byte()?;
@@ -35267,7 +35889,7 @@ accum
 PResult::Ok(jpeg_app0_jfif { version_major, version_minor, density_units, density_x, density_y, thumbnail_width, thumbnail_height, thumbnail_pixels })
 }
 
-/// d#409
+/// d#411
 fn Decoder_gif_color_table_entry(_input: &mut Parser<'_>) -> Result<gif_color_table_entry, ParseError> {
 let r = _input.read_byte()?;
 let g = _input.read_byte()?;
@@ -35275,7 +35897,7 @@ let b = _input.read_byte()?;
 PResult::Ok(gif_color_table_entry { r, g, b })
 }
 
-/// d#410
+/// d#412
 fn Decoder_jpeg_dri_data(_input: &mut Parser<'_>) -> Result<jpeg_dri_data, ParseError> {
 let restart_interval = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -35284,14 +35906,14 @@ u16be(x)
 PResult::Ok(jpeg_dri_data { restart_interval })
 }
 
-/// d#411
+/// d#413
 fn Decoder_jpeg_dac_data(_input: &mut Parser<'_>) -> Result<jpeg_dac_data, ParseError> {
 let class_table_id = (Decoder_jpeg_class_table_id(_input))?;
 let value = _input.read_byte()?;
 PResult::Ok(jpeg_dac_data { class_table_id, value })
 }
 
-/// d#412
+/// d#414
 fn Decoder_jpeg_class_table_id(_input: &mut Parser<'_>) -> Result<jpeg_class_table_id, ParseError> {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -35306,11 +35928,11 @@ let class_table_id = inner;
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(11247369915737850258u64));
+return Err(ParseError::FalsifiedWhere(8473414866110322269u64));
 })
 }
 
-/// d#413
+/// d#415
 fn Decoder_jpeg_dht_data(_input: &mut Parser<'_>) -> Result<jpeg_dht_data, ParseError> {
 let class_table_id = (Decoder_jpeg_class_table_id(_input))?;
 let num_codes = {
@@ -35339,14 +35961,14 @@ accum
 PResult::Ok(jpeg_dht_data { class_table_id, num_codes, values })
 }
 
-/// d#414
+/// d#416
 fn Decoder_jpeg_dqt_data(_input: &mut Parser<'_>) -> Result<jpeg_dqt_data, ParseError> {
 let precision_table_id = (Decoder_jpeg_precision_table_id(_input))?;
 let elements = (Decoder_jpeg_dqt_data_elements(_input, precision_table_id.precision))?;
 PResult::Ok(jpeg_dqt_data { precision_table_id, elements })
 }
 
-/// d#415
+/// d#417
 fn Decoder_jpeg_precision_table_id(_input: &mut Parser<'_>) -> Result<jpeg_precision_table_id, ParseError> {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -35361,11 +35983,11 @@ let precision_table_id = inner;
 PResult::Ok(if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(7546547171508918509u64));
+return Err(ParseError::FalsifiedWhere(671785503440284610u64));
 })
 }
 
-/// d#416
+/// d#418
 fn Decoder_jpeg_dqt_data_elements(_input: &mut Parser<'_>, precision: u8) -> Result<jpeg_dqt_data_elements, ParseError> {
 PResult::Ok(match precision {
 0u8 => {
@@ -35401,7 +36023,7 @@ unreachable!(r#"ExprMatch refuted: match refuted with unexpected value {_other:?
 })
 }
 
-/// d#417
+/// d#419
 fn Decoder_gzip_header(_input: &mut Parser<'_>) -> Result<gzip_header, ParseError> {
 let magic = {
 let arg0 = {
@@ -35409,7 +36031,7 @@ let b = _input.read_byte()?;
 if b == 31 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14304129837244038526u64));
+return Err(ParseError::ExcludedBranch(2651182070283403637u64));
 }
 };
 let arg1 = {
@@ -35417,7 +36039,7 @@ let b = _input.read_byte()?;
 if b == 139 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(15347994581840044382u64));
+return Err(ParseError::ExcludedBranch(8284996377131534070u64));
 }
 };
 (arg0, arg1)
@@ -35433,7 +36055,7 @@ let os_id = _input.read_byte()?;
 PResult::Ok(gzip_header { magic, method, file_flags, timestamp, compression_flags, os_id })
 }
 
-/// d#418
+/// d#420
 fn Decoder_gzip_fextra(_input: &mut Parser<'_>) -> Result<gzip_fextra, ParseError> {
 let xlen = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -35469,8 +36091,8 @@ ret
 PResult::Ok(gzip_fextra { xlen, subfields })
 }
 
-/// d#419
-fn Decoder419(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#421
+fn Decoder421(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let chars = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -35487,7 +36109,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(18237415135895269790u64));
+return Err(ParseError::ExcludedBranch(16948595091237008543u64));
 }
 };
 _input.close_peek_context()?;
@@ -35500,7 +36122,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4706601668945989307u64));
+return Err(ParseError::ExcludedBranch(108256050843388088u64));
 }
 };
 accum.push(next_elem)
@@ -35515,13 +36137,13 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1678201523848816632u64));
+return Err(ParseError::ExcludedBranch(7834223795690054720u64));
 }
 };
 PResult::Ok(chars.clone())
 }
 
-/// d#420
+/// d#422
 fn Decoder_gzip_fcomment(_input: &mut Parser<'_>) -> Result<gzip_fcomment, ParseError> {
 let comment = {
 let chars = {
@@ -35540,7 +36162,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(13246474195614162055u64));
+return Err(ParseError::ExcludedBranch(787921071240225899u64));
 }
 };
 _input.close_peek_context()?;
@@ -35553,7 +36175,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8414108255387456730u64));
+return Err(ParseError::ExcludedBranch(11557974043504662535u64));
 }
 };
 accum.push(next_elem)
@@ -35568,7 +36190,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1432698095084823598u64));
+return Err(ParseError::ExcludedBranch(14238499412440345954u64));
 }
 };
 chars.clone()
@@ -35576,7 +36198,7 @@ chars.clone()
 PResult::Ok(gzip_fcomment { comment })
 }
 
-/// d#421
+/// d#423
 fn Decoder_gzip_fhcrc(_input: &mut Parser<'_>) -> Result<gzip_fhcrc, ParseError> {
 let crc = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -35585,7 +36207,7 @@ u16le(x)
 PResult::Ok(gzip_fhcrc { crc })
 }
 
-/// d#422
+/// d#424
 fn Decoder_gzip_footer(_input: &mut Parser<'_>) -> Result<gzip_footer, ParseError> {
 let crc = {
 let x = (_input.read_byte()?, _input.read_byte()?, _input.read_byte()?, _input.read_byte()?);
@@ -35598,7 +36220,7 @@ u32le(x)
 PResult::Ok(gzip_footer { crc, length })
 }
 
-/// d#423
+/// d#425
 fn Decoder_gzip_fextra_subfield(_input: &mut Parser<'_>) -> Result<gzip_fextra_subfield, ParseError> {
 let si1 = _input.read_byte()?;
 let si2 = _input.read_byte()?;
@@ -35617,7 +36239,7 @@ accum
 PResult::Ok(gzip_fextra_subfield { si1, si2, len, data })
 }
 
-/// d#424
+/// d#426
 fn Decoder_gzip_header_file_flags(_input: &mut Parser<'_>) -> Result<gzip_header_file_flags, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let fcomment = _packed_bits >> 4u8 & 1u8 > 0u8;
@@ -35628,8 +36250,8 @@ let ftext = _packed_bits & 1u8 > 0u8;
 PResult::Ok(gzip_header_file_flags { fcomment, fname, fextra, fhcrc, ftext })
 }
 
-/// d#425
-fn Decoder425(_input: &mut Parser<'_>) -> Result<Vec<gzip_main>, ParseError> {
+/// d#427
+fn Decoder427(_input: &mut Parser<'_>) -> Result<Vec<gzip_main>, ParseError> {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
 let matching_ix = {
@@ -35660,12 +36282,12 @@ Some((Decoder_gzip_fextra(_input))?)
 None
 };
 let fname = if header.file_flags.fname {
-Some((Decoder427(_input))?)
+Some((Decoder429(_input))?)
 } else {
 None
 };
 let fcomment = if header.file_flags.fcomment {
-Some((Decoder428(_input))?)
+Some((Decoder430(_input))?)
 } else {
 None
 };
@@ -35689,8 +36311,8 @@ accum.push(next_elem)
 PResult::Ok(accum)
 }
 
-/// d#426
-fn Decoder426(_input: &mut Parser<'_>) -> Result<tar_main, ParseError> {
+/// d#428
+fn Decoder428(_input: &mut Parser<'_>) -> Result<tar_main, ParseError> {
 let contents = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -35707,7 +36329,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9372987348964131232u64));
+return Err(ParseError::ExcludedBranch(14703397633096852322u64));
 }
 };
 _input.close_peek_context()?;
@@ -35735,7 +36357,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8473414866110322269u64));
+return Err(ParseError::ExcludedBranch(268478239438800266u64));
 }
 };
 accum.push(next_elem)
@@ -35764,7 +36386,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(671785503440284610u64));
+return Err(ParseError::ExcludedBranch(6301432137385173939u64));
 }
 };
 accum.push(next_elem)
@@ -35777,8 +36399,8 @@ accum
 PResult::Ok(tar_main { contents })
 }
 
-/// d#427
-fn Decoder427(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
+/// d#429
+fn Decoder429(_input: &mut Parser<'_>) -> Result<Vec<u8>, ParseError> {
 let chars = {
 let mut accum = Vec::new();
 while _input.remaining() > 0 {
@@ -35795,7 +36417,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(2651182070283403637u64));
+return Err(ParseError::ExcludedBranch(17762152702085771435u64));
 }
 };
 _input.close_peek_context()?;
@@ -35808,7 +36430,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(8284996377131534070u64));
+return Err(ParseError::ExcludedBranch(6803443871185192093u64));
 }
 };
 accum.push(next_elem)
@@ -35823,14 +36445,14 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16948595091237008543u64));
+return Err(ParseError::ExcludedBranch(204361505388532862u64));
 }
 };
 PResult::Ok(chars.clone())
 }
 
-/// d#428
-fn Decoder428(_input: &mut Parser<'_>) -> Result<gzip_fcomment, ParseError> {
+/// d#430
+fn Decoder430(_input: &mut Parser<'_>) -> Result<gzip_fcomment, ParseError> {
 let comment = {
 let chars = {
 let mut accum = Vec::new();
@@ -35848,7 +36470,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(108256050843388088u64));
+return Err(ParseError::ExcludedBranch(11161970641928094938u64));
 }
 };
 _input.close_peek_context()?;
@@ -35861,7 +36483,7 @@ let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7834223795690054720u64));
+return Err(ParseError::ExcludedBranch(8787536656121914522u64));
 }
 };
 accum.push(next_elem)
@@ -35876,7 +36498,7 @@ let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(787921071240225899u64));
+return Err(ParseError::ExcludedBranch(18210277358428599455u64));
 }
 };
 chars.clone()
@@ -35884,7 +36506,7 @@ chars.clone()
 PResult::Ok(gzip_fcomment { comment })
 }
 
-/// d#429
+/// d#431
 fn Decoder_gif_header(_input: &mut Parser<'_>) -> Result<gif_header, ParseError> {
 let signature = {
 let arg0 = {
@@ -35892,7 +36514,7 @@ let b = _input.read_byte()?;
 if b == 71 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11557974043504662535u64));
+return Err(ParseError::ExcludedBranch(9453259036882642818u64));
 }
 };
 let arg1 = {
@@ -35900,7 +36522,7 @@ let b = _input.read_byte()?;
 if b == 73 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14238499412440345954u64));
+return Err(ParseError::ExcludedBranch(16811847696882257499u64));
 }
 };
 let arg2 = {
@@ -35908,7 +36530,7 @@ let b = _input.read_byte()?;
 if b == 70 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(14703397633096852322u64));
+return Err(ParseError::ExcludedBranch(11078254580983048780u64));
 }
 };
 (arg0, arg1, arg2)
@@ -35917,13 +36539,13 @@ let version = vec![_input.read_byte()?, _input.read_byte()?, _input.read_byte()?
 PResult::Ok(gif_header { signature, version })
 }
 
-/// d#430
+/// d#432
 fn Decoder_gif_logical_screen(_input: &mut Parser<'_>) -> Result<gif_logical_screen, ParseError> {
 let descriptor = (Decoder_gif_logical_screen_descriptor(_input))?;
 let global_color_table = if descriptor.flags.table_flag {
 let mut accum = Vec::new();
 for _ in 0..2u16 << (descriptor.flags.table_size as u16) {
-let next_elem = (Decoder444(_input))?;
+let next_elem = (Decoder446(_input))?;
 accum.push(next_elem)
 };
 Some(accum)
@@ -35933,7 +36555,7 @@ None
 PResult::Ok(gif_logical_screen { descriptor, global_color_table })
 }
 
-/// d#431
+/// d#433
 fn Decoder_gif_block(_input: &mut Parser<'_>) -> Result<gif_block, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -35958,7 +36580,7 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(268478239438800266u64));
+return Err(ParseError::ExcludedBranch(1845850007550452160u64));
 }
 }
 },
@@ -35968,7 +36590,7 @@ return Err(ParseError::ExcludedBranch(268478239438800266u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6301432137385173939u64));
+return Err(ParseError::ExcludedBranch(7779176190297216638u64));
 }
 };
 _input.close_peek_context()?;
@@ -35987,25 +36609,25 @@ gif_block::special_purpose_block(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(17762152702085771435u64));
+return Err(ParseError::ExcludedBranch(1016564408906296566u64));
 }
 })
 }
 
-/// d#432
+/// d#434
 fn Decoder_gif_trailer(_input: &mut Parser<'_>) -> Result<gif_trailer, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 59 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6803443871185192093u64));
+return Err(ParseError::ExcludedBranch(1591903561633999639u64));
 }
 };
 PResult::Ok(gif_trailer { separator })
 }
 
-/// d#433
+/// d#435
 fn Decoder_gif_graphic_block(_input: &mut Parser<'_>) -> Result<gif_graphic_block, ParseError> {
 let graphic_control_extension = {
 let tree_index = {
@@ -36023,7 +36645,7 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(204361505388532862u64));
+return Err(ParseError::ExcludedBranch(9590821821210520154u64));
 }
 }
 },
@@ -36033,7 +36655,7 @@ return Err(ParseError::ExcludedBranch(204361505388532862u64));
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(11161970641928094938u64));
+return Err(ParseError::ExcludedBranch(6175893723851407495u64));
 }
 };
 _input.close_peek_context()?;
@@ -36050,7 +36672,7 @@ None
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8787536656121914522u64));
+return Err(ParseError::ExcludedBranch(4491050975676636472u64));
 }
 }
 };
@@ -36058,7 +36680,7 @@ let graphic_rendering_block = (Decoder_gif_graphic_rendering_block(_input))?;
 PResult::Ok(gif_graphic_block { graphic_control_extension, graphic_rendering_block })
 }
 
-/// d#434
+/// d#436
 fn Decoder_gif_special_purpose_block(_input: &mut Parser<'_>) -> Result<gif_special_purpose_block, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -36075,11 +36697,11 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(18210277358428599455u64));
+return Err(ParseError::ExcludedBranch(9933460716242958610u64));
 }
 }
 } else {
-return Err(ParseError::ExcludedBranch(9453259036882642818u64));
+return Err(ParseError::ExcludedBranch(10865781264025109219u64));
 };
 _input.close_peek_context()?;
 ret
@@ -36097,19 +36719,19 @@ gif_special_purpose_block::comment_extension(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16811847696882257499u64));
+return Err(ParseError::ExcludedBranch(1125515999835788388u64));
 }
 })
 }
 
-/// d#435
+/// d#437
 fn Decoder_gif_application_extension(_input: &mut Parser<'_>) -> Result<gif_application_extension, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11078254580983048780u64));
+return Err(ParseError::ExcludedBranch(6928743980636918648u64));
 }
 };
 let label = {
@@ -36117,7 +36739,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1845850007550452160u64));
+return Err(ParseError::ExcludedBranch(10349067556055585673u64));
 }
 };
 let block_size = {
@@ -36125,7 +36747,7 @@ let b = _input.read_byte()?;
 if b == 11 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(7779176190297216638u64));
+return Err(ParseError::ExcludedBranch(9276145871181842621u64));
 }
 };
 let identifier = {
@@ -36153,7 +36775,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1016564408906296566u64));
+return Err(ParseError::ExcludedBranch(16224083238566163922u64));
 }
 };
 _input.close_peek_context()?;
@@ -36169,18 +36791,18 @@ break
 };
 accum
 };
-let terminator = (Decoder438(_input))?;
+let terminator = (Decoder440(_input))?;
 PResult::Ok(gif_application_extension { separator, label, block_size, identifier, authentication_code, application_data, terminator })
 }
 
-/// d#436
+/// d#438
 fn Decoder_gif_comment_extension(_input: &mut Parser<'_>) -> Result<gif_comment_extension, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1591903561633999639u64));
+return Err(ParseError::ExcludedBranch(9651999844283402729u64));
 }
 };
 let label = {
@@ -36188,7 +36810,7 @@ let b = _input.read_byte()?;
 if b == 254 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9590821821210520154u64));
+return Err(ParseError::ExcludedBranch(4150962867603307131u64));
 }
 };
 let comment_data = {
@@ -36207,7 +36829,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6175893723851407495u64));
+return Err(ParseError::ExcludedBranch(1180075112413234847u64));
 }
 };
 _input.close_peek_context()?;
@@ -36223,18 +36845,18 @@ break
 };
 accum
 };
-let terminator = (Decoder438(_input))?;
+let terminator = (Decoder440(_input))?;
 PResult::Ok(gif_comment_extension { separator, label, comment_data, terminator })
 }
 
-/// d#437
+/// d#439
 fn Decoder_gif_subblock(_input: &mut Parser<'_>) -> Result<gif_subblock, ParseError> {
 let len_bytes = {
 let b = _input.read_byte()?;
 if b != 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4491050975676636472u64));
+return Err(ParseError::ExcludedBranch(4914981965961925407u64));
 }
 };
 let data = {
@@ -36248,24 +36870,24 @@ accum
 PResult::Ok(gif_subblock { len_bytes, data })
 }
 
-/// d#438
-fn Decoder438(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
+/// d#440
+fn Decoder440(_input: &mut Parser<'_>) -> Result<u8, ParseError> {
 let b = _input.read_byte()?;
 PResult::Ok(if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9933460716242958610u64));
+return Err(ParseError::ExcludedBranch(4792114144900142999u64));
 })
 }
 
-/// d#439
+/// d#441
 fn Decoder_gif_graphic_control_extension(_input: &mut Parser<'_>) -> Result<gif_graphic_control_extension, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10865781264025109219u64));
+return Err(ParseError::ExcludedBranch(6091354260726402337u64));
 }
 };
 let label = {
@@ -36273,7 +36895,7 @@ let b = _input.read_byte()?;
 if b == 249 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(1125515999835788388u64));
+return Err(ParseError::ExcludedBranch(16173518488310098141u64));
 }
 };
 let block_size = {
@@ -36281,7 +36903,7 @@ let b = _input.read_byte()?;
 if b == 4 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(6928743980636918648u64));
+return Err(ParseError::ExcludedBranch(6485872802951288360u64));
 }
 };
 let flags = (Decoder_gif_graphic_control_extension_flags(_input))?;
@@ -36290,11 +36912,11 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16le(x)
 };
 let transparent_color_index = _input.read_byte()?;
-let terminator = (Decoder438(_input))?;
+let terminator = (Decoder440(_input))?;
 PResult::Ok(gif_graphic_control_extension { separator, label, block_size, flags, delay_time, transparent_color_index, terminator })
 }
 
-/// d#440
+/// d#442
 fn Decoder_gif_graphic_rendering_block(_input: &mut Parser<'_>) -> Result<gif_graphic_rendering_block, ParseError> {
 let tree_index = {
 _input.open_peek_context();
@@ -36309,7 +36931,7 @@ let ret = match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(10349067556055585673u64));
+return Err(ParseError::ExcludedBranch(14222995392916087968u64));
 }
 };
 _input.close_peek_context()?;
@@ -36328,18 +36950,18 @@ gif_graphic_rendering_block::plain_text_extension(inner)
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9276145871181842621u64));
+return Err(ParseError::ExcludedBranch(9204716142356529030u64));
 }
 })
 }
 
-/// d#441
+/// d#443
 fn Decoder_gif_table_based_image(_input: &mut Parser<'_>) -> Result<gif_table_based_image, ParseError> {
 let descriptor = (Decoder_gif_image_descriptor(_input))?;
 let local_color_table = if descriptor.flags.table_flag {
 let mut accum = Vec::new();
 for _ in 0..2u16 << (descriptor.flags.table_size as u16) {
-let next_elem = (Decoder444(_input))?;
+let next_elem = (Decoder446(_input))?;
 accum.push(next_elem)
 };
 Some(accum)
@@ -36350,14 +36972,14 @@ let data = (Decoder_gif_table_based_image_data(_input))?;
 PResult::Ok(gif_table_based_image { descriptor, local_color_table, data })
 }
 
-/// d#442
+/// d#444
 fn Decoder_gif_plain_text_extension(_input: &mut Parser<'_>) -> Result<gif_plain_text_extension, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 33 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16224083238566163922u64));
+return Err(ParseError::ExcludedBranch(14055113049862078139u64));
 }
 };
 let label = {
@@ -36365,7 +36987,7 @@ let b = _input.read_byte()?;
 if b == 1 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(9651999844283402729u64));
+return Err(ParseError::ExcludedBranch(8236384974725516720u64));
 }
 };
 let block_size = {
@@ -36373,7 +36995,7 @@ let b = _input.read_byte()?;
 if b == 12 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4150962867603307131u64));
+return Err(ParseError::ExcludedBranch(4851501206534868925u64));
 }
 };
 let text_grid_left_position = {
@@ -36412,7 +37034,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(1180075112413234847u64));
+return Err(ParseError::ExcludedBranch(4255480819017852249u64));
 }
 };
 _input.close_peek_context()?;
@@ -36428,18 +37050,18 @@ break
 };
 accum
 };
-let terminator = (Decoder438(_input))?;
+let terminator = (Decoder440(_input))?;
 PResult::Ok(gif_plain_text_extension { separator, label, block_size, text_grid_left_position, text_grid_top_position, text_grid_width, text_grid_height, character_cell_width, character_cell_height, text_foreground_color_index, text_background_color_index, plain_text_data, terminator })
 }
 
-/// d#443
+/// d#445
 fn Decoder_gif_image_descriptor(_input: &mut Parser<'_>) -> Result<gif_image_descriptor, ParseError> {
 let separator = {
 let b = _input.read_byte()?;
 if b == 44 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(4914981965961925407u64));
+return Err(ParseError::ExcludedBranch(17733863216727871551u64));
 }
 };
 let image_left_position = {
@@ -36462,15 +37084,15 @@ let flags = (Decoder_gif_image_descriptor_flags(_input))?;
 PResult::Ok(gif_image_descriptor { separator, image_left_position, image_top_position, image_width, image_height, flags })
 }
 
-/// d#444
-fn Decoder444(_input: &mut Parser<'_>) -> Result<gif_color_table_entry, ParseError> {
+/// d#446
+fn Decoder446(_input: &mut Parser<'_>) -> Result<gif_color_table_entry, ParseError> {
 let r = _input.read_byte()?;
 let g = _input.read_byte()?;
 let b = _input.read_byte()?;
 PResult::Ok(gif_color_table_entry { r, g, b })
 }
 
-/// d#445
+/// d#447
 fn Decoder_gif_table_based_image_data(_input: &mut Parser<'_>) -> Result<gif_table_based_image_data, ParseError> {
 let lzw_min_code_size = _input.read_byte()?;
 let image_data = {
@@ -36489,7 +37111,7 @@ byte if (byte != 0) => {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4792114144900142999u64));
+return Err(ParseError::ExcludedBranch(389354767835086292u64));
 }
 };
 _input.close_peek_context()?;
@@ -36505,11 +37127,11 @@ break
 };
 accum
 };
-let terminator = (Decoder438(_input))?;
+let terminator = (Decoder440(_input))?;
 PResult::Ok(gif_table_based_image_data { lzw_min_code_size, image_data, terminator })
 }
 
-/// d#446
+/// d#448
 fn Decoder_gif_image_descriptor_flags(_input: &mut Parser<'_>) -> Result<gif_image_descriptor_flags, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let table_flag = _packed_bits >> 7u8 & 1u8 > 0u8;
@@ -36519,7 +37141,7 @@ let table_size = _packed_bits & 7u8;
 PResult::Ok(gif_image_descriptor_flags { table_flag, interlace_flag, sort_flag, table_size })
 }
 
-/// d#447
+/// d#449
 fn Decoder_gif_graphic_control_extension_flags(_input: &mut Parser<'_>) -> Result<gif_graphic_control_extension_flags, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let disposal_method = _packed_bits >> 2u8 & 7u8;
@@ -36528,7 +37150,7 @@ let transparent_color_flag = _packed_bits & 1u8 > 0u8;
 PResult::Ok(gif_graphic_control_extension_flags { disposal_method, user_input_flag, transparent_color_flag })
 }
 
-/// d#448
+/// d#450
 fn Decoder_gif_logical_screen_descriptor(_input: &mut Parser<'_>) -> Result<gif_logical_screen_descriptor, ParseError> {
 let screen_width = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -36544,7 +37166,7 @@ let pixel_aspect_ratio = _input.read_byte()?;
 PResult::Ok(gif_logical_screen_descriptor { screen_width, screen_height, flags, bg_color_index, pixel_aspect_ratio })
 }
 
-/// d#449
+/// d#451
 fn Decoder_gif_logical_screen_descriptor_flags(_input: &mut Parser<'_>) -> Result<gif_logical_screen_descriptor_flags, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let table_flag = _packed_bits >> 7u8 & 1u8 > 0u8;
@@ -36554,8 +37176,8 @@ let table_size = _packed_bits & 7u8;
 PResult::Ok(gif_logical_screen_descriptor_flags { table_flag, color_resolution, sort_flag, table_size })
 }
 
-/// d#450
-fn Decoder450(_input: &mut Parser<'_>) -> Result<u32, ParseError> {
+/// d#452
+fn Decoder452(_input: &mut Parser<'_>) -> Result<u32, ParseError> {
 let tuple_var = {
 let arg0 = {
 let mut accum = Vec::new();
@@ -36621,55 +37243,55 @@ match _input.read_byte()? {
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6091354260726402337u64));
+return Err(ParseError::ExcludedBranch(3216028881355025849u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(16173518488310098141u64));
+return Err(ParseError::ExcludedBranch(479680595494617916u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(6485872802951288360u64));
+return Err(ParseError::ExcludedBranch(10531068763070667405u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14222995392916087968u64));
+return Err(ParseError::ExcludedBranch(12431089125438936538u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(9204716142356529030u64));
+return Err(ParseError::ExcludedBranch(9066809807580136020u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(14055113049862078139u64));
+return Err(ParseError::ExcludedBranch(12347909352078849049u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(8236384974725516720u64));
+return Err(ParseError::ExcludedBranch(10900015085754267678u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4851501206534868925u64));
+return Err(ParseError::ExcludedBranch(5999000939515818447u64));
 }
 }
 },
 
 _ => {
-return Err(ParseError::ExcludedBranch(4255480819017852249u64));
+return Err(ParseError::ExcludedBranch(10508718825232435214u64));
 }
 };
 _input.close_peek_context()?;
@@ -36684,7 +37306,7 @@ let b = _input.read_byte()?;
 if b == 83 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(17733863216727871551u64));
+return Err(ParseError::ExcludedBranch(13460389694602013078u64));
 }
 };
 accum.push(next_elem)
@@ -36697,7 +37319,7 @@ let b = _input.read_byte()?;
 if b == 90 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(389354767835086292u64));
+return Err(ParseError::ExcludedBranch(16535687493193441589u64));
 }
 };
 (arg0, arg1)
@@ -36708,7 +37330,7 @@ let (s, _z) = tuple_var;
 })
 }
 
-/// d#451
+/// d#453
 fn Decoder_jpeg_dhp_image_component_sampling_factor(_input: &mut Parser<'_>) -> Result<jpeg_dhp_image_component_sampling_factor, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let horizontal = _packed_bits >> 4u8 & 15u8;
@@ -36716,31 +37338,31 @@ let vertical = _packed_bits & 15u8;
 PResult::Ok(jpeg_dhp_image_component_sampling_factor { horizontal, vertical })
 }
 
-/// d#452
-fn Decoder452(_input: &mut Parser<'_>) -> Result<jpeg_sof_image_component, ParseError> {
+/// d#454
+fn Decoder454(_input: &mut Parser<'_>) -> Result<jpeg_sof_image_component, ParseError> {
 let id = _input.read_byte()?;
-let sampling_factor = (Decoder453(_input))?;
+let sampling_factor = (Decoder455(_input))?;
 let quantization_table_id = {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(3216028881355025849u64));
+return Err(ParseError::ExcludedBranch(16678380679225161433u64));
 }
 };
 PResult::Ok(jpeg_sof_image_component { id, sampling_factor, quantization_table_id })
 }
 
-/// d#453
-fn Decoder453(_input: &mut Parser<'_>) -> Result<jpeg_dhp_image_component_sampling_factor, ParseError> {
+/// d#455
+fn Decoder455(_input: &mut Parser<'_>) -> Result<jpeg_dhp_image_component_sampling_factor, ParseError> {
 let _packed_bits = _input.read_byte()?;
 let horizontal = _packed_bits >> 4u8 & 15u8;
 let vertical = _packed_bits & 15u8;
 PResult::Ok(jpeg_dhp_image_component_sampling_factor { horizontal, vertical })
 }
 
-/// d#454
-fn Decoder454(_input: &mut Parser<'_>) -> Result<jpeg_sof_data, ParseError> {
+/// d#456
+fn Decoder456(_input: &mut Parser<'_>) -> Result<jpeg_sof_data, ParseError> {
 let sample_precision = _input.read_byte()?;
 let num_lines = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -36758,7 +37380,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(479680595494617916u64));
+return Err(ParseError::FalsifiedWhere(11416999240256111317u64));
 }
 };
 let num_image_components = {
@@ -36770,13 +37392,13 @@ x != 0u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(10531068763070667405u64));
+return Err(ParseError::FalsifiedWhere(13319962755558045565u64));
 }
 };
 let image_components = {
 let mut accum = Vec::new();
 for _ in 0..num_image_components {
-let next_elem = (Decoder455(_input))?;
+let next_elem = (Decoder457(_input))?;
 accum.push(next_elem)
 };
 accum
@@ -36784,22 +37406,22 @@ accum
 PResult::Ok(jpeg_sof_data { sample_precision, num_lines, num_samples_per_line, num_image_components, image_components })
 }
 
-/// d#455
-fn Decoder455(_input: &mut Parser<'_>) -> Result<jpeg_sof_image_component, ParseError> {
+/// d#457
+fn Decoder457(_input: &mut Parser<'_>) -> Result<jpeg_sof_image_component, ParseError> {
 let id = _input.read_byte()?;
-let sampling_factor = (Decoder453(_input))?;
+let sampling_factor = (Decoder455(_input))?;
 let quantization_table_id = {
 let b = _input.read_byte()?;
 if b == 0 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12431089125438936538u64));
+return Err(ParseError::ExcludedBranch(17426992236827678217u64));
 }
 };
 PResult::Ok(jpeg_sof_image_component { id, sampling_factor, quantization_table_id })
 }
 
-/// d#456
+/// d#458
 fn Decoder_jpeg_exp_data(_input: &mut Parser<'_>) -> Result<jpeg_exp_data, ParseError> {
 let expand_horizontal_vertical = {
 let inner = {
@@ -36815,21 +37437,21 @@ let x = inner;
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(9066809807580136020u64));
+return Err(ParseError::FalsifiedWhere(1236150641026759388u64));
 }
 };
 PResult::Ok(jpeg_exp_data { expand_horizontal_vertical })
 }
 
-/// d#457
-fn Decoder457(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
+/// d#459
+fn Decoder459(_input: &mut Parser<'_>) -> Result<jpeg_app2, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(12347909352078849049u64));
+return Err(ParseError::ExcludedBranch(12386662728078486919u64));
 }
 };
 let marker = {
@@ -36837,7 +37459,7 @@ let b = _input.read_byte()?;
 if b == 200 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10900015085754267678u64));
+return Err(ParseError::ExcludedBranch(14581882220438260695u64));
 }
 };
 jpeg_soi { marker }
@@ -36876,15 +37498,15 @@ ret
 PResult::Ok(jpeg_app2 { marker, length, data })
 }
 
-/// d#458
-fn Decoder458(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
+/// d#460
+fn Decoder460(_input: &mut Parser<'_>) -> Result<jpeg_sof0, ParseError> {
 let marker = {
 {
 let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(5999000939515818447u64));
+return Err(ParseError::ExcludedBranch(107739895477412745u64));
 }
 };
 let marker = {
@@ -36892,7 +37514,7 @@ let b = _input.read_byte()?;
 if b == 222 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(10508718825232435214u64));
+return Err(ParseError::ExcludedBranch(11249661549694067250u64));
 }
 };
 jpeg_soi { marker }
@@ -36904,15 +37526,15 @@ u16be(x)
 let data = {
 let sz = (try_sub!(length, 2u16, 11599300513837427027u64)) as usize;
 _input.start_slice(sz)?;
-let ret = (Decoder459(_input))?;
+let ret = (Decoder461(_input))?;
 _input.end_slice()?;
 ret
 };
 PResult::Ok(jpeg_sof0 { marker, length, data })
 }
 
-/// d#459
-fn Decoder459(_input: &mut Parser<'_>) -> Result<jpeg_sof_data, ParseError> {
+/// d#461
+fn Decoder461(_input: &mut Parser<'_>) -> Result<jpeg_sof_data, ParseError> {
 let sample_precision = _input.read_byte()?;
 let num_lines = {
 let x = (_input.read_byte()?, _input.read_byte()?);
@@ -36930,7 +37552,7 @@ x != 0u16
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13460389694602013078u64));
+return Err(ParseError::FalsifiedWhere(15129618400245272391u64));
 }
 };
 let num_image_components = {
@@ -36942,13 +37564,13 @@ x != 0u8
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(16535687493193441589u64));
+return Err(ParseError::FalsifiedWhere(4714328060581312491u64));
 }
 };
 let image_components = {
 let mut accum = Vec::new();
 for _ in 0..num_image_components {
-let next_elem = (Decoder455(_input))?;
+let next_elem = (Decoder457(_input))?;
 accum.push(next_elem)
 };
 accum
@@ -36956,7 +37578,7 @@ accum
 PResult::Ok(jpeg_sof_data { sample_precision, num_lines, num_samples_per_line, num_image_components, image_components })
 }
 
-/// d#460
+/// d#462
 fn Decoder_jpeg_exp(_input: &mut Parser<'_>) -> Result<jpeg_exp, ParseError> {
 let marker = {
 {
@@ -36964,7 +37586,7 @@ let b = _input.read_byte()?;
 if b == 255 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(16678380679225161433u64));
+return Err(ParseError::ExcludedBranch(1886731551318106143u64));
 }
 };
 let marker = {
@@ -36972,7 +37594,7 @@ let b = _input.read_byte()?;
 if b == 223 {
 b
 } else {
-return Err(ParseError::ExcludedBranch(11416999240256111317u64));
+return Err(ParseError::ExcludedBranch(2159624515109346846u64));
 }
 };
 jpeg_soi { marker }
@@ -36984,15 +37606,15 @@ u16be(x)
 let data = {
 let sz = (try_sub!(length, 2u16, 950046280632689001u64)) as usize;
 _input.start_slice(sz)?;
-let ret = (Decoder461(_input))?;
+let ret = (Decoder463(_input))?;
 _input.end_slice()?;
 ret
 };
 PResult::Ok(jpeg_exp { marker, length, data })
 }
 
-/// d#461
-fn Decoder461(_input: &mut Parser<'_>) -> Result<jpeg_exp_data, ParseError> {
+/// d#463
+fn Decoder463(_input: &mut Parser<'_>) -> Result<jpeg_exp_data, ParseError> {
 let expand_horizontal_vertical = {
 let inner = {
 let _packed_bits = _input.read_byte()?;
@@ -37007,7 +37629,7 @@ let x = inner;
 if is_valid {
 inner
 } else {
-return Err(ParseError::FalsifiedWhere(13319962755558045565u64));
+return Err(ParseError::FalsifiedWhere(6789861264798225044u64));
 }
 };
 PResult::Ok(jpeg_exp_data { expand_horizontal_vertical })

--- a/generated/gencode.rs
+++ b/generated/gencode.rs
@@ -3277,6 +3277,11 @@ italic: bool,
 bold: bool
 }
 
+/// expected size: 4
+/// trait-orphaned: no decoder functions provided
+#[derive(Debug, Copy, Clone)]
+pub enum opentype_head_table_font_direction_hint { Mixed, StrongLR, StrongRL, UnknownDirHint(i16), WeakLR, WeakRL }
+
 impl CommonObject for opentype_head_table {
 type Args<'x> = ();
 
@@ -3287,7 +3292,7 @@ Decoder_opentype_head_table(p)
 }
 }
 
-/// expected size: 64
+/// expected size: 72
 /// trait-ready: unique decoder function (d#32)
 #[derive(Debug, Copy, Clone)]
 pub struct opentype_head_table {
@@ -3303,7 +3308,7 @@ modified: i64,
 glyph_extents: opentype_head_table_glyph_extents,
 mac_style: opentype_head_table_mac_style,
 lowest_rec_ppem: u16,
-font_direction_hint: u16,
+font_direction_hint: opentype_head_table_font_direction_hint,
 index_to_loc_format: u16,
 glyph_data_format: u16
 }
@@ -7180,7 +7185,7 @@ Decoder_opentype_table_directory_table_links(p, tables, font_view)
 }
 }
 
-/// expected size: 1200
+/// expected size: 1208
 /// trait-ready: unique decoder function (d#30)
 #[derive(Debug, Clone)]
 pub struct opentype_table_directory_table_links<'input> {
@@ -7220,7 +7225,7 @@ Decoder_opentype_table_directory(p, font_view)
 }
 }
 
-/// expected size: 1240
+/// expected size: 1248
 /// trait-ready: unique decoder function (d#27)
 #[derive(Debug, Clone)]
 pub struct opentype_table_directory<'input> {
@@ -7233,7 +7238,7 @@ table_records: Vec<opentype_table_record>,
 table_links: opentype_table_directory_table_links<'input>
 }
 
-/// expected size: 1248
+/// expected size: 1256
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
 pub struct opentype_ttc_header_header_Version1_table_directories<'input> {
@@ -7285,7 +7290,7 @@ minor_version: u16,
 header: opentype_ttc_header_header<'input>
 }
 
-/// expected size: 1248
+/// expected size: 1256
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InEnum { variants: [Noop, DirectHeap] }, Layout { size: 56, align: 8 (1 << 3) })
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
@@ -7301,7 +7306,7 @@ Decoder_opentype_main(p)
 }
 }
 
-/// expected size: 1256
+/// expected size: 1264
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] }, Layout { size: 64, align: 8 (1 << 3) })
 /// trait-ready: unique decoder function (d#14)
 #[derive(Debug, Clone)]
@@ -8010,7 +8015,7 @@ noise: Vec<u8>,
 waldo: &'input [u8]
 }
 
-/// expected size: 1264
+/// expected size: 1272
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] }, Layout { size: 104, align: 8 (1 << 3) })
 /// trait-orphaned: no decoder functions provided
 #[derive(Debug, Clone)]
@@ -8116,7 +8121,7 @@ _char: u8,
 buf: Vec<u8>
 }
 
-/// expected size: 1264
+/// expected size: 1272
 /// heap outcome (HeapStrategy { absolute_cutoff: None, variant_cutoff: Some(128) }): (InRecord { fields: [InDef(InEnum { variants: [DirectHeap, Noop, Noop, DirectHeap, Noop, Noop, InTuple { pos: [InDef(InRecord { fields: [Noop, InDef(InEnum { variants: [Noop, DirectHeap] })] })] }, Noop, DirectHeap, Noop, Noop, Noop, Noop, Noop, Noop, Noop] })] }, Layout { size: 104, align: 8 (1 << 3) })
 /// trait-unready: multiple (2) decoders exist (d#{0, 1})
 #[derive(Debug, Clone)]
@@ -10973,8 +10978,53 @@ let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
 };
 let font_direction_hint = {
+let disc = {
+let raw = {
 let x = (_input.read_byte()?, _input.read_byte()?);
 u16be(x)
+};
+raw as i16
+};
+match disc {
+0 => {
+{
+();
+opentype_head_table_font_direction_hint::Mixed
+}
+},
+
+1 => {
+{
+();
+opentype_head_table_font_direction_hint::StrongLR
+}
+},
+
+2 => {
+{
+();
+opentype_head_table_font_direction_hint::WeakLR
+}
+},
+
+-1 => {
+{
+();
+opentype_head_table_font_direction_hint::StrongRL
+}
+},
+
+-2 => {
+{
+();
+opentype_head_table_font_direction_hint::WeakRL
+}
+},
+
+other => {
+opentype_head_table_font_direction_hint::UnknownDirHint(other)
+}
+}
 };
 let index_to_loc_format = {
 let inner = {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -916,6 +916,8 @@ fn embed_pattern(pat: &GTPattern) -> RustPattern {
         TypedPattern::U16(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U16(*n))),
         TypedPattern::U32(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U32(*n))),
         TypedPattern::U64(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U64(*n))),
+        TypedPattern::ZConst(_, z) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::SomeInt(z.clone()))),
+        TypedPattern::ZRange(_, range) => RustPattern::PrimRange(RustPrimLit::Numeric(RustNumLit::SomeInt(range.min.clone())), Some(RustPrimLit::Numeric(RustNumLit::SomeInt(range.max.clone())))),
         TypedPattern::Int(gt, bounds) => match bounds.is_exact() {
             Some(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::Usize(n))),
             None => match gt {
@@ -4065,6 +4067,14 @@ impl<'a> Elaborator<'a> {
             Pattern::Int(bounds) => {
                 let gt = self.get_gt_from_index(index);
                 GTPattern::Int(gt, *bounds)
+            }
+            Pattern::ZConst(z) => {
+                let gt = self.get_gt_from_index(index);
+                GTPattern::ZConst(gt, z.clone())
+            }
+            Pattern::ZRange(zb) => {
+                let gt = self.get_gt_from_index(index);
+                GTPattern::ZRange(gt, zb.clone())
             }
             Pattern::Char(c) => GTPattern::Char(*c),
             Pattern::Tuple(elts) => {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -916,8 +916,13 @@ fn embed_pattern(pat: &GTPattern) -> RustPattern {
         TypedPattern::U16(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U16(*n))),
         TypedPattern::U32(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U32(*n))),
         TypedPattern::U64(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::U64(*n))),
-        TypedPattern::ZConst(_, z) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::SomeInt(z.clone()))),
-        TypedPattern::ZRange(_, range) => RustPattern::PrimRange(RustPrimLit::Numeric(RustNumLit::SomeInt(range.min.clone())), Some(RustPrimLit::Numeric(RustNumLit::SomeInt(range.max.clone())))),
+        TypedPattern::ZConst(_, z) => {
+            RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::SomeInt(z.clone())))
+        }
+        TypedPattern::ZRange(_, range) => RustPattern::PrimRange(
+            RustPrimLit::Numeric(RustNumLit::SomeInt(range.min.clone())),
+            Some(RustPrimLit::Numeric(RustNumLit::SomeInt(range.max.clone()))),
+        ),
         TypedPattern::Int(gt, bounds) => match bounds.is_exact() {
             Some(n) => RustPattern::PrimLiteral(RustPrimLit::Numeric(RustNumLit::Usize(n))),
             None => match gt {

--- a/src/codegen/rust_ast/mod.rs
+++ b/src/codegen/rust_ast/mod.rs
@@ -1663,24 +1663,28 @@ pub(crate) enum RustPrimLit {
     String(Label),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub(crate) enum RustNumLit {
     U8(u8),
     U16(u16),
     U32(u32),
     U64(u64),
     Usize(usize),
+    SomeInt(BigInt),
 }
 
-impl From<RustNumLit> for usize {
-    fn from(value: RustNumLit) -> Self {
-        match value {
+impl TryFrom<RustNumLit> for usize {
+    type Error = <BigInt as TryInto<usize>>::Error;
+
+    fn try_from(value: RustNumLit) -> Result<Self, Self::Error> {
+        Ok(match value {
             RustNumLit::U8(n) => n as usize,
             RustNumLit::U16(n) => n as usize,
             RustNumLit::U32(n) => n as usize,
             RustNumLit::U64(n) => n as usize,
             RustNumLit::Usize(n) => n,
-        }
+            RustNumLit::SomeInt(big) => big.try_into()?,
+        })
     }
 }
 
@@ -1692,6 +1696,7 @@ impl ToFragment for RustNumLit {
             RustNumLit::U32(n) => Fragment::string(format!("{n}u32")),
             RustNumLit::U64(n) => Fragment::string(format!("{n}u64")),
             RustNumLit::Usize(n) => Fragment::string(format!("{n}")),
+            RustNumLit::SomeInt(z) => Fragment::string(z.to_string()),
         }
     }
 }
@@ -2252,6 +2257,7 @@ impl RustExpr {
                     RustNumLit::U32(..) => Some(PrimType::U32),
                     RustNumLit::U64(..) => Some(PrimType::U64),
                     RustNumLit::Usize(..) => Some(PrimType::Usize),
+                    RustNumLit::SomeInt(..) => None,
                 },
                 RustPrimLit::Char(..) => Some(PrimType::Char),
                 RustPrimLit::String(..) => None,
@@ -2654,7 +2660,7 @@ impl RustExpr {
 
     pub(crate) fn get_const(&self) -> Option<usize> {
         match self {
-            RustExpr::PrimitiveLit(RustPrimLit::Numeric(rnl)) => Some(usize::from(*rnl)),
+            RustExpr::PrimitiveLit(RustPrimLit::Numeric(rnl)) => usize::try_from(rnl.clone()).ok(),
             _ => None,
         }
     }
@@ -4396,6 +4402,7 @@ pub mod short_circuit {
         }
     }
 }
+use num_bigint::BigInt;
 pub use short_circuit::{ShortCircuit, ShortCircuitExt, ValueCheckpoint};
 
 pub mod var_container {

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -2,6 +2,8 @@ use std::borrow::Cow;
 use std::ops::Add;
 use std::rc::Rc;
 
+use num_bigint::BigInt;
+
 use super::rust_ast::{PrimType, RustType, RustTypeDecl};
 use super::{AtomType, LocalType};
 use crate::bounds::Bounds;
@@ -9,6 +11,7 @@ use crate::byte_set::ByteSet;
 use crate::codegen::rust_ast::{RustLt, RustParams, UseParams};
 use crate::numeric::elaborator::TypedExpr as TypedNumExpr;
 use crate::{Arith, BaseKind, Endian, IntRel, Label, StyleHint, TypeHint, UnaryOp};
+use crate::numeric::core::Bounds as NumBounds;
 
 pub(crate) mod variables;
 
@@ -934,6 +937,8 @@ pub enum TypedPattern<TypeRep> {
     U32(u32),
     U64(u64),
     Int(TypeRep, Bounds),
+    ZConst(TypeRep, BigInt),
+    ZRange(TypeRep, NumBounds),
     Char(char),
     Tuple(TypeRep, Vec<TypedPattern<TypeRep>>),
     Variant(TypeRep, Label, Box<TypedPattern<TypeRep>>),
@@ -956,6 +961,8 @@ impl TypedPattern<GenType> {
             | TypedPattern::Tuple(gt, ..)
             | TypedPattern::Option(gt, ..)
             | TypedPattern::Int(gt, ..)
+            | TypedPattern::ZConst(gt, ..)
+            | TypedPattern::ZRange(gt, ..)
             | TypedPattern::Variant(gt, ..)
             | TypedPattern::Seq(gt, ..) => Cow::Borrowed(gt),
         }
@@ -974,6 +981,8 @@ impl<TypeRep> std::hash::Hash for TypedPattern<TypeRep> {
             TypedPattern::U32(n) => n.hash(state),
             TypedPattern::U64(n) => n.hash(state),
             TypedPattern::Int(_, bounds) => bounds.hash(state),
+            TypedPattern::ZConst(_, z) => z.hash(state),
+            TypedPattern::ZRange(_, range) => range.hash(state),
             TypedPattern::Char(c) => c.hash(state),
             TypedPattern::Tuple(_, tup) => tup.hash(state),
             TypedPattern::Variant(_, lbl, inner) => {
@@ -1248,6 +1257,8 @@ mod __impls {
                 TypedPattern::U32(n) => Pattern::U32(n),
                 TypedPattern::U64(n) => Pattern::U64(n),
                 TypedPattern::Int(_, bounds) => Pattern::Int(bounds),
+                TypedPattern::ZConst(_, z) => Pattern::ZConst(z),
+                TypedPattern::ZRange(_, bounds) => Pattern::ZRange(bounds),
                 TypedPattern::Char(c) => Pattern::Char(c),
                 TypedPattern::Tuple(_, elts) => Pattern::Tuple(revec(elts)),
                 TypedPattern::Variant(_, name, inner) => Pattern::Variant(name, rebox(inner)),

--- a/src/codegen/typed_format.rs
+++ b/src/codegen/typed_format.rs
@@ -9,9 +9,9 @@ use super::{AtomType, LocalType};
 use crate::bounds::Bounds;
 use crate::byte_set::ByteSet;
 use crate::codegen::rust_ast::{RustLt, RustParams, UseParams};
+use crate::numeric::core::Bounds as NumBounds;
 use crate::numeric::elaborator::TypedExpr as TypedNumExpr;
 use crate::{Arith, BaseKind, Endian, IntRel, Label, StyleHint, TypeHint, UnaryOp};
-use crate::numeric::core::Bounds as NumBounds;
 
 pub(crate) mod variables;
 

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -206,7 +206,7 @@ impl Value {
                 Value::Usize(n) => range.contains(&BigInt::from(*n)),
                 Value::Numeric(n) => range.contains(n.as_raw_value()),
                 _ => false,
-            }
+            },
             Pattern::Char(c0) => matches!(self, Value::Char(c1) if c0 == c1),
             Pattern::Tuple(ps) => match self {
                 Value::Tuple(vs) if ps.len() == vs.len() => {

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use anyhow::{Result as AResult, anyhow};
+use num_bigint::BigInt;
 use serde::Serialize;
 
 use crate::byte_set::ByteSet;
@@ -188,6 +189,24 @@ impl Value {
                 Value::Numeric(n) => n.matches_int_range(*bounds),
                 _ => false,
             },
+            Pattern::ZConst(z) => match self {
+                Value::U8(n) => z == &BigInt::from(*n),
+                Value::U16(n) => z == &BigInt::from(*n),
+                Value::U32(n) => z == &BigInt::from(*n),
+                Value::U64(n) => z == &BigInt::from(*n),
+                Value::Usize(n) => z == &BigInt::from(*n),
+                Value::Numeric(n) => n.eq_num(z),
+                _ => false,
+            },
+            Pattern::ZRange(range) => match self {
+                Value::U8(n) => range.contains(&BigInt::from(*n)),
+                Value::U16(n) => range.contains(&BigInt::from(*n)),
+                Value::U32(n) => range.contains(&BigInt::from(*n)),
+                Value::U64(n) => range.contains(&BigInt::from(*n)),
+                Value::Usize(n) => range.contains(&BigInt::from(*n)),
+                Value::Numeric(n) => range.contains(n.as_raw_value()),
+                _ => false,
+            }
             Pattern::Char(c0) => matches!(self, Value::Char(c1) if c0 == c1),
             Pattern::Tuple(ps) => match self {
                 Value::Tuple(vs) if ps.len() == vs.len() => {

--- a/src/dep_ref.rs
+++ b/src/dep_ref.rs
@@ -40,6 +40,10 @@ impl<const M: usize> DepFormat<0, M> {
 }
 
 impl<const N: usize, const M: usize> DepFormat<N, M> {
+    pub fn get_level(&self) -> usize {
+        self.inner.get_level()
+    }
+
     pub fn invoke_args_views(&self, args: [Expr; N], views: [ViewExpr; M]) -> Format {
         self.inner.call_args_views(args.to_vec(), views.to_vec())
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1604,7 +1604,7 @@ pub fn hint(hint: StyleHint, format: Format) -> Format {
 
 pub mod base {
     use super::*;
-    use crate::CommonOp;
+    use crate::{CommonOp, numeric::MachineRep};
 
     macro_rules! endian {
         ( $( $fname:ident, $kind_endian:ident, $size:expr, $op:ident );* $(;)? ) => {
@@ -1651,8 +1651,34 @@ pub mod base {
         u64be, U64BE, 8, U64Be;
         u64le, U64LE, 8, U64Le;
     }
+
+
+    // TODO[epic=signed-parse] - add stylehint support for signed-parse operations
+    /// Parses a u8 value and performs a bitwise cast to i8.
+    pub fn i8() -> Format {
+        map_numeric(u8(), |v| num::cast_bitwise(MachineRep::I8, v))
+    }
+
+    // TODO[epic=signed-parse] - add stylehint support for signed-parse operations
+    /// Parses a big-endian u16 value and performs a bitwise cast to i16.
+    pub fn i16be() -> Format {
+        map_numeric(u16be(), |v| num::cast_bitwise(MachineRep::I16, v))
+    }
+
+    // TODO[epic=signed-parse] - add stylehint support for signed-parse operations
+    /// Parses a big-endian u32 value and performs a bitwise cast to i32.
+    pub fn i32be() -> Format {
+        map_numeric(u32be(), |v| num::cast_bitwise(MachineRep::I32, v))
+    }
+
+    // TODO[epic=signed-parse] - add stylehint support for signed-parse operations
+    /// Parses a big-endian u64 value and performs a bitwise cast to i64.
+    pub fn i64be() -> Format {
+        map_numeric(u64be(), |v| num::cast_bitwise(MachineRep::I64, v))
+    }
+
 }
-pub use base::{bit, u8, u16be, u16le, u32be, u32le, u64be, u64le};
+pub use base::{bit, u8, u16be, u16le, u32be, u32le, u64be, u64le, i8, i16be, i32be, i64be};
 
 pub mod ascii {
     use super::{mk_ascii_string, *};

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1652,7 +1652,6 @@ pub mod base {
         u64le, U64LE, 8, U64Le;
     }
 
-
     // TODO[epic=signed-parse] - add stylehint support for signed-parse operations
     /// Parses a u8 value and performs a bitwise cast to i8.
     pub fn i8() -> Format {
@@ -1676,9 +1675,8 @@ pub mod base {
     pub fn i64be() -> Format {
         map_numeric(u64be(), |v| num::cast_bitwise(MachineRep::I64, v))
     }
-
 }
-pub use base::{bit, u8, u16be, u16le, u32be, u32le, u64be, u64le, i8, i16be, i32be, i64be};
+pub use base::{bit, i8, i16be, i32be, i64be, u8, u16be, u16le, u32be, u32le, u64be, u64le};
 
 pub mod ascii {
     use super::{mk_ascii_string, *};

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1905,6 +1905,27 @@ where
 }
 // !SECTION
 
+/// Given a base expression and a mapping from single-value patterns to variant names (along with an optional label for an unknown-value catch-all),
+/// yields an expression that matches on the base expression and interprets it as the implied enum.
+pub fn interpret_as_enum<const N: usize>(
+    expr: Expr,
+    mapping: [(Pattern, &'static str); N],
+    fallthrough: Option<&'static str>,
+) -> Expr {
+    expr_match(
+        expr,
+        mapping
+            .into_iter()
+            .map(|(pat, vname)| (pat, variant(vname, Expr::UNIT)))
+            .chain(fallthrough.map(|vname| {
+                (
+                    Pattern::Binding(Label::Borrowed("other")),
+                    variant(vname, var("other")),
+                )
+            })),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -796,6 +796,7 @@ impl ViewExpr {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(tag = "tag", content = "args")]
 pub enum CommonOp {
+    // FIXME[epic=signed-parse] - add in expressivity for signed-integer parsing as commonop
     EndianParse(BaseKind<Endian>),
 }
 

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -424,9 +424,9 @@ impl ParsedValue {
                     Value::Usize(n) => z == &BigInt::from(*n),
                     Value::Numeric(tc) => tc.eq_num(z),
                     _ => false,
-                }
+                },
                 _ => false,
-            }
+            },
             Pattern::ZRange(bounds) => match self {
                 ParsedValue::Flat(Parsed { inner: v, .. }) => match v {
                     Value::U8(n) => bounds.contains(&BigInt::from(*n)),
@@ -438,7 +438,7 @@ impl ParsedValue {
                     _ => false,
                 },
                 _ => false,
-            }
+            },
         }
     }
 

--- a/src/loc_decoder.rs
+++ b/src/loc_decoder.rs
@@ -11,6 +11,7 @@ use crate::read::ReadCtxt;
 use crate::{
     Arith, BaseKind, DynFormat, Endian, Expr, Format, IntRel, Label, Pattern, UnaryOp, ViewExpr,
 };
+use num_bigint::BigInt;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cmp::Ordering;
@@ -414,6 +415,30 @@ impl ParsedValue {
                 },
                 _ => false,
             },
+            Pattern::ZConst(z) => match self {
+                ParsedValue::Flat(Parsed { inner: v, .. }) => match v {
+                    Value::U8(n) => z == &BigInt::from(*n),
+                    Value::U16(n) => z == &BigInt::from(*n),
+                    Value::U32(n) => z == &BigInt::from(*n),
+                    Value::U64(n) => z == &BigInt::from(*n),
+                    Value::Usize(n) => z == &BigInt::from(*n),
+                    Value::Numeric(tc) => tc.eq_num(z),
+                    _ => false,
+                }
+                _ => false,
+            }
+            Pattern::ZRange(bounds) => match self {
+                ParsedValue::Flat(Parsed { inner: v, .. }) => match v {
+                    Value::U8(n) => bounds.contains(&BigInt::from(*n)),
+                    Value::U16(n) => bounds.contains(&BigInt::from(*n)),
+                    Value::U32(n) => bounds.contains(&BigInt::from(*n)),
+                    Value::U64(n) => bounds.contains(&BigInt::from(*n)),
+                    Value::Usize(n) => bounds.contains(&BigInt::from(*n)),
+                    Value::Numeric(tc) => bounds.contains(tc.as_raw_value()),
+                    _ => false,
+                },
+                _ => false,
+            }
         }
     }
 

--- a/src/numeric/codegen.rs
+++ b/src/numeric/codegen.rs
@@ -1,4 +1,5 @@
 use crate::Label;
+use crate::codegen::rust_ast::RustType;
 use crate::codegen::{
     rust_ast::{
         ClosureBody, FnEntity, NumType, RustClosure, RustClosureHead, RustEntity, RustExpr,
@@ -325,7 +326,9 @@ pub(crate) fn synthesize(model: &TypedExpr<GenType>) -> RustExpr {
                         fname: RustEntity::Local(induce_binary_fname(op.inner, class)),
                     },
                     vec![lhs, rhs],
-                ),
+                )
+                .call_method("eval")
+                .wrap_try(),
                 class @ (BinOpClass::HomLossy(t1 @ t0, t2) | BinOpClass::HetLossy(t0, t1, t2)) => {
                     RustExpr::Invoke(
                         FnEntity::Synthetic {
@@ -345,6 +348,8 @@ pub(crate) fn synthesize(model: &TypedExpr<GenType>) -> RustExpr {
                             synthesize_binop(op.inner),
                         ],
                     )
+                    .call_method("eval")
+                    .wrap_try()
                 }
             }
         }
@@ -362,7 +367,9 @@ pub(crate) fn synthesize(model: &TypedExpr<GenType>) -> RustExpr {
                         fname: RustEntity::Local(induce_unary_fname(op.inner, class)),
                     },
                     vec![input],
-                ),
+                )
+                .call_method("eval")
+                .wrap_try(),
                 class @ UnaryOpClass::Lossy(t0, t1) => RustExpr::Invoke(
                     FnEntity::Synthetic {
                         fname: RustEntity::Local(Label::Borrowed(SYNTHETIC_UNARY)),
@@ -375,7 +382,9 @@ pub(crate) fn synthesize(model: &TypedExpr<GenType>) -> RustExpr {
                         ))),
                         synthesize_unary(op.inner),
                     ],
-                ),
+                )
+                .call_method("eval")
+                .wrap_try(),
             }
         }
         TypedExpr::ElabCast(_, cast, input) => {
@@ -386,15 +395,27 @@ pub(crate) fn synthesize(model: &TypedExpr<GenType>) -> RustExpr {
                 .clone()
                 .try_map_type(&coerce)
                 .expect("failed to coerce cast signature");
-            match classify_unary(None, sig) {
-                // NOTE - we avoid function stubbing for no-op casts (i.e. T -> T)
-                UnaryOpClass::Pure(_) => input,
-                class @ (UnaryOpClass::Lossy(..) | UnaryOpClass::NonLossy(..)) => RustExpr::Invoke(
-                    FnEntity::Specific {
-                        fname: RustEntity::Local(induce_cast_fname(class)),
-                    },
-                    vec![input],
-                ),
+            let is_arith = cast.op.cast_semantics.is_arithmetic();
+            if is_arith {
+                match classify_unary(None, sig) {
+                    // NOTE - we avoid function stubbing for no-op casts (i.e. T -> T)
+                    UnaryOpClass::Pure(_) => input,
+                    class @ (UnaryOpClass::Lossy(..) | UnaryOpClass::NonLossy(..)) => {
+                        RustExpr::Invoke(
+                            FnEntity::Specific {
+                                fname: RustEntity::Local(induce_cast_fname(class)),
+                            },
+                            vec![input],
+                        )
+                        .call_method("eval")
+                        .wrap_try()
+                    }
+                }
+            } else {
+                RustExpr::Operation(crate::codegen::rust_ast::RustOp::AsCast(
+                    Box::new(input),
+                    RustType::from(sig.1),
+                ))
             }
         }
     }

--- a/src/numeric/core.rs
+++ b/src/numeric/core.rs
@@ -229,10 +229,14 @@ impl NumRep {
 }
 
 /// Representative min and max bounds for a numeric type
-#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+///
+/// Both ends are inclusive, and `min <= max`.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Serialize)]
 pub struct Bounds {
-    min: Number,
-    max: Number,
+    #[serde(serialize_with = "ser_bigint")]
+    pub min: Number,
+    #[serde(serialize_with = "ser_bigint")]
+    pub max: Number,
 }
 
 impl std::fmt::Display for Bounds {
@@ -282,6 +286,10 @@ impl Bounds {
                 max: Ord::max(&self.max, &bs2.max).clone(),
             })
         }
+    }
+
+    pub(crate) fn contains(&self, val: &BigInt) -> bool {
+        self.min <= *val && self.max >= *val
     }
 }
 
@@ -352,7 +360,7 @@ pub struct TypedConst(
     #[serde(serialize_with = "ser_num_rep")] pub NumRep,
 );
 
-fn ser_bigint<S>(value: &BigInt, serializer: S) -> Result<S::Ok, S::Error>
+pub(crate) fn ser_bigint<S>(value: &BigInt, serializer: S) -> Result<S::Ok, S::Error>
 where
     S: serde::Serializer,
 {

--- a/src/numeric/eval.rs
+++ b/src/numeric/eval.rs
@@ -59,10 +59,22 @@ where
 }
 
 /// Error type for failed coercion of `Eval<T>` into `T` (via [`Eval::eval`])
+#[derive(Clone, Debug)]
 pub enum EvalError {
     Indirect(BigInt),
     NotANumber,
 }
+
+impl std::fmt::Display for EvalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EvalError::Indirect(v) => write!(f, "out-of-range value: {v}"),
+            EvalError::NotANumber => write!(f, "operation yielded NaN"),
+        }
+    }
+}
+
+impl std::error::Error for EvalError {}
 
 impl<T: Copy> Eval<T> {
     /// Attempts to evaluate `self` as a value of type `T`, returning `Err` if `self` is `NaN` or `Indirect`.

--- a/src/output/tree.rs
+++ b/src/output/tree.rs
@@ -1752,6 +1752,8 @@ impl<'module> TreePrinter<'module> {
                 .cat(Fragment::Char(')'))
                 .group(),
             Pattern::Int(..)
+            | Pattern::ZConst(..)
+            | Pattern::ZRange(..)
             | Pattern::U8(..)
             | Pattern::U16(..)
             | Pattern::U32(..)

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,7 +14,7 @@ pub(crate) fn mk_trace(value: &impl std::hash::Hash) -> TraceHash {
 }
 
 /// General error type for both recoverable and unrecoverable errors encountered during parsing operations
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum ParseError {
     /// Explicit `Format::Fail` or any of its derived equivalents
     FailToken(TraceHash),
@@ -39,6 +39,14 @@ pub enum ParseError {
     InternalError(StateError),
     /// An operation performed on values derived via parsing is not sound, mostly due to a bad assumption of the format for what is being parsed
     UnsoundOperation(Option<&'static str>, TraceHash),
+    /// A numeric evaluation error
+    BadEval(crate::numeric::eval::EvalError),
+}
+
+impl From<crate::numeric::eval::EvalError> for ParseError {
+    fn from(err: crate::numeric::eval::EvalError) -> Self {
+        Self::BadEval(err)
+    }
 }
 
 /// Error-kind indicator that distinguishes between different Overrun errors.
@@ -102,6 +110,7 @@ impl std::fmt::Display for ParseError {
                 ),
             },
             ParseError::InternalError(e) => write!(f, "unrecoverable internal error: {e}"),
+            ParseError::BadEval(e) => write!(f, "{e}"),
         }
     }
 }
@@ -110,6 +119,7 @@ impl std::error::Error for ParseError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             ParseError::InternalError(e) => Some(e),
+            ParseError::BadEval(e) => Some(e),
             _ => None,
         }
     }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,7 +1,9 @@
 use crate::alt::{FormatExt, FormatModuleExt, ValueTypeExt};
 use crate::bounds::Bounds;
 use crate::{BaseType, Expr, Format, FormatModule, IntoLabel, Label, TypeScope, ValueType};
+use crate::numeric::core::Bounds as NumBounds;
 use anyhow::Result as AResult;
+use num_bigint::BigInt;
 use serde::Serialize;
 use std::rc::Rc;
 
@@ -16,6 +18,8 @@ pub enum Pattern {
     U32(u32),
     U64(u64),
     Int(Bounds),
+    ZConst(#[serde(serialize_with = "crate::numeric::core::ser_bigint")] BigInt),
+    ZRange(NumBounds),
     Char(char),
     Tuple(Vec<Pattern>),
     Variant(Label, Box<Pattern>),
@@ -25,6 +29,18 @@ pub enum Pattern {
 
 impl Pattern {
     pub const UNIT: Pattern = Pattern::Tuple(Vec::new());
+
+    pub fn z_const<N>(n: N) -> Pattern
+    where BigInt: From<N>
+    {
+        Pattern::ZConst(BigInt::from(n))
+    }
+
+    pub fn z_range<N>(min: N, max: N) -> Pattern
+    where BigInt: From<N>
+    {
+        Pattern::ZRange(NumBounds::new(min.into(), max.into()))
+    }
 
     /// Constructs a pattern that matches against literal sequence of bytes.
     pub fn from_bytes(bs: &[u8]) -> Pattern {
@@ -51,10 +67,10 @@ impl Pattern {
             (Pattern::U16(..), ValueType::Base(BaseType::U16)) => {}
             (Pattern::U32(..), ValueType::Base(BaseType::U32)) => {}
             (Pattern::U64(..), ValueType::Base(BaseType::U64)) => {}
-            (Pattern::Int(..), ValueType::Base(BaseType::U8)) => {}
-            (Pattern::Int(..), ValueType::Base(BaseType::U16)) => {}
-            (Pattern::Int(..), ValueType::Base(BaseType::U32)) => {}
-            (Pattern::Int(..), ValueType::Base(BaseType::U64)) => {}
+            (Pattern::Int(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZConst(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZRange(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueType::UnknownNumeric) => {},
             (Pattern::Tuple(ps), ValueType::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope(scope, Rc::new(t.clone()));
@@ -99,10 +115,10 @@ impl Pattern {
             (Pattern::U16(..), ValueTypeExt::Base(BaseType::U16)) => {}
             (Pattern::U32(..), ValueTypeExt::Base(BaseType::U32)) => {}
             (Pattern::U64(..), ValueTypeExt::Base(BaseType::U64)) => {}
-            (
-                Pattern::Int(..),
-                ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
-            ) => {}
+            (Pattern::Int(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZConst(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZRange(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
+            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueTypeExt::UnknownNumeric) => {},
             (Pattern::Tuple(ps), ValueTypeExt::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope_ext(scope, Rc::new(t.clone()));
@@ -187,6 +203,8 @@ impl Pattern {
             | Pattern::U32(_)
             | Pattern::U64(_)
             | Pattern::Int(_)
+            | Pattern::ZConst(_)
+            | Pattern::ZRange(_)
             | Pattern::Char(_) => false,
             Pattern::Tuple(ts) => ts.iter().any(|p| p.shadows(name)),
             Pattern::Variant(_, p) => p.shadows(name),

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -1,7 +1,7 @@
 use crate::alt::{FormatExt, FormatModuleExt, ValueTypeExt};
 use crate::bounds::Bounds;
-use crate::{BaseType, Expr, Format, FormatModule, IntoLabel, Label, TypeScope, ValueType};
 use crate::numeric::core::Bounds as NumBounds;
+use crate::{BaseType, Expr, Format, FormatModule, IntoLabel, Label, TypeScope, ValueType};
 use anyhow::Result as AResult;
 use num_bigint::BigInt;
 use serde::Serialize;
@@ -31,13 +31,15 @@ impl Pattern {
     pub const UNIT: Pattern = Pattern::Tuple(Vec::new());
 
     pub fn z_const<N>(n: N) -> Pattern
-    where BigInt: From<N>
+    where
+        BigInt: From<N>,
     {
         Pattern::ZConst(BigInt::from(n))
     }
 
     pub fn z_range<N>(min: N, max: N) -> Pattern
-    where BigInt: From<N>
+    where
+        BigInt: From<N>,
     {
         Pattern::ZRange(NumBounds::new(min.into(), max.into()))
     }
@@ -67,10 +69,19 @@ impl Pattern {
             (Pattern::U16(..), ValueType::Base(BaseType::U16)) => {}
             (Pattern::U32(..), ValueType::Base(BaseType::U32)) => {}
             (Pattern::U64(..), ValueType::Base(BaseType::U64)) => {}
-            (Pattern::Int(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZConst(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZRange(..), ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueType::UnknownNumeric) => {},
+            (
+                Pattern::Int(..),
+                ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (
+                Pattern::ZConst(..),
+                ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (
+                Pattern::ZRange(..),
+                ValueType::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueType::UnknownNumeric) => {}
             (Pattern::Tuple(ps), ValueType::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope(scope, Rc::new(t.clone()));
@@ -115,10 +126,19 @@ impl Pattern {
             (Pattern::U16(..), ValueTypeExt::Base(BaseType::U16)) => {}
             (Pattern::U32(..), ValueTypeExt::Base(BaseType::U32)) => {}
             (Pattern::U64(..), ValueTypeExt::Base(BaseType::U64)) => {}
-            (Pattern::Int(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZConst(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZRange(..), ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64)) => {}
-            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueTypeExt::UnknownNumeric) => {},
+            (
+                Pattern::Int(..),
+                ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (
+                Pattern::ZConst(..),
+                ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (
+                Pattern::ZRange(..),
+                ValueTypeExt::Base(BaseType::U8 | BaseType::U16 | BaseType::U32 | BaseType::U64),
+            ) => {}
+            (Pattern::ZConst(..) | Pattern::ZRange(..), ValueTypeExt::UnknownNumeric) => {}
             (Pattern::Tuple(ps), ValueTypeExt::Tuple(ts)) if ps.len() == ts.len() => {
                 for (p, t) in Iterator::zip(ps.iter(), ts.iter()) {
                     p.build_scope_ext(scope, Rc::new(t.clone()));

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -292,7 +292,7 @@ where
 {
     match rf {
         Ok(f) => Box::new(f),
-        Err(e) => Box::new(move |_| Err(e)),
+        Err(e) => Box::new(move |_| Err(e.clone())),
     }
 }
 

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3,15 +3,18 @@ use std::{
     rc::Rc,
 };
 
-use crate::{base_set::PrimIntSet, numeric::{
-    MachineRep, NumRep,
-    core::{BitWidth, Bounds as ZBounds, Expr as NExpr},
-    elaborator::{IntType, PrimInt},
-}};
 use crate::valuetype::{SeqBorrowHint, augmented::AugValueType};
 use crate::{
     Arith, BaseType, DynFormat, Expr, Format, FormatModule, Label, Pattern, UnaryOp, ValueType,
     ViewExpr, ViewFormat,
+};
+use crate::{
+    base_set::PrimIntSet,
+    numeric::{
+        MachineRep, NumRep,
+        core::{BitWidth, Bounds as ZBounds, Expr as NExpr},
+        elaborator::{IntType, PrimInt},
+    },
 };
 
 pub mod base_set;
@@ -920,7 +923,11 @@ impl TypeChecker {
         let new_scope = UScope::Multi(&tmp);
         let new_ctxt = ctxt.with_scope(&new_scope);
         let local_rhs_var = self.infer_var_format(rhs_format, new_ctxt)?;
-        let _tmp = ("unify_utype_format_match_case", pvar, format!("{:?}", head_t));
+        let _tmp = (
+            "unify_utype_format_match_case",
+            pvar,
+            format!("{:?}", head_t),
+        );
         try_with!( self.unify_var_utype(pvar, head_t) => _tmp );
         self.unify_var_pair(rhs_var, local_rhs_var)?;
         Ok(())
@@ -1494,7 +1501,13 @@ impl TypeChecker {
                             .unwrap()
                             .1
                             .clone();
-                        let _tmp = ("unify_var_proj_field", rec_var, fname, fld_var, format!("{:?}", fld_type));
+                        let _tmp = (
+                            "unify_var_proj_field",
+                            rec_var,
+                            fname,
+                            fld_var,
+                            format!("{:?}", fld_type),
+                        );
                         try_with!(self.unify_var_utype(fld_var, fld_type) => _tmp);
                         Ok(())
                     }
@@ -1537,7 +1550,12 @@ impl TypeChecker {
                 Constraint::Equiv(ut) => match ut.as_ref() {
                     UType::Option(inner) => {
                         let param_t = inner.clone();
-                        let _tmp = ("unify_var_proj_param", opt_v, param_v, format!("{:?}", param_t));
+                        let _tmp = (
+                            "unify_var_proj_param",
+                            opt_v,
+                            param_v,
+                            format!("{:?}", param_t),
+                        );
                         try_with!(self.unify_var_utype(param_v, param_t) => _tmp);
                         Ok(())
                     }
@@ -1572,7 +1590,12 @@ impl TypeChecker {
                 Constraint::Equiv(ut) => match ut.as_ref() {
                     UType::Seq(inner, _) => {
                         let elem_t = inner.clone();
-                        let _tmp = ("unify_var_proj_elem", seq_v, elem_v, format!("{:?}", elem_t));
+                        let _tmp = (
+                            "unify_var_proj_elem",
+                            seq_v,
+                            elem_v,
+                            format!("{:?}", elem_t),
+                        );
                         try_with!(self.unify_var_utype(elem_v, elem_t) => _tmp);
                         Ok(())
                     }
@@ -2031,7 +2054,12 @@ impl TypeChecker {
                             for (fld, ut) in fld_ut.iter() {
                                 keys_ut.insert(fld.clone());
                                 if let Some(var) = fld_p.get(fld) {
-                                    let _tmp = ("unify_constraint_pair@Proj<->Equiv", fld.clone(), *var, format!("{:?}", ut));
+                                    let _tmp = (
+                                        "unify_constraint_pair@Proj<->Equiv",
+                                        fld.clone(),
+                                        *var,
+                                        format!("{:?}", ut),
+                                    );
                                     try_with!(self.unify_var_utype(*var, ut.clone()) => _tmp);
                                 }
                             }

--- a/src/typecheck.rs
+++ b/src/typecheck.rs
@@ -3,11 +3,11 @@ use std::{
     rc::Rc,
 };
 
-use crate::numeric::{
+use crate::{base_set::PrimIntSet, numeric::{
     MachineRep, NumRep,
     core::{BitWidth, Bounds as ZBounds, Expr as NExpr},
     elaborator::{IntType, PrimInt},
-};
+}};
 use crate::valuetype::{SeqBorrowHint, augmented::AugValueType};
 use crate::{
     Arith, BaseType, DynFormat, Expr, Format, FormatModule, Label, Pattern, UnaryOp, ValueType,
@@ -766,13 +766,12 @@ impl TypeChecker {
     /// otherwise untyped Format-tree nodes
     ///
     /// This should never return `Err(_)` unless something catastrophic has happened, or it was called
-    /// with an improper `UTYpe` (e.g. one that references an out-of-range UVar at the time it was constructed)
+    /// with an improper `UType` (e.g. one that references an out-of-range UVar at the time it was constructed)
     fn init_var_simple(&mut self, typ: UType) -> TCResult<(UVar, Rc<UType>)> {
         let newvar = self.get_new_uvar();
         let rc = Rc::new(typ);
         let constr = Constraint::Equiv(rc.clone());
         self.unify_var_constraint(newvar, constr)?;
-        // FIXME - not sure whether to return rc or newvar
         Ok((newvar, rc))
     }
 
@@ -831,7 +830,31 @@ impl TypeChecker {
             Pattern::Int(bounds) => {
                 let var = self.get_new_uvar();
                 let width = bounds.min_required_width();
-                self.unify_utype_baseset(var.into(), BaseSet::U(UintSet::at_least(width)))?;
+                self.unify_var_baseset(var, BaseSet::U(UintSet::at_least(width)))?;
+                Ok(var)
+            }
+            Pattern::ZConst(n) => {
+                let var = self.get_new_uvar();
+                let c = inference::Constraint::Encompasses(ZBounds::singleton(n.clone()));
+                let mut iset = PrimIntSet::ANY;
+                for p in crate::numeric::elaborator::PRIM_INTS {
+                    if c.is_satisfied_by(IntType::Prim(p)) == Some(false) {
+                        iset.remove(p);
+                    }
+                }
+                self.unify_var_intset(var, IntSet::Z(iset))?;
+                Ok(var)
+            }
+            Pattern::ZRange(bounds) => {
+                let var = self.get_new_uvar();
+                let c = inference::Constraint::Encompasses(bounds.clone());
+                let mut iset = PrimIntSet::ANY;
+                for p in crate::numeric::elaborator::PRIM_INTS {
+                    if c.is_satisfied_by(IntType::Prim(p)) == Some(false) {
+                        iset.remove(p);
+                    }
+                }
+                self.unify_var_intset(var, IntSet::Z(iset))?;
                 Ok(var)
             }
             Pattern::Char(_) => {
@@ -897,7 +920,8 @@ impl TypeChecker {
         let new_scope = UScope::Multi(&tmp);
         let new_ctxt = ctxt.with_scope(&new_scope);
         let local_rhs_var = self.infer_var_format(rhs_format, new_ctxt)?;
-        self.unify_var_utype(pvar, head_t)?;
+        let _tmp = ("unify_utype_format_match_case", pvar, format!("{:?}", head_t));
+        try_with!( self.unify_var_utype(pvar, head_t) => _tmp );
         self.unify_var_pair(rhs_var, local_rhs_var)?;
         Ok(())
     }
@@ -915,7 +939,8 @@ impl TypeChecker {
         let tmp = child.clone();
         let new_scope = UScope::Multi(&tmp);
         let local_rhs_var = self.infer_var_expr(rhs_expr, &new_scope)?;
-        self.unify_var_utype(pvar, head_t)?;
+        let _tmp = ("unify_utype_expr_match_case", pvar, format!("{:?}", head_t));
+        try_with!(self.unify_var_utype(pvar, head_t) => _tmp);
         self.unify_var_pair(rhs_var, local_rhs_var)?;
         Ok(())
     }
@@ -1301,7 +1326,7 @@ impl TypeChecker {
                 let id = *vmid;
                 let vm = self.varmaps.get_varmap(id);
                 if let Some(prior) = vm.get(&cname) {
-                    let updated = self.unify_utype(prior.clone(), inner)?;
+                    let updated = try_with!( self.unify_utype(prior.clone(), inner) => ("add_uvar_variant", v, cname) );
                     if updated.as_ref() != self.varmaps.get_varmap(id).get(&cname).unwrap().as_ref()
                     {
                         self.varmaps.get_varmap_mut(id).insert(cname, updated);
@@ -1399,7 +1424,7 @@ impl TypeChecker {
                     format!("{uvar} {prior}"),
                     format!("{uvar} {constraint}"),
                 );
-                let ret = self.unify_constraint_pair(c1, constraint)?;
+                let ret = try_with!( self.unify_constraint_pair(c1, constraint) => _tmp );
                 self.constraints[can_ix] = Constraints::Invariant(ret.clone());
                 Ok(ret)
             }
@@ -1469,7 +1494,8 @@ impl TypeChecker {
                             .unwrap()
                             .1
                             .clone();
-                        self.unify_var_utype(fld_var, fld_type)?;
+                        let _tmp = ("unify_var_proj_field", rec_var, fname, fld_var, format!("{:?}", fld_type));
+                        try_with!(self.unify_var_utype(fld_var, fld_type) => _tmp);
                         Ok(())
                     }
                     UType::Var(v_other) => {
@@ -1511,7 +1537,8 @@ impl TypeChecker {
                 Constraint::Equiv(ut) => match ut.as_ref() {
                     UType::Option(inner) => {
                         let param_t = inner.clone();
-                        self.unify_var_utype(param_v, param_t)?;
+                        let _tmp = ("unify_var_proj_param", opt_v, param_v, format!("{:?}", param_t));
+                        try_with!(self.unify_var_utype(param_v, param_t) => _tmp);
                         Ok(())
                     }
                     other => unreachable!("expected UType::Option, found {other:?}"),
@@ -1545,7 +1572,8 @@ impl TypeChecker {
                 Constraint::Equiv(ut) => match ut.as_ref() {
                     UType::Seq(inner, _) => {
                         let elem_t = inner.clone();
-                        self.unify_var_utype(elem_v, elem_t)?;
+                        let _tmp = ("unify_var_proj_elem", seq_v, elem_v, format!("{:?}", elem_t));
+                        try_with!(self.unify_var_utype(elem_v, elem_t) => _tmp);
                         Ok(())
                     }
                     other => unreachable!("expected UType::Seq, found {other:?}"),
@@ -1610,7 +1638,7 @@ impl TypeChecker {
                 if e1 == e2 {
                     if h1 <= h2 { Ok(left) } else { Ok(right) }
                 } else {
-                    let inner = self.unify_utype(e1.clone(), e2.clone())?;
+                    let inner = try_with!( self.unify_utype(e1.clone(), e2.clone()) => "unify_utype@Seq|Seq" );
                     Ok(Rc::new(UType::Seq(inner, Ord::min(*h1, *h2))))
                 }
             }
@@ -1618,7 +1646,7 @@ impl TypeChecker {
                 if o1 == o2 {
                     Ok(left)
                 } else {
-                    let inner = self.unify_utype(o1.clone(), o2.clone())?;
+                    let inner = try_with!( self.unify_utype(o1.clone(), o2.clone()) => "unify_utype@Option|Option" );
                     Ok(Rc::new(UType::Option(inner)))
                 }
             }
@@ -1626,7 +1654,7 @@ impl TypeChecker {
                 if p1 == p2 {
                     Ok(left)
                 } else {
-                    let inner = self.unify_utype(p1.clone(), p2.clone())?;
+                    let inner = try_with!(self.unify_utype(p1.clone(), p2.clone()) => "unify_utype@PhantomData|PhantomData");
                     Ok(Rc::new(UType::PhantomData(inner)))
                 }
             }
@@ -1644,8 +1672,8 @@ impl TypeChecker {
                     return Ok(left);
                 }
                 let mut ts0 = Vec::with_capacity(ts1.len());
-                for (t1, t2) in Iterator::zip(ts1.iter(), ts2.iter()) {
-                    ts0.push(self.unify_utype(t1.clone(), t2.clone())?);
+                for (_ix, (t1, t2)) in Iterator::zip(ts1.iter(), ts2.iter()).enumerate() {
+                    ts0.push(try_with!(self.unify_utype(t1.clone(), t2.clone()) => ("unify_utype@Tuple|Tuple", _ix)));
                 }
                 Ok(Rc::new(UType::Tuple(ts0)))
             }
@@ -1661,7 +1689,7 @@ impl TypeChecker {
                     if l1 != l2 {
                         return Err(UnificationError::Unsatisfiable(left, right).into());
                     }
-                    fs0.push((l1.clone(), self.unify_utype(f1.clone(), f2.clone())?));
+                    fs0.push((l1.clone(), try_with!( self.unify_utype(f1.clone(), f2.clone()) => ("unify_utype@Record|Record", l2.clone()) )));
                 }
                 Ok(Rc::new(UType::Record(fs0)))
             }
@@ -1681,13 +1709,23 @@ impl TypeChecker {
             }
             (&UType::Var(v), _) => {
                 let constraint = Constraint::Equiv(right.clone());
-                let _ = self.unify_var_constraint(v, constraint)?;
+                let _tmp = (
+                    "unify_utype@Var|_",
+                    format!("var: {}", v),
+                    format!("other: {:?}", right),
+                );
+                let _ = try_with!(self.unify_var_constraint(v, constraint) => _tmp);
                 self.occurs(v)?;
                 Ok(Rc::new(UType::Var(v)))
             }
             (_, &UType::Var(v)) => {
                 let constraint = Constraint::Equiv(left.clone());
-                let _ = self.unify_var_constraint(v, constraint)?;
+                let _tmp = (
+                    "unify_utype@_|Var",
+                    format!("var: {}", v),
+                    format!("other: {:?}", left),
+                );
+                let _ = try_with!( self.unify_var_constraint(v, constraint) => _tmp );
                 self.occurs(v)?;
                 Ok(Rc::new(UType::Var(v)))
             }
@@ -1704,7 +1742,8 @@ impl TypeChecker {
                 Ok(())
             }
             _ => {
-                self.unify_var_constraint(v1, Constraint::Equiv(solution.clone()))?;
+                let _tmp = ("unify_var_utype", v1, format!("{:?}", solution));
+                try_with!( self.unify_var_constraint(v1, Constraint::Equiv(solution.clone())) => _tmp );
                 Ok(())
             }
         }
@@ -1781,7 +1820,8 @@ impl TypeChecker {
 
     fn unify_var_intset(&mut self, uv: UVar, is: IntSet) -> TCResult<Constraint> {
         let constraint = is.to_constraint();
-        self.unify_var_constraint(uv, constraint)
+        let _tmp = ("unify_var_intset", uv, is);
+        Ok(try_with!(self.unify_var_constraint(uv, constraint) => _tmp))
     }
 
     /// Unifies a UVar against a BaseSet, updating any aliased-variable constraints in the process.
@@ -1790,7 +1830,8 @@ impl TypeChecker {
     /// Otherwise, returns an `Err` indicating that the unification was not possible.
     fn unify_var_baseset(&mut self, uv: UVar, bs: BaseSet) -> TCResult<Constraint> {
         let constraint = bs.to_constraint();
-        self.unify_var_constraint(uv, constraint)
+        let _tmp = ("unify_var_baseset", uv, bs);
+        Ok(try_with!(self.unify_var_constraint(uv, constraint) => _tmp))
     }
 
     /// Attempts to unify a [`PrimInt`] with a [`BaseType`], returning the unified [`UType`] if successful.
@@ -1817,7 +1858,10 @@ impl TypeChecker {
     /// Attempt to unify a [`UVar`] with a [`ValueType`], primarily for use with `Expr::FlatMapAccum`.
     fn unify_var_valuetype(&mut self, uv: UVar, vt: &ValueType) -> TCResult<()> {
         match UType::from_valuetype(vt) {
-            Some(ref ut) => self.unify_var_utype(uv, Rc::new(ut.clone()))?,
+            Some(ref ut) => {
+                let _tmp = ("unify_var_valuetype", uv, format!("{:?}", vt));
+                try_with!(self.unify_var_utype(uv, Rc::new(ut.clone())) => _tmp)
+            }
             _ => match vt {
                 ValueType::Union(branches) => {
                     self.unify_var_valuetype_union(uv, branches)?;
@@ -1865,7 +1909,7 @@ impl TypeChecker {
                 if t1 == t2 {
                     Ok(Constraint::Equiv(t1.clone()))
                 } else {
-                    let t0 = self.unify_utype(t1.clone(), t2.clone())?;
+                    let t0 = try_with!( self.unify_utype(t1.clone(), t2.clone()) => "unify_constraint_pair" );
                     Ok(Constraint::Equiv(t0))
                 }
             }
@@ -1987,7 +2031,8 @@ impl TypeChecker {
                             for (fld, ut) in fld_ut.iter() {
                                 keys_ut.insert(fld.clone());
                                 if let Some(var) = fld_p.get(fld) {
-                                    self.unify_var_utype(*var, ut.clone())?;
+                                    let _tmp = ("unify_constraint_pair@Proj<->Equiv", fld.clone(), *var, format!("{:?}", ut));
+                                    try_with!(self.unify_var_utype(*var, ut.clone()) => _tmp);
                                 }
                             }
 
@@ -2105,7 +2150,7 @@ impl TypeChecker {
         for (vname, inner) in hi_entries.into_iter() {
             if let Some(t_lo) = self.varmaps.get_varmap(lo).get(&vname) {
                 let t_hi = inner;
-                let unified = self.unify_utype(t_lo.clone(), t_hi.clone())?;
+                let unified = try_with!(self.unify_utype(t_lo.clone(), t_hi.clone()) => ("unify_varmaps", v1, vmid1, v2, vmid2));
                 let _ = self.varmaps.get_varmap_mut(lo).insert(vname, unified);
             } else {
                 self.varmaps.get_varmap_mut(lo).insert(vname, inner);
@@ -3170,7 +3215,8 @@ impl TypeChecker {
             unsafe { self.repoint(a1, a) };
         }
         self.aliases[a1].add_forward_ref(a2);
-        unsafe { self.transfer_constraints(a1, a2) }
+        let _tmp = ("recanonicalize", UVar(a1), UVar(a2));
+        Ok(try_with!( unsafe { self.transfer_constraints(a1, a2) } => _tmp))
     }
 
     /// Rewrites the aliasing of `self` so that `lo<->hi` is enforced, without any other changes.
@@ -3238,7 +3284,8 @@ impl TypeChecker {
                 }
             }
             (Constraints::Invariant(c1), Constraints::Invariant(c2)) => {
-                let c0 = self.unify_constraint_pair(c1.clone(), c2.clone())?;
+                let _tmp = ("transfer_constraints", UVar(a1), UVar(a2));
+                let c0 = try_with!(self.unify_constraint_pair(c1.clone(), c2.clone()) => _tmp);
                 let _ =
                     self.replace_constraints_with_value(v1.0, Constraints::Invariant(c0.clone()));
                 let _ = self.replace_constraints_with_value(v2.0, Constraints::Invariant(c0));


### PR DESCRIPTION
Phases out scaffolding `s8|s16be|s32be|s64be` in `opentype.rs` and uses constructed I8..I64 parsers instead.

Also modifies `otf_metrics` accordingly based on updated types.